### PR TITLE
fix annoying warning in Test::Mojo

### DIFF
--- a/lib/Test/Mojo.pm
+++ b/lib/Test/Mojo.pm
@@ -132,9 +132,12 @@ sub header_like {
 
 sub header_unlike {
   my ($self, $name, $regex, $desc) = @_;
+
   $desc ||= "$name is not similar";
-  return $self->_test('unlike', scalar $self->tx->res->headers->header($name),
-    $regex, $desc);
+  my $header = $self->tx->res->headers->header($name);
+
+  return $self->_test('pass', $desc) unless defined $header;
+  return $self->_test('unlike', $header, $regex, $desc);
 }
 
 sub json_content_is {


### PR DESCRIPTION
unlike $t->header_isnt, $t->header_unlike(Header => qr/regexp/) generates annoying warnings when Mojo::Headers does not contain a "Header" header
Test:

``` perl
#!/usr/bin/env perl
use Mojo::Base -strict;
use Test::More tests => 2;
use Test::Mojo;
use Mojolicious::Lite;


my $t = Test::Mojo->new();


local $SIG{__WARN__} = sub {
  fail "annoying warning: " . shift;
};

$t->get_ok('/')->header_unlike(NotExisting => qr/Foo/);
```
