### PR TITLE
Extended Payload (64 bit) on a websocket silently fails on 32 bit perl

### DIFF
--- a/lib/Mojo/Transaction/WebSocket.pm
+++ b/lib/Mojo/Transaction/WebSocket.pm
@@ -69,7 +69,7 @@ sub build_frame {
     $frame
       .= $Config{ivsize} > 4
       ? pack('Q>', $len)
-      : pack('NN', $len >> 32, $len & 0xFFFFFFFF);
+      : pack('NN', $len / 0xFFFFFFFF, ($len % 0xFFFFFFFF) - ($len / 0xFFFFFFFF) + 1);
   }
 
   # Mask payload


### PR DESCRIPTION
There's possibly a better way of doing this - but this worked for me.
