### PR TITLE
Clarify param() documentation for multi-valued parameters

### DIFF
--- a/lib/Mojo/Parameters.pm
+++ b/lib/Mojo/Parameters.pm
@@ -280,7 +280,10 @@ Merge L<Mojo::Parameters> objects.
   my $foo   = $params->param(foo => 'ba;r');
   my @foo   = $params->param(foo => qw(ba;r ba;z));
 
-Check and replace parameter values.
+Check and replace parameter value. Be aware that if you request a parameter by
+name in scalar context, you will receive only the I<first> value for that
+parameter, if there are multiple values for that name. In list context you will
+receive I<all> of the values for that name.
 
 =head2 params
 


### PR DESCRIPTION
Our misunderstanding of this behavior led to a bug in one of our projects. If I'd read this in the documentation, it would have been easier to find and to fix.
