### PR TITLE
Little doc bug

### DIFF
--- a/lib/Mojo/DOM.pm
+++ b/lib/Mojo/DOM.pm
@@ -637,7 +637,7 @@ Replace element content.
 
   my $root = $dom->root;
 
-Find root element.
+Find root node.
 
 =head2 C<text>
 


### PR DESCRIPTION
At the moment, ->root returns the root of the document, not the root element.
That's why ->root and ->at(':root') are not the same. The nomenclature however is a bit confusing throughout the different xml specs (XML, XPath, XSLT etc.), with XPath having the best definitions (my colleague believes ;)) with calling all these things "nodes" and only elements "elements" (http://www.w3.org/TR/xpath20/).
The bug is - it does not return an element for the moment.
For a discussion on that topic, refer to http://www.dpawson.co.uk/xsl/sect2/root.html.

Best,
Nils
