### PR TITLE
Fixed a small xml flag bug

### DIFF
--- a/lib/Mojo/DOM.pm
+++ b/lib/Mojo/DOM.pm
@@ -196,7 +196,12 @@ sub children {
     next unless $e->[0] eq 'tag';
 
     # Add child
-    push @children, $self->new(charset => $self->charset, tree => $e);
+    push @children,
+      $self->new(
+      charset => $self->charset,
+      tree    => $e,
+      xml     => $self->xml
+      );
   }
 
   return \@children;
@@ -273,7 +278,11 @@ sub parent {
   return if $tree->[0] eq 'root';
 
   # Parent
-  return $self->new(charset => $self->charset, tree => $tree->[3]);
+  return $self->new(
+    charset => $self->charset,
+    tree    => $tree->[3],
+    xml     => $self->xml
+  );
 }
 
 sub parse {
@@ -296,8 +305,12 @@ sub replace {
 
   # Root
   return $self->replace_inner(
-    $self->new(charset => $self->charset, tree => $new))
-    if $tree->[0] eq 'root';
+    $self->new(
+      charset => $self->charset,
+      tree    => $new,
+      xml     => $self->xml
+    )
+  ) if $tree->[0] eq 'root';
 
   # Parent
   my $parent = $tree->[3];
@@ -354,7 +367,11 @@ sub root {
     $root = $parent;
   }
 
-  return $self->new(charset => $self->charset, tree => $root);
+  return $self->new(
+    charset => $self->charset,
+    tree    => $root,
+    xml     => $self->xml
+  );
 }
 
 sub text {
@@ -878,7 +895,13 @@ sub _match_tree {
 
   # Upgrade results
   @results =
-    map { $self->new(charset => $self->charset, tree => $_) } @results;
+    map {
+    $self->new(
+      charset => $self->charset,
+      tree    => $_,
+      xml     => $self->xml
+      )
+    } @results;
 
   # Collection
   return bless \@results, 'Mojo::DOM::_Collection';

--- a/t/mojo/dom.t
+++ b/t/mojo/dom.t
@@ -5,7 +5,7 @@ use warnings;
 
 use utf8;
 
-use Test::More tests => 514;
+use Test::More tests => 521;
 
 # "Homer gave me a kidney: it wasn't his, I didn't need it,
 #  and it came postage due- but I appreciated the gesture!"
@@ -1562,3 +1562,25 @@ is $dom->at('#screw-up .ewww > a > img')->attrs('src'), '/test.png',
 is $dom->find('#screw-up .ewww > a > img')->[1]->attrs('src'), '/test2.png',
   'right attribute';
 is $dom->find('#screw-up .ewww > a > img')->[2], undef, 'no result';
+
+# Modyfing an XML document
+$dom = Mojo::DOM->new->parse(<<'EOF');
+<?xml version='1.0' encoding='UTF-8'?>
+<XMLTest />
+EOF
+
+is $dom->xml, 1, 'xml mode detected';
+
+$dom->at('XMLTest')->replace_inner('<Element />');
+my $element = $dom->at('Element');
+is $element->type, 'Element', 'right type';
+is $element->xml,  1,         'xml mode detected';
+
+$element = $dom->at('XMLTest')->children->[0];
+is $element->type, 'Element', 'right child';
+is $element->parent->type, 'XMLTest', 'right parent';
+is $element->root->xml,    1,         'xml mode detected';
+
+
+$dom->replace('<XMLTest2 />');
+is $dom->xml, 1, 'xml mode detected';


### PR DESCRIPTION
This should solve some problems with embedding xml fragments and the xml flag.
However - the last test is questionable as the root is replaced but the xml flag of the former document is inherited. But I see no reasonable way to set this to undef in advance and then get an xml treatment when it's detected in the xml prolog.
