### PR TITLE
Small patch to support "plackup -s Feersum"

### DIFF
--- a/lib/Mojo/Message/Request.pm
+++ b/lib/Mojo/Message/Request.pm
@@ -252,10 +252,12 @@ sub _parse_env {
   my $base    = $url->base;
 
   # Headers
-  while (my ($name, $value) = each %$env) {
+  for my $name (keys %$env) {
 
     # Header
-    if ($name =~ s/^HTTP_//i) {
+    if ($name =~ /^HTTP_/i) {
+      my $value = $env->{$name};
+      $name =~ s/^HTTP_//i;
       $name =~ s/_/-/g;
       $headers->header($name, $value);
 


### PR DESCRIPTION
Hi! First of all, thanks for the Mojolicious framework - I'm only a few days into it but it's been a joyful ride thus far.

This patch is required for "plackup -s Feersum" support, because currently fetching the "psgix.io" env provided by Feersum (i.e. triggering its SV get magic) without a "psgi.streaming" response results in an error.

Since the patch in the Mojo side to avoid accidentally fetching $env->{'psgix.io'} is trivial, it'd be wonderful if you can consider it for inclusion. :-)

Many thanks!
Audrey
