### PR TITLE
after_dispatch hook cannot handle session

### DIFF
--- a/lib/Mojolicious/Controller.pm
+++ b/lib/Mojolicious/Controller.pm
@@ -463,8 +463,8 @@ sub rendered {
   unless ($stash->{'mojo.finished'}) {
     $res->code(200) unless $res->code;
     my $app = $self->app;
-    $app->sessions->store($self);
     $app->plugins->run_hook_reverse(after_dispatch => $self);
+    $app->sessions->store($self);
     $stash->{'mojo.finished'} = 1;
   }
   $self->tx->resume;


### PR DESCRIPTION
after_dispatch hook cannot handle session now, because this hook run after storing sessions.
This patch fix the above bug.
