### PR TITLE
Encoding in which POD files are opened.

### DIFF
--- a/lib/Mojolicious/Plugin/PodRenderer.pm
+++ b/lib/Mojolicious/Plugin/PodRenderer.pm
@@ -66,8 +66,14 @@ sub register {
         unless $path && -r $path;
 
       # POD
+      my $encoding =
+      defined $conf->{encoding}
+      ? $conf->{encoding}
+      : $conf->{charset};
+
       my $file = IO::File->new;
       $file->open("< $path");
+      $file->binmode($encoding ? ':encoding('. $encoding . ')' : ':utf8');      
       my $html = _pod_to_html(join '', <$file>);
       my $dom = Mojo::DOM->new->parse("$html");
       $dom->find('a[href]')->each(


### PR DESCRIPTION
Happy Easter day (Христос воскресе)!

Please see my changes and pull them if you think this is how it should be.

I think this is desired behaviour. Documents written in plain ascii or latin-1 will feel no change.
Most modern perl modules are valid "utf8" so it should be ok.
Thanks!  
