### PR TITLE
Remove userinfo from base_tag

### DIFF
--- a/lib/Mojolicious/Plugin/TagHelpers.pm
+++ b/lib/Mojolicious/Plugin/TagHelpers.pm
@@ -15,7 +15,7 @@ sub register {
 
   # Add "base_tag" helper
   $app->helper(
-    base_tag => sub { _tag('base', href => shift->req->url->base, @_) });
+    base_tag => sub { _tag('base', href => shift->req->url->base->clone->userinfo(undef), @_) });
 
   # Add "checkbox" helper
   $app->helper(check_box =>

--- a/t/mojolicious/lite_app.t
+++ b/t/mojolicious/lite_app.t
@@ -516,6 +516,9 @@ get '/dynamic/inline' => sub {
   $self->render(inline => 'dynamic inline ' . $dynamic_inline++);
 };
 
+# GET /base_tag
+get '/base_tag';
+
 # Oh Fry, I love you more than the moon, and the stars,
 # and the POETIC IMAGE NUMBER 137 NOT FOUND
 my $t = Test::Mojo->new;
@@ -1237,6 +1240,9 @@ $t->get_ok('/dynamic/inline')->status_is(200)
 $t->get_ok('/dynamic/inline')->status_is(200)
   ->content_is("dynamic inline 2\n");
 
+$t->get_ok( $t->ua->app_url->userinfo('secret:pass')->path('/base_tag') )
+  ->status_is(200)->content_unlike(qr/secret/);
+
 done_testing();
 
 __DATA__
@@ -1329,6 +1335,9 @@ Not a favicon!
 %== url_with('http://mojolicio.us/test')
 %== url_with('/test')->query([foo => undef])
 %== url_with('bartest', test => 23)->query([foo => 'yada'])
+
+@@ base_tag.html.ep
+base tag : <%= base_tag %>
 
 __END__
 This is not a template!


### PR DESCRIPTION
Hi again (re : github issue 436),

Here's a pull request to remove userinfo from the base_tag helper.  This seems like a good security fix;  putting userinfo inside a web page means credentials may not only be in caches but also some browsers (firefox 17) actually display the credentials as part of the link destination (on the bottom of the screen).  Am happy to bring this up on the mailing list if you think more discussion is warranted.

thanks again
Brian
