### PR TITLE
Don't delete exception from stash

### DIFF
--- a/lib/Mojolicious/templates/exception.development.html.ep
+++ b/lib/Mojolicious/templates/exception.development.html.ep
@@ -1,4 +1,4 @@
-% my $e = delete $self->stash->{'exception'};
+% my $e = $self->stash->{'exception'};
 <!DOCTYPE html>
 <html>
   <head>


### PR DESCRIPTION
There's no reason to delete the exception from the stash (recursion-prevention is accomplished with the separate mojo.exception-stash).

This makes it possible to indirectly handle errors _and_ knowing what request it came from.

All of the tests still pass.
