### PR TITLE
minor inflate command bug

### DIFF
--- a/lib/Mojolicious/Command/inflate.pm
+++ b/lib/Mojolicious/Command/inflate.pm
@@ -14,7 +14,7 @@ sub run {
   my $all = {};
   my $app = $self->app;
   for my $class (@{$app->renderer->classes}, @{$app->static->classes}) {
-    $all = {%{$self->get_all_data($class)}, %$all};
+    $all = {%{$self->get_all_data($class) // {}}, %$all};
   }
 
   # Turn them into real files


### PR DESCRIPTION
Hi there,

I found out that the inflate command dies if a class from `renderer->classes` or `static->classes` contains no `__END__` or `__DATA__` section. This fixes the issue but I couldn't find inflate tests in the Mojolicious test suite and I don't know how to deal with that. Test case is here: https://gist.github.com/2218462

Mirko/memowe :)
