### PR TITLE
Mojolicious::Command::get HEAD method

### DIFF
--- a/lib/Mojolicious/Command/get.pm
+++ b/lib/Mojolicious/Command/get.pm
@@ -59,6 +59,8 @@ sub run {
     verbose     => sub { $verbose  = 1 }
   );
 
+  $verbose = 1 if ($method eq 'HEAD');
+
   # Headers
   my $headers = {};
   for my $header (@headers) {


### PR DESCRIPTION
Hi there.
I noticed that with the --method HEAD option mojo get does not do what is expected as it is necessary to use --verbose to see the HTTP headers.
So, I thinked that with HEAD verb --verbose could to be true by default.
If it can be useful in your opinion, here is a micro-patch.

In every case, thanks for your attention.
Simone
