### PR TITLE
allow non-trimmed text data

### DIFF
--- a/lib/Mojo/DOM.pm
+++ b/lib/Mojo/DOM.pm
@@ -66,7 +66,8 @@ EOF
 
 sub all_text {
   my $self = shift;
-  return $self->_text($self->tree, 1, 1);
+  my $trim = defined $_[0] ? shift : 1;
+  return $self->_text($trim, $self->tree, 1, 1);
 }
 
 sub append { shift->_add(1, @_) }
@@ -306,7 +307,8 @@ sub root {
 
 sub text {
   my $self = shift;
-  return $self->_text($self->tree, 0, 1);
+  my $trim = defined $_[0] ? shift : 1;
+  return $self->_text($trim, $self->tree, 0, 1);
 }
 
 sub to_xml { shift->[0]->render }
@@ -383,7 +385,7 @@ sub _parse {
 }
 
 sub _text {
-  my ($self, $tree, $recurse, $trim) = @_;
+  my ($self, $trim, $tree, $recurse) = @_;
 
   # Don't trim preformatted text
   my $start = 4;
@@ -391,7 +393,9 @@ sub _text {
   elsif ($trim) {
     my $parent = $tree;
     while ($parent->[0] eq 'tag') {
-      $trim = 0 if $parent->[1] eq 'pre';
+      if (!$self->xml && $parent->[1] eq 'pre') {
+        $trim = 0;
+      }
       last unless $parent = $parent->[3];
     }
   }
@@ -403,7 +407,7 @@ sub _text {
 
     # Nested tag
     my $content = '';
-    if ($type eq 'tag' && $recurse) { $content = $self->_text($e, 1, $trim) }
+    if ($type eq 'tag' && $recurse) { $content = $self->_text($trim, $e, 1) }
 
     # Text
     elsif ($type eq 'text') {
@@ -515,8 +519,10 @@ Construct a new L<Mojo::DOM> object.
 =head2 C<all_text>
 
   my $text = $dom->all_text;
+  my $text = $dom->all_text(0);
 
 Extract all text content from DOM structure.
+By default this will trim all whitespaces, which can be disabled.
 
 =head2 C<append>
 
@@ -655,8 +661,10 @@ Find root node.
 =head2 C<text>
 
   my $text = $dom->text;
+  my $text = $dom->text(0);
 
 Extract text content from element only, not including child elements.
+By default this will trim all whitespaces, which can be disabled.
 
 =head2 C<to_xml>
 

--- a/t/mojo/dom.t
+++ b/t/mojo/dom.t
@@ -3,7 +3,7 @@ use Mojo::Base -strict;
 
 use utf8;
 
-use Test::More tests => 637;
+use Test::More tests => 646;
 
 # "Homer gave me a kidney: it wasn't his, I didn't need it,
 #  and it came postage due- but I appreciated the gesture!"
@@ -1894,3 +1894,45 @@ is $dom->div->pre->text, "\n  ", 'right text';
 is $dom->div->pre->all_text, "like\n  it\n    really\n  ", 'right text';
 is $dom->div->pre->code->text,     "like\n  it\n    really", 'right text';
 is $dom->div->pre->code->all_text, "like\n  it\n    really", 'right text';
+is $dom->div->text(0), "\n  looks\n  \n  works\n", 'right text';
+is $dom->div->all_text(0), "\n  looks\n  like\n  it\n    really\n  \n  works\n", 'right text';
+
+# Portable Contacts Example, modified from
+# http://portablecontacts.net/draft-spec.html
+$dom = Mojo::DOM->new(<<EOF);
+<?xml version="1.0" encoding="UTF-8"?>
+<response>
+  <entry>
+    <id>1286823</id>
+    <displayName>Homer Simpson</displayName>
+    <addresses>
+     <type>home</type>
+     <formatted><![CDATA[742 Evergreen Terrace
+Springfield, VT 12345 USA]]></formatted>
+   </addresses>
+ </entry>
+  <entry>
+    <id>1286822</id>
+    <displayName>Marge Simpson</displayName>
+    <addresses>
+     <type>home</type>
+     <formatted>742 Evergreen Terrace
+Springfield, VT 12345 USA</formatted>
+   </addresses>
+ </entry>
+</response>
+EOF
+
+is $dom->at('entry displayName')->text, 'Homer Simpson', 'right text';
+is $dom->find('entry')->[1]->displayName->text, 'Marge Simpson', 'right text';
+is $dom->at('entry')->addresses->formatted->text,
+    "742 Evergreen Terrace\nSpringfield, VT 12345 USA", 'right text';
+is $dom->find('entry')->[1]->addresses->formatted->text,
+    "742 Evergreen Terrace Springfield, VT 12345 USA", 'right text';
+is $dom->find('entry')->[1]->addresses->formatted->text(0),
+    "742 Evergreen Terrace\nSpringfield, VT 12345 USA", 'right text';
+is $dom->find('entry')->[1]->addresses->all_text,
+    "home 742 Evergreen Terrace Springfield, VT 12345 USA", 'right text';
+is $dom->find('entry')->[1]->addresses->all_text(0),
+    "\n     home\n     742 Evergreen Terrace\nSpringfield, VT 12345 USA\n   ",
+    'right text';


### PR DESCRIPTION
This is an easy way to allow non-trimmed text data retrieval.
Additionally it accepts the special pre-treatment only in html mode.
