### PR TITLE
Some typos

### DIFF
--- a/lib/Mojo/Message.pm
+++ b/lib/Mojo/Message.pm
@@ -733,7 +733,7 @@ Get a chunk of start line data starting from a specific position.
 
   my $leftovers = $message->has_leftovers;
 
-CHeck if message parser has leftover data.
+Check if message parser has leftover data.
 
 =head2 C<header_size>
 
@@ -806,7 +806,7 @@ Note that this method is EXPERIMENTAL and might change without warning!
   my $param  = $message->param('foo');
   my @params = $message->param('foo');
 
-Access C<GET> and C<POST> parameters>.
+Access C<GET> and C<POST> parameters.
 
 =head2 C<parse>
 

--- a/lib/Mojo/Path.pm
+++ b/lib/Mojo/Path.pm
@@ -199,7 +199,7 @@ Parse path.
 
   my $string = $path->to_abs_string;
 
-Turn path into absolute string.
+Turn path into an absolute string.
 Note that this method is EXPERIMENTAL and might change without warning!
 
 =head2 C<to_string>


### PR DESCRIPTION
Because you have a determiner in the example below (or above?), I introduced the "an".
