### PR TITLE
Issue with huge file uploads on 32-bit Perl

### DIFF
--- a/lib/Mojo/Content.pm
+++ b/lib/Mojo/Content.pm
@@ -140,6 +140,7 @@ sub parse {
     my $len = $headers->content_length || 0;
     $self->{size} ||= 0;
     if ((my $need = $len - $self->{size}) > 0) {
+      $need = length($self->{buffer}) if $need > length($self->{buffer});
       my $chunk = substr $self->{buffer}, 0, $need, '';
       $self->_uncompress($chunk);
       $self->{size} += length $chunk;

--- a/t/mojo/content.t
+++ b/t/mojo/content.t
@@ -77,4 +77,12 @@ ok !$content->charset, 'no charset';
 'a' =~ /(.)/;
 ok !$content->boundary, 'no boundary';
 
+# Upload > 2G on 32-bit Perl
+$content = Mojo::Content::Single->new;
+$content->parse("Content-Length: 2200000000\r\n\r\nHello World!");
+is $content->asset->size, 12, 'right upload size';
+$content = Mojo::Content::Single->new;
+$content->parse("Content-Length: 4400000000\r\n\r\nHello World!");
+is $content->asset->size, 12, 'right upload size';
+
 done_testing();


### PR DESCRIPTION
I have to depoy a Mojolicious application on a Perl 5.10.1 w/ 32 bit on an Open Solaris system.
That application offers a file upload.
By trying to upload a file > 2G (and smaller than 4G) with multipart/form-data, the application tries to load everything into RAM - **without considerung $MOJO_MAX_MESSAGE_SIZE**.
The reason seems to be an overflow of a signed 32-bit decimal in substr(). A simple test:

```
[host ~]# perl -wE 'my $s = "abc"; say length(substr $s, 0, 2_200_000_000)'
0
```

On a 64-bit system the result is '3' of course.

Also interesting is the double-overflow btw:

```
[host ~]# perl -wE 'my $s = "abc"; say length(substr $s, 0, 4_400_000_000)'
2
```

The additional tests in t/mojo/content.t are failing without the changes in lib/Mojo/Content.pm .
