### PR TITLE
Tiny warning fix.

### DIFF
--- a/lib/Mojo/Message.pm
+++ b/lib/Mojo/Message.pm
@@ -219,7 +219,7 @@ sub is_dynamic    { shift->content->is_dynamic }
 
 sub is_finished { (shift->{state} || '') eq 'finished' }
 
-sub is_limit_exceeded { ((shift->error)[1] || '') ~~ [413, 431] }
+sub is_limit_exceeded { ((shift->error)[1] || 0) ~~ [413, 431] }
 
 sub is_multipart { shift->content->is_multipart }
 


### PR DESCRIPTION
After my last Mojolicious update I found this warning in my logs:

Argument "" isn't numeric in smart match

This patch should fix that.
