### PR TITLE
match attributes having hyphens

### DIFF
--- a/lib/Mojo/DOM/CSS.pm
+++ b/lib/Mojo/DOM/CSS.pm
@@ -4,7 +4,7 @@ use Mojo::Base -base;
 my $ESCAPE_RE = qr/\\[^0-9a-fA-F]|\\[0-9a-fA-F]{1,6}/;
 my $ATTR_RE   = qr/
   \[
-  (?<key>(?:$ESCAPE_RE|[\w-]+)                           # Key
+  (?<key>(?:$ESCAPE_RE|[\w-])+)                         # Key
   (?:
     (?<op>\W)?                                          # Operator
     =


### PR DESCRIPTION
Hi Sebastian!

Bin gerade über ein Problem mit dem Matching von &lt;meta http-eqiv="..."&gt; Tags gestolpert und hab anbei mal einen Quick Fix gepostet.

Ich vermute nicht, daß das schon die korrekte Lösung ist, verwirf den Pull Request ruhig, es geht nur darum, den Punkt klar zu machen.

Im übrigen arbeite ich seit einiger Zeit mit Deinem Framework, gerade an einem Projekt das auch in Produktion gehen wird - und ich halte es für brilliant! Danke, danke, danke! :-)
(Nicht das das viel bedeuten würde, daß ich es dafür halte... trotzdem...)

lg,

Benjamin
