### PR TITLE
make decamelize nicer to FOO and FOOBar cases

### DIFF
--- a/lib/Mojo/Util.pm
+++ b/lib/Mojo/Util.pm
@@ -324,17 +324,12 @@ sub camelize {
 sub decamelize {
   return if $_[0] !~ /^[A-Z\:]+/;
 
-  # Module parts
-  my @parts;
-  for my $part (split /\:\:/, $_[0]) {
-
-    # Camelcase words
-    my @words;
-    push @words, $1 while ($part =~ s/([A-Z]{1}[^A-Z]*)//);
-    @words = map {lc} @words;
-    push @parts, join '_', @words;
-  }
-  $_[0] = join '-', @parts;
+  $_[0] =~ s/::/-/g;
+  # ClassicCamelCase -> classic_camel_case
+  $_[0] =~ s/(?<=[a-z])(?=[A-Z])/_/g;
+  # NotSoCLASSICCase -> not_so_classic_case
+  $_[0] =~ s/(?<=[A-Za-z])(?=[A-Z][a-z])/_/g;
+  $_[0] = lc $_[0];
 }
 
 sub decode {

--- a/t/mojo/util.t
+++ b/t/mojo/util.t
@@ -1,0 +1,25 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 9;
+
+use_ok 'Mojo::Util', 'decamelize';
+
+{
+    my %set = (
+        'no camel' => 'no camel',
+        'Camel' => 'camel',
+        'CamelCase' => 'camel_case',
+        'Camel::Case' => 'camel-case',
+        'FOO'        => 'foo',
+        'FOO::BAR'   => 'foo-bar',
+        'FooBAR'     => 'foo_bar',
+        'BARFoo'     => 'bar_foo',
+    );
+    while ( my ($orig, $expected) = each %set ) {
+        decamelize( my $got = $orig );
+        is $got, $expected, "correctly decamelized '$orig'";
+    }
+}


### PR DESCRIPTION
The following speaks for itself:

perl -MMojo::Util=decamelize -e '@a = qw(CamCase Camel BarFOO FOOBar); for (@a) { my $o = my $n = $_; $n =~ s/(?<=[a-z])(?=[A-Z])|(?<=[A-Za-z])(?=[A-Z][a-z])/_/g; decamelize $o; print "$_\n  $o\n  \L$n\n"}'
CamCase
  cam_case
  cam_case
Camel
  camel
  camel
BarFOO
  bar_f_o_o
  bar_foo
FOOBar
  f_o_o_bar
  foo_bar
