### PR TITLE
added prompt_password which uses Term::ReadKey or goto &prompt

### DIFF
--- a/lib/Mojo/Util.pm
+++ b/lib/Mojo/Util.pm
@@ -134,6 +134,23 @@ sub prompt {
   return $input;
 }
 
+sub prompt_password {
+  unless ( eval 'use Term::ReadKey (); 1' ) {
+    warn "Term::ReadKey not installed, reverting to standard prompt\n";
+    goto &prompt;
+  }
+
+  local $| = 1;
+
+  Term::ReadKey::ReadMode(2);
+  my $input = prompt(@_);
+  Term::ReadKey::ReadMode(0);
+
+  print "\n";
+
+  return $input;
+}
+
 sub punycode_decode {
   my $input = shift;
   use integer;


### PR DESCRIPTION
Yet another patch to allow Term::ReadKey to hide a password after prompting (#394). This one creates a `prompt_password` function in Mojo::Util which calls `prompt` but wraps it in calls to ReadMode to suppress the output. While this mechanism would work in external modules, again, my aim is to hide the password in `mojo cpanify`.
