### PR TITLE
Workaround for morbo (MSWin + threads related)

### DIFF
--- a/script/morbo
+++ b/script/morbo
@@ -37,6 +37,13 @@ These options are available:
                                  working directory.
 EOF
 
+if ($^O eq 'MSWin32') {
+  # morbo uses fork() which is on MS Windows emulated via threads
+  # however some pieces used by Mojo are not completely thread-safe
+  $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll'; # avoid using Mojo::Reactor::EV
+  $ENV{MOJO_NO_TLS} or require IO::Socket::SSL; # workaround for RT #79685
+}
+
 $ENV{MOJO_LISTEN} = join(',', @listen) if @listen;
 require Mojo::Server::Morbo;
 my $morbo = Mojo::Server::Morbo->new;


### PR DESCRIPTION
Hi,

I was investigating why morbo's autoreloading feature is crashing on MS Windows.

It turns out that there are 2 pieces used by Mojo that do not play well with threads (you probably know that fork() which is used by morbo is emulated via threads on MS Windows).

1/ Mojo::Reactor::EV seems to have troubles when used with perl's threads

2/ IO::Socket::SSL is basically thread safe providing that it is loaded in the main thread - I have created an RT for this issue https://rt.cpan.org/Public/Bug/Display.html?id=79685

The patch in this pull request tries to deal with those 2 issues.

I know that it is a hack and that proper fix should be made in other modules outside Mojo. On the other hand providing that morbo is "only" development server I hope you will not reject it.
## 

kmx
