### PR TITLE
Force stop on connect. Otherwise, a failed test never ends

### DIFF
--- a/t/mojo/ioloop.t
+++ b/t/mojo/ioloop.t
@@ -138,7 +138,10 @@ my $connected;
 $loop->connect(
   address    => 'localhost',
   port       => $port,
-  on_connect => sub { $connected = 1 },
+  on_connect => sub { 
+    $connected = 1;
+    shift->stop;
+  },
   on_error   => sub {
     shift->stop;
     $error = pop;


### PR DESCRIPTION
Hi!

I could not solve the cygwin trouble, but with this commit the test continues informing the failed check.

Nothing changes in my Linux (Ubuntu) platform. With this patch I can send the failed cpan report in cygwin. Neither I am an expert on Win. Maybe someone can solve. 

Silvio
