### PR TITLE
Document use of charset when encoding parameters.

### DIFF
--- a/lib/Mojo/Parameters.pm
+++ b/lib/Mojo/Parameters.pm
@@ -219,7 +219,7 @@ L<Mojo::Parameters> implements the following attributes.
   my $charset = $p->charset;
   $p          = $p->charset('UTF-8');
 
-Charset used for decoding parameters, defaults to C<UTF-8>.
+Charset used for encoding or decoding parameters, defaults to C<UTF-8>.
 
 =head2 C<pair_separator>
 


### PR DESCRIPTION
This information was no clear on Mojo::Parameters docs.

```
my $p = new Mojo::Parameters();
$p->charset('iso-8859-1');
$p->append( string => 'Usuário' );
say $p->to_string;
# string=Usu%E1rio
```
