### PR TITLE
Make it safe to run many SSL tests in parallel.

### DIFF
--- a/lib/Mojo/IOLoop/Server.pm
+++ b/lib/Mojo/IOLoop/Server.pm
@@ -213,7 +213,7 @@ sub _cert_file {
 
   # Create temporary TLS cert file
   $cert = File::Spec->catfile($ENV{MOJO_TMPDIR} || File::Spec->tmpdir,
-    'mojocert.pem');
+    "mojocert-$$.pem");
   croak qq/Can't create temporary TLS cert file "$cert"/
     unless my $file = IO::File->new("> $cert");
   print $file CERT;
@@ -230,7 +230,7 @@ sub _key_file {
 
   # Create temporary TLS key file
   $key = File::Spec->catfile($ENV{MOJO_TMPDIR} || File::Spec->tmpdir,
-    'mojokey.pem');
+    "mojokey-$$.pem");
   croak qq/Can't create temporary TLS key file "$key"/
     unless my $file = IO::File->new("> $key");
   print $file KEY;


### PR DESCRIPTION
- the problem is that each test process's copy of Mojo::IOLoop::Server writes
  the cert and key to /tmp/mojokey.pem and /tmp/mojocert.pem without any kind
  of lock, so it periodically truncates or deletes a file while it is being
  parsed by another test's openssl library.
- the fix is to use the pid in the cert/key filenames, so that tests don't
  interfere with each other.
- you can verify this by running t/mojolicious/tls_lite_app.t in parallel in a
  tight loop:
  
    for i in 1 2 3 4 5 6 7 8 9; do
    cp t/mojolicious/tls_lite_app.t t/parallel/tls_$i.t
    done
    while true; do
    make test TEST_FILES=t/parallel/*.t HARNESS_OPTIONS=j9 TEST_TLS=1 || break
    done
  
  Without this patch, I never get more that a few iterations. With the patch
  in place, it has never failed (on my machine).
