### PR TITLE
fixing set-cookie for PSGI

### DIFF
--- a/lib/Mojo/Server/PSGI.pm
+++ b/lib/Mojo/Server/PSGI.pm
@@ -44,8 +44,8 @@ sub run {
     my $headers = $res->content->headers;
     my @headers;
     for my $name (@{$headers->names}) {
-        my $value = $headers->header($name);
-        push @headers, $name => $value;
+        my @values = $headers->header($name);
+        push @headers, map { $name => $_ } @values;
     }
 
     # Response body


### PR DESCRIPTION
For case if there are few headers with the same name and different values, Mojo should send this headers separately, without joining them with comma
