### PR TITLE
Added type declaration for XSL documents 

### DIFF
--- a/lib/Mojolicious/Types.pm
+++ b/lib/Mojolicious/Types.pm
@@ -25,6 +25,7 @@ has types => sub {
     txt  => 'text/plain',
     woff => 'application/x-font-woff',
     xml  => 'text/xml',
+    xsl  => 'text/xml',
     zip  => 'application/zip'
   };
 };


### PR DESCRIPTION
I'm using Mojolicious to develop applications that make heavy use of XSLT, so I added a type declaration for .xsl files of 'text/xml.' Firefox throws an error if an XSL stylesheet is transferred as 'text/plain' and won't render it.

Thanks for the awesome framework :)

-Michael
