### PR TITLE
fixup for fix loggin utf8 messages

### DIFF
--- a/lib/Mojo/Log.pm
+++ b/lib/Mojo/Log.pm
@@ -69,7 +69,7 @@ sub log {
 
     my $time = localtime(time);
     my $msgs = join "\n",
-      map { utf8::is_utf8 $_ ? $_ : utf8::encode $_} @msgs;
+      map { unless (utf8::is_utf8 $_) { utf8::decode $_ }; $_ } @msgs;
 
     # Caller
     my ($pkg, $line) = (caller())[0, 2];


### PR DESCRIPTION
Actually you totally broke Mojo::Log
Also we need data to be decoded unless it is in utf8
