### PR TITLE
Made urls in perldoc work everywhere

### DIFF
--- a/lib/Mojolicious/Plugin/PodRenderer.pm
+++ b/lib/Mojolicious/Plugin/PodRenderer.pm
@@ -101,10 +101,10 @@ sub register {
           url_escape $anchor, 'A-Za-z0-9_';
           $anchor =~ s/\%//g;
           push @$sections, [] if $tag->type eq 'h1' || !@$sections;
-          push @{$sections->[-1]}, $text, "$url#$anchor";
+          push @{$sections->[-1]}, $text, "/$url#$anchor";
           $tag->replace_inner(
             $self->link_to(
-              $text => "$url#toc",
+              $text => "/$url#toc",
               class => 'mojoscroll',
               id    => $anchor
               )->to_string


### PR DESCRIPTION
Hi Sebastian.
I noticed that when an application is installed in a subdirectory of an Apache virtual host the internal anchors does not work propeerly.
Adding a slash in front of the url solves the problem.
Example(before): 
application deployed : http://localhost/MYDLjE/
link in toc: 
http://localhost/MYDLjE/mydlje/MYDLjE/mydlje/perldoc%3FMojolicious/Commands%23generate_lite_app
Example(after):
link in toc:
http://localhost/MYDLjE/mydlje/perldoc?Mojolicious%2FCommands#generate_lite_app

Thanks in advance.
