### PR TITLE
Bugfix

### DIFF
--- a/lib/Mojo/Server/Hypnotoad.pm
+++ b/lib/Mojo/Server/Hypnotoad.pm
@@ -182,7 +182,9 @@ sub _manage {
     $self->{log}->info("Upgrade successful, stopping $ENV{HYPNOTOAD_PID}.");
     kill 'QUIT', $ENV{HYPNOTOAD_PID};
   }
-  $ENV{HYPNOTOAD_PID} = $$;
+  if (!exists $ENV{HYPNOTOAD_PID} || $ENV{HYPNOTOAD_PID} ne $$) {
+    $ENV{HYPNOTOAD_PID} = $$;
+  }
 
   # Check heartbeat
   $self->_heartbeat;


### PR DESCRIPTION
Perl uses putenv(3) when you alter %ENV, which can, depending on the implementation, leak memory. Therefore, you should avoid unneccessary calls of putenv, this small patch eliminates most of these calls.
