### PR TITLE
Add expires/cache_control accessors to Mojo::Headers

### DIFF
--- a/lib/Mojo/Headers.pm
+++ b/lib/Mojo/Headers.pm
@@ -102,6 +102,7 @@ sub add {
   return $self;
 }
 
+sub cache_control       { scalar shift->header('Cache-Control'       => @_) }
 sub connection          { scalar shift->header(Connection            => @_) }
 sub content_disposition { scalar shift->header('Content-Disposition' => @_) }
 sub content_length      { scalar shift->header('Content-Length'      => @_) }
@@ -116,6 +117,7 @@ sub cookie       { scalar shift->header(Cookie         => @_) }
 sub date         { scalar shift->header(Date           => @_) }
 sub dnt          { scalar shift->header(DNT            => @_) }
 sub expect       { scalar shift->header(Expect         => @_) }
+sub expires      { scalar shift->header(Expires        => @_) }
 
 sub from_hash {
   my $self = shift;
@@ -379,6 +381,13 @@ Add one or more header lines.
 
 Shortcut for the C<Authorization> header.
 
+=head2 C<cache_control>
+
+  my $cache_control = $headers->cache_control;
+  $headers          = $headers->cache_control('max-age=1, no-cache');
+
+Shortcut for the C<Cache-Control> header.
+
 =head2 C<connection>
 
   my $connection = $headers->connection;
@@ -449,6 +458,13 @@ Note that this method is EXPERIMENTAL and might change without warning!
   $headers   = $headers->expect('100-continue');
 
 Shortcut for the C<Expect> header.
+
+=head2 C<expires>
+
+  my $expires = $headers->expires;
+  $headers    = $headers->expires('Thu, 01 Dec 1994 16:00:00 GMT');
+
+Shortcut for the C<Expires> header.
 
 =head2 C<from_hash>
 

--- a/t/mojo/headers.t
+++ b/t/mojo/headers.t
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 
 # "Remember, you can always find East by staring directly at the sun."
-use Test::More tests => 37;
+use Test::More tests => 41;
 
 # "So, have a merry Christmas, a happy Hanukkah, a kwaazy Kwanza,
 #  a tip-top Tet, and a solemn, dignified, Ramadan.
@@ -34,6 +34,10 @@ is_deeply $hash->{Expect},         [['continue-100']], 'right structure';
 is_deeply $hash->{'Content-Type'}, [['text/html']],    'right structure';
 is_deeply [sort @{$headers->names}], [qw/Connection Content-Type Expect/],
   'right structure';
+$headers->expires('Thu, 01 Dec 1994 16:00:00 GMT');
+$headers->cache_control('public');
+is $headers->expires, 'Thu, 01 Dec 1994 16:00:00 GMT', 'right value';
+is $headers->cache_control, 'public', 'right value';
 
 # Multiline values
 $headers = Mojo::Headers->new;
@@ -56,11 +60,15 @@ $headers = Mojo::Headers->new;
 isa_ok $headers->parse(<<'EOF'), 'Mojo::Headers', 'right return value';
 Content-Type: text/plain
 Expect: 100-continue
+Cache-control: public
+Expires: Thu, 01 Dec 1994 16:00:00 GMT
 
 EOF
-ok $headers->is_done,      'parser is done';
-is $headers->content_type, 'text/plain', 'right value';
-is $headers->expect,       '100-continue', 'right value';
+ok $headers->is_done,       'parser is done';
+is $headers->content_type,  'text/plain', 'right value';
+is $headers->expect,        '100-continue', 'right value';
+is $headers->cache_control, 'public', 'right value';
+is $headers->expires,       'Thu, 01 Dec 1994 16:00:00 GMT', 'right value';
 
 # Set headers from hash
 $headers = Mojo::Headers->new;


### PR DESCRIPTION
Now with POD, and the functions rearranged.
