### PR TITLE
Morbo dies on Windows

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 This file documents the revision history for Perl extension Mojolicious.
 
+        - Fix Morbo development server exit and reloading on Windows
+
 1.46    2011-06-20 00:00:00
         - Improved overall performance by about 3% with many small
           optimizations.


### PR DESCRIPTION
This patch fixes two issues on Windows (tested only on Windows 7 64bit with Strawberry Perl 5.12.3):
- Morbo dies on reload
- Strg-C leads to loop on exit

Some more debug output is there now too. Feel free to clean up if it's too verbose for you, but I guess until this is resolved it should be more verbose.

Hope this resolves the issues for the other guys too, seems to be a strange behaviour on Windows (mayby also depending if some other modules are used or not). With the additional check in the manager and kill 15 in the child it's working fine for me now.
