### PR TITLE
JavaScript Helper Creates Invalid JavaScript Tag

### DIFF
--- a/lib/Mojolicious/Plugin/TagHelpers.pm
+++ b/lib/Mojolicious/Plugin/TagHelpers.pm
@@ -74,7 +74,7 @@ sub register {
             # CDATA
 	    if(ref $_[-1] && ref $_[-1] eq 'CODE') {	      
 	      my $old = pop;
-	      $cb = sub { "//<![CDATA[" . $old->() . "//]]>" }
+	      $cb = sub { "//<![CDATA[\n" . $old->() . "\n//]]>" }
 	    }
 
 	    # Path
@@ -189,7 +189,7 @@ sub register {
             # CDATA
             my $cb;
             my $old = $cb = pop if ref $_[-1] && ref $_[-1] eq 'CODE';
-            $cb = sub { '/*<![CDATA[*/' . $old->() . '/*]]>*/' }
+            $cb = sub { "/*<![CDATA[*/\n" . $old->() . "\n/*]]>*/" }
               if $cb;
 
             # Path

--- a/t/mojolicious/lite_app.t
+++ b/t/mojolicious/lite_app.t
@@ -828,17 +828,25 @@ $t->get_ok('/tags/lala?a=b&b=0&c=2&d=3&escaped=1%22+%222')->status_is(200)
 <input name="a" value="b" />
 <script src="script.js" type="text/javascript"></script>
 <script type="text/javascript">//<![CDATA[
+
     var a = 'b';
+
 //]]></script>
 <script type="foo">//<![CDATA[
+
     var a = 'b';
+
 //]]></script>
 <link href="foo.css" media="screen" rel="stylesheet" type="text/css" />
 <style type="text/css">/*<![CDATA[*/
+
     body {color: #000}
+
 /*]]>*/</style>
 <style type="foo">/*<![CDATA[*/
+
     body {color: #000}
+
 /*]]>*/</style>
 EOF
 
@@ -878,17 +886,25 @@ $t->get_ok('/tags/lala?c=b&d=3&e=4&f=5')->status_is(200)->content_is(<<EOF);
 <input name="a" value="c" />
 <script src="script.js" type="text/javascript"></script>
 <script type="text/javascript">//<![CDATA[
+
     var a = 'b';
+
 //]]></script>
 <script type="foo">//<![CDATA[
+
     var a = 'b';
+
 //]]></script>
 <link href="foo.css" media="screen" rel="stylesheet" type="text/css" />
 <style type="text/css">/*<![CDATA[*/
+
     body {color: #000}
+
 /*]]>*/</style>
 <style type="foo">/*<![CDATA[*/
+
     body {color: #000}
+
 /*]]>*/</style>
 EOF
 


### PR DESCRIPTION
The JS element cannot be empty:

```
%= javascript 'script.js' 
```

generates:

```
<script src="script.js" type="text/javascript" />
```

For JS blocks the CDATA tags needs to be commented out:

```
%=javascript begin
    alert('Wont see this'); 
%end
```

generates: 

```
<script type="text/javascript"><![CDATA[
    alert('Wont see this'); 
]]></script>
```

The same problem arises with the stylesheet tag. 

I fixed both, but I'm somewhat confused about the logic dealing with CODE ref arguments. This seems unnecessary: 

```
  if (@_ % 2 ? ref $_[-1] ne 'CODE' : ref $_[-1] eq 'CODE') {
```

What's the point of the false branch? It would handle odd cases like:

```
%=javascript 'xxx', sub { "var y = 123" }, begin
    var x = 456;
%end
```

Generating:

```
<script src="xxx" type="text/javascript">var y = 123</script>
```

Which ignores the earlier attempt to wrap the code in CDATA. The same logic is used for the stylesheet helper. 

Maybe I'm missing something because I haven't looked at the template parsing code?

I removed this logic from my JS fix but not in the stylesheet fix. 
