### PR TITLE
simplified non-blocking crawler recipe

### DIFF
--- a/lib/Mojolicious/Guides/Cookbook.pod
+++ b/lib/Mojolicious/Guides/Cookbook.pod
@@ -934,30 +934,32 @@ can keep many parallel connections active at the same time.
   # User agent following up to 5 redirects
   my $ua = Mojo::UserAgent->new(max_redirects => 5);
 
-  # Crawler
-  sub crawl {
+  my $active = 0;
+  Mojo::IOLoop->recurring(0 => sub {
 
-    # Dequeue URL or wait 2 seconds for more
-    return Mojo::IOLoop->timer(2 => \&crawl) unless my $url = shift @urls;
+    # Keep up to 4 parallel crawlers sharing the same user agent
+    for ($active .. 4 - 1) {
 
-    # Fetch non-blocking just by adding a callback
-    $ua->get($url => sub {
-      my ($ua, $tx) = @_;
+      # Dequeue or halt if there are no active crawlers anymore
+      return ($active or Mojo::IOLoop->stop) unless my $url = shift @urls;
 
-      # Extract and enqueue URLs
-      say $url;
-      for my $e ($tx->res->dom('a[href]')->each) {
-        push @urls, Mojo::URL->new($e->{href})->to_abs($tx->req->url);
-        say " -> $urls[-1]";
-      }
+      # Fetch non-blocking just by adding a callback and marking as active
+      ++$active;
+      $ua->get($url => sub {
+        my ($ua, $tx) = @_;
 
-      # Next
-      crawl();
-    });
-  }
+        # Extract and enqueue URLs
+        say $url;
+        for my $e ($tx->res->dom('a[href]')->each) {
+            push @urls, Mojo::URL->new($e->{href})->to_abs($tx->req->url);
+            say " -> $urls[-1]";
+        }
 
-  # Start a bunch of parallel crawlers sharing the same user agent
-  crawl() for 1 .. 3;
+        # Deactivate
+        --$active;
+      });
+    }
+  });
 
   # Start event loop if necessary
   Mojo::IOLoop->start unless Mojo::IOLoop->is_running;


### PR DESCRIPTION
Take two: get rid of the tail call; crawler halts when the queue is empty.
I am a bit concerned about people "growing" real web crawlers from the former recipe. They'll have a bad time.
