### PR TITLE
multipart request sometimes causes infinit loop

### DIFF
--- a/lib/Mojo/Content/MultiPart.pm
+++ b/lib/Mojo/Content/MultiPart.pm
@@ -163,6 +163,10 @@ sub _parse_multipart {
     elsif (($self->{multi_state} || '') eq 'multipart_body') {
       last unless $self->_parse_multipart_body($boundary);
     }
+    
+    else {
+      last;
+    }
   }
 }
 

--- a/t/mojo/content2.t
+++ b/t/mojo/content2.t
@@ -1,0 +1,26 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 1;
+
+use Mojo::Content::MultiPart;
+use Mojo::Message::Request;
+
+local $SIG{ALRM} = sub { die "timeout\n" }; alarm 2;
+
+my $req_seed = <<EOF;
+GET /foo HTTP/1.0
+Content-Type: multipart/mixed; boundary="abcdefg"
+
+Content
+--abcdefg--
+EOF
+
+$req_seed =~ s{\x0a}{\x0d\x0a}g;
+my $req = Mojo::Message::Request->new;
+$req->parse($req_seed);
+$req->parse({});
+
+is(1, 1, 'no infinit loop');


### PR DESCRIPTION
I found multipart request sometimes causes infinit loop.
This is very rare case and not occurs on proper way to use of Mojolicious. 
You can reproduce it by parsing request twice with hash or hash reference for argument.
Parsing request twice may not be a good idea but avoiding the infinit loop makes the class more reliable.

I encountered this when I was working on a plugin which reconstract the request with modified %ENV inside on_process.

https://github.com/jamadam/Mojolicious-Plugin-PlackMiddleware/blob/master/lib/Mojolicious/Plugin/PlackMiddleware.pm#L128
