### PR TITLE
Added pdf type

### DIFF
--- a/lib/Mojolicious/Types.pm
+++ b/lib/Mojolicious/Types.pm
@@ -19,6 +19,7 @@ has types => sub {
     json => 'application/json',
     mp3  => 'audio/mpeg',
     png  => 'image/png',
+    pdf  => 'application/pdf',
     rss  => 'application/rss+xml',
     svg  => 'image/svg+xml',
     tar  => 'application/x-tar',


### PR DESCRIPTION
Noticed that detect() was not working for MIME type "application/pdf" so I added to list of types.
