### PR TITLE
WOFF mime type

### DIFF
--- a/lib/Mojolicious/Types.pm
+++ b/lib/Mojolicious/Types.pm
@@ -23,6 +23,7 @@ has types => sub {
     svg  => 'image/svg+xml',
     tar  => 'application/x-tar',
     txt  => 'text/plain',
+    woff => 'application/x-woff',
     xml  => 'text/xml',
     zip  => 'application/zip'
   };


### PR DESCRIPTION
WOFF is a broadly (Gecko, Webkit, Opera, IE) supported W3C standard for web fronts. Its major strength are portability and size.
