### PR TITLE
enable_bundled attr for Mojolicious::Static

### DIFF
--- a/lib/Mojolicious/Static.pm
+++ b/lib/Mojolicious/Static.pm
@@ -11,6 +11,7 @@ use Mojo::Path;
 
 has classes => sub { ['main'] };
 has paths   => sub { [] };
+has enable_bundled => 1;
 
 # "Valentine's Day's coming? Aw crap! I forgot to get a girlfriend again!"
 sub dispatch {
@@ -58,7 +59,7 @@ sub serve {
   }
 
   # Search bundled files
-  elsif (!$asset) {
+  elsif (!$asset && $self->enable_bundled) {
     my $b = $self->{bundled} ||= Mojo::Home->new(Mojo::Home->mojo_lib_dir)
       ->rel_dir('Mojolicious/public');
     my $data = $self->_get_file(catfile($b, split('/', $rel)));

--- a/t/mojolicious/enable_bundled.t
+++ b/t/mojolicious/enable_bundled.t
@@ -1,0 +1,14 @@
+#!/usr/bin/env perl
+use Mojo::Base -strict;
+use Test::More tests => 4;
+use Test::Mojo;
+use Mojolicious::Lite;
+
+my $t = Test::Mojo->new();
+
+# default
+$t->get_ok('/favicon.ico')->status_is(200);
+
+# disable it
+app->static->enable_bundled(0);
+$t->get_ok('/favicon.ico')->status_is(404);


### PR DESCRIPTION
I need to disable bundled files in my project (to overwrite favicon.ico in the embedded app). This feature makes it possible

``` perl
$app->static->enable_bundled(0)
```
