### PR TITLE
Improved handling of mulitple ->set in Mojo::Cache

### DIFF
--- a/lib/Mojo/Cache.pm
+++ b/lib/Mojo/Cache.pm
@@ -16,10 +16,9 @@ sub set {
 
   # Cache with size limit
   my $cache = $self->{cache} ||= {};
-  my $stack = $self->{stack} ||= [];
-  my $keys  = $self->max_keys;
-  delete $cache->{shift @$stack} while @$stack >= $keys;
-  push @$stack, $key;
+  my $queue = $self->{queue} ||= [];
+  delete $cache->{shift @$queue} if @$queue >= $self->max_keys;
+  push @$queue, $key unless exists $cache->{$key};
   $cache->{$key} = $value;
 
   return $self;


### PR DESCRIPTION
In the main version, if the same key is set multiple times, each time consumes a slot in the space-bounded queue, lessening the value of the cache and hastening the unnecessary removal of entries.
While fixing that, I removed two sources of confusion: the queue is no longer called 'stack' and the while-loop is replaced by a simple conditional.
But the bit you'll like: it now has (1) fewer lines of code while retaining the same functionality and passing all tests.
Nic
