### PR TITLE
Document the return value of M::Headers::header() in list context

### DIFF
--- a/lib/Mojo/Headers.pm
+++ b/lib/Mojo/Headers.pm
@@ -440,6 +440,15 @@ Get or replace the current header values.
 Note that this method is context sensitive and will turn all header lines
 into a single one in scalar context.
 
+In list context, this method returns an array with one entry for each
+occurrence of the specified header. The array may contain one string,
+or a number of arrayrefs, each containing a list of one or more
+comma-separated values that occurred in that header line.
+
+(Thus, if the X-Foo header occurs twice and contains "foo, bar" on one
+line and "baz" on the next, C<header('X-Foo')> would return two
+arrayrefs, namely C<[qw/foo bar/]> and C<[qw/baz/]>).
+
 =head2 C<host>
 
   my $host = $headers->host;


### PR DESCRIPTION
The example implies (weakly) that it's just an array of values, and I wrote the wrong code before I understood the real return value by reading the code. This patch just documents what I found.
