### PR TITLE
Mojo::Template uses _escape function in its sandbox namespace if it exists

### DIFF
--- a/lib/Mojo/Template.pm
+++ b/lib/Mojo/Template.pm
@@ -93,10 +93,12 @@ sub build {
     }
   }
 
-  # Escape helper
-  my $escape = q[no warnings 'redefine'; sub _escape {];
-  $escape .= q/no warnings 'uninitialized'; ref $_[0] eq 'Mojo::ByteStream'/;
-  $escape .= '? $_[0] : Mojo::Util::xml_escape("$_[0]") }';
+  my $escape = '';
+  unless ( $self->namespace->can('_escape') ) {
+    $escape .= 'sub _escape {';
+    $escape .= q/no warnings 'uninitialized'; ref $_[0] eq 'Mojo::ByteStream'/;
+    $escape .= '? $_[0] : Mojo::Util::xml_escape("$_[0]") }';
+  }
 
   # Wrap lines
   my $first = $lines[0] ||= '';

--- a/t/mojo/template.t
+++ b/t/mojo/template.t
@@ -17,7 +17,7 @@ use Mojo::Base -strict;
 
 use utf8;
 
-use Test::More tests => 199;
+use Test::More tests => 201;
 
 use File::Spec::Functions qw(catfile splitdir);
 use FindBin;
@@ -1072,3 +1072,12 @@ $mt = Mojo::Template->new(encoding => 'shift_jis');
 $file = catfile(splitdir($FindBin::Bin), qw(templates utf8_exception.mt));
 ok !eval { $mt->render_file($file) }, 'file not rendered';
 like $@, qr/invalid encoding/, 'right error';
+
+# Custom escape handler in sandbox namespace
+{
+  package Mojo::Template::Sandbox::Custom;
+  sub _escape { return '+' . $_[0] }
+}
+$mt = Mojo::Template->new( namespace => 'Mojo::Template::Sandbox::Custom' );
+is $mt->render('<%== "hi" =%>'), '+hi', 'right escaped string';
+unlike $mt->template, qr/_escape/, 'no _escape function in template';


### PR DESCRIPTION
I was sad to see that custom escape handling was remove with 6dc78f369b612795849d97a11ed84f890e3a03b9, but I understood, the mechanism was too hackish, both as a string of Perl code and as a redefinable helper. I thought for a while and I think I have hit on something that not only helps me but helps Mojolicious as well!

This simple patch checks if the sandbox namespace already has a function named `_escape`. If not it defines one, just as before. This means that
1. The _escape function wont be overridden repeatedly (costing cycles)
2. The default string no longer needs the `no warnings 'redefine'`
3. I can put a function in my own namespace (e.g. `Mojo::Template::Sandbox::LaTeX::_escape`) and it will not be overridden
