### PR TITLE
ioloop drops the connection because its active time isn't updated for buffered writes

### DIFF
--- a/lib/Mojo/IOLoop.pm
+++ b/lib/Mojo/IOLoop.pm
@@ -340,10 +340,11 @@ sub stream {
 
   # Events
   weaken $self;
-  $stream->on(close => sub { $self->{connections}->{$id}->{finish} = 1 });
-  $stream->on(error => sub { $self->{connections}->{$id}->{finish} = 1 });
-  $stream->on(read  => sub { $self->{connections}->{$id}->{active} = time });
-  $stream->on(write => sub { $self->{connections}->{$id}->{active} = time });
+  $stream->on(close  => sub { $self->{connections}->{$id}->{finish} = 1 });
+  $stream->on(error  => sub { $self->{connections}->{$id}->{finish} = 1 });
+  $stream->on(read   => sub { $self->{connections}->{$id}->{active} = time });
+  $stream->on(buffer => sub { $self->{connections}->{$id}->{active} = time });
+  $stream->on(write  => sub { $self->{connections}->{$id}->{active} = time });
   $stream->resume;
 
   return $id;

--- a/lib/Mojo/IOLoop/Stream.pm
+++ b/lib/Mojo/IOLoop/Stream.pm
@@ -88,6 +88,8 @@ sub write {
   # Start writing
   $self->iowatcher->change($self->{handle}, !$self->{paused}, 1)
     if $self->{handle};
+
+  $self->emit_safe(buffer => $chunk);
 }
 
 sub _close {


### PR DESCRIPTION
I'm not sure the "buffer" event is the correct solution, but at least you know what's "wrong". Client sends a request, server parses it, then handles it and writes the response using buffered writes. Buffered writes don't update the active time value so when the next ioloop iteration begins, the connection is being closed.

To reproduce you should run Morbo, set keepalive timeout to 1s and sleep in controller for a longer time. Such timeout is for inactive clients which don't send the requests, but not for inactive (or super-slow) servers. Browsers (clients) have their own timeout for that.
