### PR TITLE
fixed Mojo::Parameters bug and improved tests

### DIFF
--- a/lib/Mojo/Parameters.pm
+++ b/lib/Mojo/Parameters.pm
@@ -73,6 +73,7 @@ sub params {
   # Replace parameters
   if (@_) {
     $self->{params} = shift;
+    delete $self->{string};
     return $self;
   }
 

--- a/t/mojo/parameters.t
+++ b/t/mojo/parameters.t
@@ -32,6 +32,7 @@ is $params->to_string, 'foo=b%3Bar;baz=23;a=4;a=5;b=6;b=7;x=1;y=2',
   'right format';
 is $params2->to_string, 'x=1&y=2', 'right format';
 
+
 # Param
 is_deeply $params->param('foo'), 'b;ar', 'right structure';
 is_deeply [$params->param('a')], [4, 5], 'right structure';
@@ -57,8 +58,8 @@ is_deeply [$params->param], [qw(q t w)], 'right structure';
 
 # Append
 $params->append('a', 4, 'a', 5, 'b', 6, 'b', 7);
-is_deeply $params->to_hash,
-  {a => [4, 5], b => [6, 7], q => 1, w => 2, t => 7}, 'right structure';
+is_deeply $params->to_hash, {a => [4, 5], b => [6, 7], q => 1, w => 2, t => 7},
+  'right structure';
 $params = Mojo::Parameters->new(foo => undef, bar => 'bar');
 is $params->to_string, 'foo=&bar=bar', 'right format';
 $params = Mojo::Parameters->new(bar => 'bar', foo => undef);
@@ -206,5 +207,11 @@ $params = Mojo::Parameters->new('%E5=%E4')->charset(undef);
 is $params->param("\xe5"), "\xe4", 'right value';
 is "$params", '%E5=%E4', 'right result';
 is $params->clone->to_string, '%E5=%E4', 'right result';
+
+# Replace
+$params = Mojo::Parameters->new('x=3&z=4');
+$params->params($params2->params);
+is_deeply $params->to_hash, $params2->to_hash,   'right structure';
+is $params->to_string,      $params2->to_string, 'right result';
 
 done_testing();

--- a/t/mojo/url.t
+++ b/t/mojo/url.t
@@ -76,6 +76,10 @@ is "$url", 'http://sri:foobar@kraih.com:8080?foo=23&bar=24&baz=25#23',
   'right format';
 $url->query([foo => 26, bar => undef, baz => undef]);
 is "$url", 'http://sri:foobar@kraih.com:8080?foo=26#23', 'right format';
+$url->query(Mojo::Parameters->new(a => 1, b => 2));
+is "$url", 'http://sri:foobar@kraih.com:8080?a=1&b=2#23';
+$url->query(z => 3);
+is "$url", 'http://sri:foobar@kraih.com:8080?z=3#23';
 
 # Query string
 $url = Mojo::URL->new(
@@ -118,8 +122,8 @@ is $url->to_abs(Mojo::URL->new('http://')), 'http://localhost/23/',
   'right absolute version';
 is $url->to_abs(Mojo::URL->new('https://')), 'https://localhost/23/',
   'right absolute version';
-is $url->to_abs(Mojo::URL->new('http://mojolicio.us')),
-  'http://localhost/23/', 'right absolute version';
+is $url->to_abs(Mojo::URL->new('http://mojolicio.us')), 'http://localhost/23/',
+  'right absolute version';
 is $url->to_abs(Mojo::URL->new('http://mojolicio.us:8080')),
   'http://localhost/23/', 'right absolute version';
 $url = Mojo::URL->new('///bar/23/');


### PR DESCRIPTION
This example from documentation of Mojo::URL is not properly working now

``` perl
# Expecting: 'http://mojolicio.us?a=2&c=3'
# :(         'http://mojolicio.us?a=1&b=2&a=2&c=3'
say Mojo::URL->new('http://mojolicio.us?a=1&b=2')->query(a => 2, c => 3);
```
