### PR TITLE
keep headers for 302 redirects

### DIFF
--- a/lib/Mojo/UserAgent/Transactor.pm
+++ b/lib/Mojo/UserAgent/Transactor.pm
@@ -142,7 +142,7 @@ sub redirect {
   # Clone request if necessary
   my $new    = Mojo::Transaction::HTTP->new;
   my $method = $req->method;
-  if ($code ~~ [301, 307]) {
+  if ($code ~~ [301, 302, 307]) {
     return unless $req = $req->clone;
     $new->req($req);
     $req->headers->remove('Host')->remove('Cookie')->remove('Referer');


### PR DESCRIPTION
My colleague found a bug with 302 redirects, where headers were "dropped". As 302 is the same for GET as 307 is for POST I see no reason to behave differently.

Thanks a lot for the great Mojo/Mojolicious eco system.
