### PR TITLE
Remove depricated use of max_redirects from Growing.pod

### DIFF
--- a/lib/Mojolicious/Guides/Growing.pod
+++ b/lib/Mojolicious/Guides/Growing.pod
@@ -680,7 +680,8 @@ C<t/login.t> can be simplified.
   use Test::Mojo;
 
   # Load application class
-  my $t = Test::Mojo->new('MyApp')->max_redirects(1);
+  my $t = Test::Mojo->new('MyApp');
+  $t->ua->max_redirects(1);
 
   $t->get_ok('/')
     ->status_is(200)


### PR DESCRIPTION
Noticed this in the tests when following the Growing Guide:

t/login.t .. Test::Mojo->max_redirects is DEPRECATED!

I think this commit fixes the documentation correctly.
