### PR TITLE
Issue a warning that 'daemon --reload' has no effect

### DIFF
--- a/lib/Mojolicious/Command/Daemon.pm
+++ b/lib/Mojolicious/Command/Daemon.pm
@@ -42,6 +42,7 @@ sub run {
     'keepalive=i' => sub { $daemon->keep_alive_timeout($_[1]) },
     'listen=s'    => \@listen,
     'proxy' => sub { $ENV{MOJO_REVERSE_PROXY} = 1 },
+    'reload' => sub { warn "Ignoring --reload (use 'morbo myapp.pl' instead)!\n" },
     'requests=i'  => sub { $daemon->max_requests($_[1]) },
     'user=s'      => sub { $daemon->user($_[1]) },
     'websocket=i' => sub { $daemon->websocket_timeout($_[1]) }


### PR DESCRIPTION
More than one person has recently tried daemon --reload, not knowing about Morbo, and been surprised when reloading didn't happen. This patch just adds a brief note to let them know that it's not doing anything.
