### PR TITLE
don't delete exception key in templates/exception.development.html.ep

### DIFF
--- a/lib/Mojolicious/templates/exception.development.html.ep
+++ b/lib/Mojolicious/templates/exception.development.html.ep
@@ -1,4 +1,4 @@
-% my $e = delete $self->stash->{'exception'};
+% my $e = $self->stash->{'exception'};
 <!DOCTYPE html>
 <html>
   <head>


### PR DESCRIPTION
not deleting the exception key will allow us to use it later in things like an
after_dispatch hook, which would allow us to encode and rendr as json, for
example.

Signed-off-by: Caleb Cushing xenoterracide@gmail.com
