### PR TITLE
easier Mojo::Exception subclassing

### DIFF
--- a/lib/Mojo/Exception.pm
+++ b/lib/Mojo/Exception.pm
@@ -19,7 +19,7 @@ sub new {
   return @_ ? $self->_detect(@_) : $self;
 }
 
-sub throw { shift and die Mojo::Exception->new->trace(2)->_detect(@_) }
+sub throw { die shift->new->trace(2)->_detect(@_) }
 
 sub to_string {
   my $self = shift;


### PR DESCRIPTION
This commit allows to make exception hierarchy easier.
In the current version we should reimplement throw() in each subclass. This behaviour looks strange.
After this commit we can write smth like:

```
package App::Error;
use base 'Mojo::Exception';

package App::Error::IO;
use base 'App::Error';

package App::Error::HTTP;
use base 'App::Error';

package main;

eval {
    -e "mojo.zip" or
        App::Error::IO->throw("file not found");
};
if (my $e = $@) {
    if ($e->isa('App::Error::HTTP')) {
        # ...
    }
    elsif ($e->isa('App::Error::IO')) {
        # ...
    }
    elsif ($e->isa('App::Error')) {
        # ...
    }
}
```
