### PR TITLE
Allow plugin names with uppercase letters to be expanded also in the name

### DIFF
--- a/lib/Mojolicious/Plugins.pm
+++ b/lib/Mojolicious/Plugins.pm
@@ -22,19 +22,19 @@ sub load_plugin {
   my ($self, $name) = @_;
 
   # Module
-  if ($name =~ /^[A-Z]+/) { return $name->new if $self->_load($name) }
+  if ($name =~ /^[A-Z]+/ && $self->_load($name)) { return $name->new }
 
   # Search plugin by name
   else {
 
     # Class
     my $class = $name;
-    camelize $class;
+    camelize $class unless $class =~ /^[A-Z]+/;
 
     # Try all namspaces
     for my $namespace (@{$self->namespaces}) {
-      my $module = "${namespace}::$class";
-      return $module->new if $self->_load($module);
+        my $module = "${namespace}::$class";
+        return $module->new if $self->_load($module);
     }
   }
 
@@ -44,10 +44,10 @@ sub load_plugin {
 
 # "Let's see how crazy I am now, Nixon. The correct answer is very."
 sub register_plugin {
-  my $self = shift;
-  my $name = shift;
-  my $app  = shift;
-  $self->load_plugin($name)->register($app, ref $_[0] ? $_[0] : {@_});
+my $self = shift;
+my $name = shift;
+my $app  = shift;
+$self->load_plugin($name)->register($app, ref $_[0] ? $_[0] : {@_});
 }
 
 sub run_hook {

--- a/t/mojolicious/app.t
+++ b/t/mojolicious/app.t
@@ -8,7 +8,7 @@ BEGIN {
   $ENV{MOJO_MODE}       = 'development';
 }
 
-use Test::More tests => 250;
+use Test::More tests => 260;
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
@@ -293,6 +293,18 @@ $t->get_ok('/foo/bar')->status_is(200)
   ->header_is('X-Powered-By' => 'Mojolicious (Perl)')->content_is('/foo/bar');
 
 $t = Test::Mojo->new('MojoliciousTest');
+
+# MojoliciousTestController::Foo::pluginupper
+$t->get_ok('/plugin/uppercase')->status_is(200)
+  ->header_is(Server         => 'Mojolicious (Perl)')
+  ->header_is('X-Powered-By' => 'Mojolicious (Perl)')
+  ->content_is('WELCOME aboard!');
+
+# MojoliciousTestController::Foo::plugincamelcase
+$t->get_ok('/plugin/camelcase')->status_is(200)
+  ->header_is(Server         => 'Mojolicious (Perl)')
+  ->header_is('X-Powered-By' => 'Mojolicious (Perl)')
+  ->content_is('Welcome aboard!');
 
 # MojoliciousTestController::Foo::stage2
 $t->get_ok('/staged', {'X-Pass' => '1'})->status_is(200)

--- a/t/mojolicious/lib/MojoliciousTest.pm
+++ b/t/mojolicious/lib/MojoliciousTest.pm
@@ -16,6 +16,7 @@ sub startup {
   unshift @{$self->plugins->namespaces},
     $self->routes->namespace . '::Plugin';
   $self->plugin('test_plugin');
+  $self->plugin('UPPERCASETestPlugin');
 
   # Templateless renderer
   $self->renderer->add_handler(
@@ -106,6 +107,10 @@ sub startup {
 
   # /withblock - template with blocks
   $r->route('/withblock')->to('foo#withblock');
+
+  # /plugin/uppercase - plugin loaded correctly in uppercase and camelcase
+  $r->route('/plugin/uppercase/')->to('foo#pluginuppercase');
+  $r->route('/plugin/camelcase/')->to('foo#plugincamelcase');
 
   # /staged - authentication with bridges
   my $b = $r->bridge('/staged')->to(controller => 'foo', action => 'stage1');

--- a/t/mojolicious/lib/MojoliciousTest/Foo.pm
+++ b/t/mojolicious/lib/MojoliciousTest/Foo.pm
@@ -49,6 +49,16 @@ sub stage2 {
   $self->render_text($self->test_plugin);
 }
 
+sub plugincamelcase {
+  my $self = shift;
+  $self->render_text($self->test_plugin);
+}
+
+sub pluginuppercase {
+  my $self = shift;
+  $self->render_text($self->uppercase_test_plugin);
+}
+
 sub syntaxerror { shift->render('syntaxerror', format => 'html') }
 
 sub templateless { shift->render(handler => 'test') }

--- a/t/mojolicious/lib/MojoliciousTest/Plugin/UPPERCASETestPlugin.pm
+++ b/t/mojolicious/lib/MojoliciousTest/Plugin/UPPERCASETestPlugin.pm
@@ -1,0 +1,13 @@
+package MojoliciousTest::Plugin::UPPERCASETestPlugin;
+use Mojo::Base 'Mojolicious::Plugin';
+
+# "I hate these nerds. Just because I'm stupider than them
+# they think they're smarter than me."
+sub register {
+  my ($self, $app) = @_;
+
+  # Add "test_plugin" helper
+  $app->helper(uppercase_test_plugin => sub {'WELCOME aboard!'});
+}
+
+1;


### PR DESCRIPTION
Allow plugin names with uppercase letters to be expanded also in the namespaces (as discussed on IRC today, e.g. allow a plugin named 'DBIC')
