### PR TITLE
Parse HTML attributes without a value.

### DIFF
--- a/lib/Mojo/DOM/HTML.pm
+++ b/lib/Mojo/DOM/HTML.pm
@@ -16,7 +16,7 @@ my $ATTR_RE = qr/
       |
       '([^']*?)'   # Apostrophes
       |
-      ([^>\s]+)    # Unquoted
+      ([^>\s]*)    # Unquoted
     )
   )?
   \s*

--- a/t/mojo/dom.t
+++ b/t/mojo/dom.t
@@ -2,7 +2,7 @@ use Mojo::Base -strict;
 
 use utf8;
 
-use Test::More tests => 683;
+use Test::More tests => 694;
 
 use ojo;
 use Mojo::Util 'encode';
@@ -1976,3 +1976,27 @@ is $dom->find('a[accesskey~="1"]')->[0]->text, 'One', 'right text';
 is $dom->find('a[accesskey~="1]')->[1], undef, 'no result';
 is $dom->find('a[accesskey*="1"]')->[0]->text, 'One', 'right text';
 is $dom->find('a[accesskey*="1]')->[1], undef, 'no result';
+
+# Empty attribute value
+$dom = Mojo::DOM->new->parse(<<EOF);
+<foo bar=>
+  test
+</foo>
+<bar>after</bar>
+EOF
+is $dom->tree->[0], 'root', 'right element';
+is $dom->tree->[1]->[0], 'tag', 'right element';
+is $dom->tree->[1]->[1], 'foo', 'right tag';
+is_deeply $dom->tree->[1]->[2], {bar => ''}, 'right attributes';
+is $dom->tree->[1]->[4]->[0], 'text', 'right element';
+is $dom->tree->[1]->[4]->[1], "\n  test\n", 'right text';
+is $dom->tree->[3]->[0], 'tag', 'right element';
+is $dom->tree->[3]->[1], 'bar', 'right tag';
+is $dom->tree->[3]->[4]->[0], 'text', 'right element';
+is $dom->tree->[3]->[4]->[1], 'after', 'right text';
+is "$dom", <<EOF, 'stringified right';
+<foo bar="">
+  test
+</foo>
+<bar>after</bar>
+EOF


### PR DESCRIPTION
Parsing a HTML attribute with an empty value should result in the value being an empty string per HTML5:

http://www.w3.org/TR/html5/parsing.html#concept-get-attributes-when-sniffing
step 10, second point.

Current behavior causes the parsing to stop as soon as this occurs. Example HTML:

```
<form>
<input type="text" value=>
<input type="text" value="0">
</form>
```
