### PR TITLE
use $^V instead of $] to get perl's version (like perl -v does)

### DIFF
--- a/lib/Mojolicious/Command/version.pm
+++ b/lib/Mojolicious/Command/version.pm
@@ -48,7 +48,7 @@ sub run {
 
   print <<"EOF";
 CORE
-  Perl        ($], $^O)
+  Perl        ($^V, $^O)
   Mojolicious ($Mojolicious::VERSION, $Mojolicious::CODENAME)
 
 OPTIONAL

--- a/lib/Mojolicious/templates/exception.development.html.ep
+++ b/lib/Mojolicious/templates/exception.development.html.ep
@@ -206,7 +206,7 @@
       <div class="box infobox" id="more">
         <div id="infos">
           <table>
-            %= $kv->(Perl => "$] ($^O)")
+            %= $kv->(Perl => "$^V ($^O)")
             % my $version  = $Mojolicious::VERSION;
             % my $codename = $Mojolicious::CODENAME;
             %= $kv->(Mojolicious => "$version ($codename)")


### PR DESCRIPTION
Usually people ask for Perl's version by running "perl -v" command so it would be good to have the same version output format in "mojo version" and exception template as "perl -v" does.

Also as documentation says "$^V for a more modern representation of the Perl version...".
