### PR TITLE
Support for timezones in Mojo::Date

### DIFF
--- a/t/mojo/date.t
+++ b/t/mojo/date.t
@@ -1,7 +1,8 @@
 #!/usr/bin/env perl
+
 use Mojo::Base -strict;
 
-use Test::More tests => 10;
+use Test::More tests => 15;
 
 # "Can't we have one meeting that doesn't end with digging up a corpse?"
 use_ok 'Mojo::Date';
@@ -9,6 +10,23 @@ use_ok 'Mojo::Date';
 # RFC 822/1123
 my $date = Mojo::Date->new('Sun, 06 Nov 1994 08:49:37 GMT');
 is $date->epoch, 784111777, 'right epoch value';
+
+# RFC 822/1123 - not strict RFC2616
+is $date->new('Sun, 06 Nov 1994 08:49:37 UT')->epoch,
+  784111777, 'right epoch value';
+
+is $date->new('Sun, 06 Nov 1994 08:49:37 EST')->epoch,
+  784111777 + (5 * 60 * 60), 'right epoch value';
+
+is $date->new('Sun, 06 Nov 1994 08:49:37 CST')->epoch,
+  784111777 + (6 * 60 * 60), 'right epoch value';
+
+is $date->new('Sun, 06 Nov 1994 08:49:37 MDT')->epoch,
+  784111777 + (6 * 60 * 60), 'right epoch value';
+
+is $date->new('Sun, 06 Nov 1994 08:49:37 PDT')->epoch,
+  784111777 + (7 * 60 * 60), 'right epoch value';
+
 
 # RFC 850/1036
 is $date->parse('Sunday, 06-Nov-94 08:49:37 GMT')->epoch,


### PR DESCRIPTION
Although RFC2616 (http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3) is strict regarding GMT timezones, it notes, that "Recipients of date values are encouraged to be robust in accepting date values that may have been sent by non-HTTP applications". In my opinion, that says implementers SHOULD support consumption of non-gmt date values (for example in rfc-822), while they are not allowed to through out anything non-gmt like.

This patch supports literal time zones as specified in RFC-822 without the incorrectly introduced military timezones. This patch does not support alpha-numeric offsets.

Real world example: I discovered this issue when parsing BoingBoing.net RSS. RSS supports RFC-822, so I expected a RFC-2616 compliant parser to accept it, but it failed.
