### PR TITLE
noting potential risks when using 5.8

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -80,3 +80,20 @@ WriteMakefile(
   },
   test => {TESTS => 't/*.t t/*/*.t'}
 );
+
+warn <<'EOF' unless $] >= 5.010;
+
+***
+You are using Perl 5.8, a version that has reached the end of its life a few
+years ago and which no longer gets updated by the community. Perl 5.8
+contains very serious flaws, especially around the regular expression
+engine, that will never get fixed and are likely to put your applications
+at risk.
+
+While your operating system vendor might keep it compiling on their
+platform, they will not fix these issues. Therefore, while we haven't
+deprecated Mojolicious in Perl 5.8, we highly recommend that you
+upgrade your Perl as soon as possible!
+***
+
+EOF


### PR DESCRIPTION
While we can't deprecate 5.8 just yet, we can (and should, imo) warn developers of the potential risks in running web applications on such systems. This patch displays the warning message from Mojolicious' FAQ whenever someone tries to install it on a 5.8 system (but doesn't prevent the installation at all).
