### PR TITLE
Pass current $captures to conditions.

### DIFF
--- a/lib/Mojolicious/Routes/Match.pm
+++ b/lib/Mojolicious/Routes/Match.pm
@@ -66,7 +66,7 @@ sub match {
 
         # Match
         return
-          if !$condition->($r, $self->{_controller}, $self->captures, $value);
+          if !$condition->($r, $self->{_controller}, $captures, $value);
     }
 
     # Partial


### PR DESCRIPTION
The third parameter (`$captures`) is always empty in my conditions; maybe there is some esotheric case where this doesn't happen, but the call from `Routes::dispatch` isn't one.  If the cached matches are needed, they should be available via the second parameter (`$c` aka the controller).  Or did I miss something?
