### PR TITLE
Simple little doc patch

### DIFF
--- a/lib/Mojolicious/Controller.pm
+++ b/lib/Mojolicious/Controller.pm
@@ -937,6 +937,8 @@ Generate a portable L<Mojo::URL> object with base for a route, path or URL.
   # "/myapp/perldoc?foo=bar" if application is deployed under "/myapp"
   $c->url_for('/perldoc')->query(foo => 'bar');
 
+Without arguments, generate the L<Mojo::URL> for the current request.
+
 You can also use the helper L<Mojolicious::Plugin::DefaultHelpers/"url_with">
 to inherit query parameters from the current request.
 


### PR DESCRIPTION
I spent _way_ too long trying to figure out the "proper" way to get the URL for the current request. I pored over the docs and tutorials because I wanted to make sure I was doing it "right". Just to get the page done I used `$c->req->url`, until this morning when I tried `$c->url_for('')`... That worked so I tried `$c->url_for;` which also worked!

I needed the requested URL because I was writing an 'under' route for checking authentication and I wanted to record the user's requested destination before forwarding them to the login page so I could then forward them where they wanted to go after logging in.
