### PR TITLE
When "run" returns result of "Mojo::Server::FastCGI->new->run", "t/mojoli

### DIFF
--- a/lib/Mojolicious/Command/Fastcgi.pm
+++ b/lib/Mojolicious/Command/Fastcgi.pm
@@ -11,7 +11,7 @@ usage: $0 fastcgi
 EOF
 
 # "Interesting... Oh no wait, the other thing, tedious."
-sub run { Mojo::Server::FastCGI->new->run }
+sub run { my $self = shift; Mojo::Server::FastCGI->new->run; return $self }
 
 1;
 __END__


### PR DESCRIPTION
When "run" returns result of "Mojo::Server::FastCGI->new->run", "t/mojolicious/external_lite_app.t" always fails on my machine: 

t/mojolicious/external/myapp.pl did not return a true value at t/mojolicious/external_lite_app.t
line 19

So this changeset fixes an issue.
