### PR TITLE
Prompt pass

### DIFF
--- a/lib/Mojolicious/Command/cpanify.pm
+++ b/lib/Mojolicious/Command/cpanify.pm
@@ -61,7 +61,7 @@ sub _read_password {
   # set to autoflush STDOUT
   # this isn't strictly necessary, but it places the newline after reading the password
   # and before any error from the uploader
-  $| = 1;
+  local $| = 1;
 
   eval 'use Term::ReadKey (); 1' or die "Prompt for password requires Term::ReadKey installed\n";
   print "Password: ";


### PR DESCRIPTION
Allows `mojo cpanify` to utilize Term::ReadKey (if available) to prompt for password. Addresses #394
