### PR TITLE
Bugfix end.* helpers

### DIFF
--- a/lib/Mojo/Template.pm
+++ b/lib/Mojo/Template.pm
@@ -173,34 +173,34 @@ sub parse {
   # Precompile
   my $token_re = qr/
     (
-      \Q$tag$replace\E                 # Replace
+      \Q$tag$replace\E                     # Replace
     |
-      \Q$tag$expr$escp\E\s*\Q$cpen\E   # Escaped expression (end)
+      \Q$tag$expr$escp\E\s*\Q$cpen\E(?!\w) # Escaped expression (end)
     |
-      \Q$tag$expr$escp\E               # Escaped expression
+      \Q$tag$expr$escp\E                   # Escaped expression
     |
-      \Q$tag$expr\E\s*\Q$cpen\E        # Expression (end)
+      \Q$tag$expr\E\s*\Q$cpen\E(?!\w)      # Expression (end)
     |
-      \Q$tag$expr\E                    # Expression
+      \Q$tag$expr\E                        # Expression
     |
-      \Q$tag$cmnt\E\s*\Q$cpen\E        # Comment (end)
+      \Q$tag$cmnt\E\s*\Q$cpen\E(?!\w)      # Comment (end)
     |
-      \Q$tag$cmnt\E                    # Comment
+      \Q$tag$cmnt\E                        # Comment
     |
-      \Q$tag\E\s*\Q$cpen\E             # Code (end)
+      \Q$tag\E\s*\Q$cpen\E(?!\w)           # Code (end)
     |
-      \Q$tag\E                         # Code
+      \Q$tag\E                             # Code
     |
-      \Q$cpst\E\s*\Q$trim$end\E        # Trim end (start)
+      \Q$cpst\E\s*\Q$trim$end\E            # Trim end (start)
     |
-      \Q$trim$end\E                    # Trim end
+      \Q$trim$end\E                        # Trim end
     |
-      \Q$cpst\E\s*\Q$end\E             # End (start)
+      \Q$cpst\E\s*\Q$end\E                 # End (start)
     |
-      \Q$end\E                         # End
+      \Q$end\E                             # End
     )
   /x;
-  my $cpen_re = qr/^(\Q$tag\E)(?:\Q$expr\E)?(?:\Q$escp\E)?\s*\Q$cpen\E/;
+  my $cpen_re = qr/^(\Q$tag\E)(?:\Q$expr\E)?(?:\Q$escp\E)?\s*\Q$cpen\E(?!\w)/;
   my $end_re  = qr/^(?:(\Q$cpst\E)\s*)?(\Q$trim\E)?\Q$end\E$/;
 
   # Split lines

--- a/t/mojolicious/lite_app.t
+++ b/t/mojolicious/lite_app.t
@@ -9,7 +9,7 @@ BEGIN {
   $ENV{MOJO_REACTOR}    = 'Mojo::Reactor::Poll';
 }
 
-use Test::More tests => 685;
+use Test::More tests => 690;
 
 # "Wait you're the only friend I have...
 #  You really want a robot for a friend?
@@ -38,6 +38,7 @@ app->defaults(default => 23);
 helper test_helper  => sub { shift->param(@_) };
 helper test_helper2 => sub { shift->app->controller_class };
 helper dead         => sub { die $_[1] || 'works!' };
+helper endpoint     => sub { 'works!' };
 is app->test_helper('foo'), undef, 'no value yet';
 is app->test_helper2, 'Mojolicious::Controller', 'right value';
 
@@ -390,6 +391,9 @@ get '/app' => {layout => 'app'};
 # GET /helper
 get '/helper' => sub { shift->render(handler => 'ep') } => 'helper';
 app->helper(agent => sub { shift->req->headers->user_agent });
+
+# GET /helper/endpoint
+get '/helper/endpoint' => sub { shift->render('endpoint')};
 
 # GET /eperror
 get '/eperror' => sub { shift->render(handler => 'ep') } => 'eperror';
@@ -1139,6 +1143,12 @@ $t->get_ok('/helper', {'User-Agent' => 'Explorer'})->status_is(200)
   ->header_is('X-Powered-By' => 'Mojolicious (Perl)')
   ->content_is("23\n<br>\n&lt;...\n/template\n(Explorer)");
 
+# GET /helper/endpoint
+$t->get_ok('/helper/endpoint')->status_is(200)
+  ->header_is(Server         => 'Mojolicious (Perl)')
+  ->header_is('X-Powered-By' => 'Mojolicious (Perl)')
+  ->content_is("works!");
+
 # GET /eperror
 $t->get_ok('/eperror')->status_is(500)
   ->header_is(Server         => 'Mojolicious (Perl)')
@@ -1434,6 +1444,9 @@ app layout <%= content %><%= app->mode %>
 %= '<...'
 %= url_for 'index'
 (<%= agent %>)\
+
+@@ endpoint.html.ep
+<%= endpoint %>\
 
 @@ eperror.html.ep
 %= $c->foo('bar');


### PR DESCRIPTION
This patch should fix following bug:
Currently helpers are not allowed to start with the prefix "end" in templates, as this will be interpreted as the terminal symbol of a block sequence.
Using a helper with this prefix will result in syntax errors.
This problem refers to, e.g., https://github.com/Akron/Sojolicious/blob/master/lib/Mojolicious/Plugin/Util/Endpoint.pm .

The patch should be fully backwards compatible.
Tests are attached.
