### PR TITLE
Cookies for host specified by IP address

### DIFF
--- a/lib/Mojo/UserAgent/CookieJar.pm
+++ b/lib/Mojo/UserAgent/CookieJar.pm
@@ -43,11 +43,19 @@ sub extract {
   for my $cookie (@{$tx->res->cookies}) {
 
     # Validate domain
-    my $host = lc $url->ihost;
+    # RFC6265 - 5.1.3 (Domain Matching)
+    my $is_valid_domain;
+
+    my $host   = lc $url->ihost;
     my $domain = lc($cookie->domain // $host);
+
+    $is_valid_domain ||= $host eq $domain;
+
     $domain =~ s/^\.//;
-    next unless $host eq $domain || $host =~ /\Q.$domain\E$/;
-    next if $host =~ /\.\d+$/;
+    $is_valid_domain ||= ($host =~ /\Q.$domain\E$/ && $domain !~ /\d+$/);
+    
+    next unless $is_valid_domain;
+    
     $cookie->domain($domain);
 
     # Validate path

--- a/t/mojo/cookiejar.t
+++ b/t/mojo/cookiejar.t
@@ -409,21 +409,35 @@ $tx->res->cookies(
   Mojo::Cookie::Response->new(
     name   => 'foo',
     value  => 'invalid',
-    domain => '213.133.102.53'
+    domain => '.213.133.102.53'
   ),
   Mojo::Cookie::Response->new(
-    name   => 'foo',
+    name   => 'bar',
     value  => 'invalid',
     domain => '102.53'
   ),
   Mojo::Cookie::Response->new(
-    name   => 'foo',
+    name   => 'baz',
     value  => 'invalid',
     domain => '53'
-  )
+  ),
+  Mojo::Cookie::Response->new(
+    name   => 'no',
+    value  => 'domain',
+  ),
+  Mojo::Cookie::Response->new(
+    name   => 'domain',
+    value  => 'equals',
+    domain => '213.133.102.53'
+  ),
 );
 $jar->extract($tx);
-is_deeply [$jar->all], [], 'no cookies';
+@cookies = $jar->all;
+is $cookies[0]->name,  'no',     'right name';
+is $cookies[0]->value, 'domain', 'right value';
+is $cookies[1]->name,  'domain', 'right name';
+is $cookies[1]->value, 'equals', 'right value';
+is $cookies[2], undef, 'no third cookie';
 
 # Extract cookies with invalid path
 $jar = Mojo::UserAgent::CookieJar->new;


### PR DESCRIPTION
From 3.79 version cookie extraction wasn't working for host specified by IP address.
According to RFC 6265 domain string match given string if strings are identical:

```
5.1.3.  Domain Matching

   A string domain-matches a given domain string if at least one of the
   following conditions hold:

   o  The domain string and the string are identical.  (Note that both
      the domain string and the string will have been canonicalized to
      lower case at this point.)

   o  All of the following conditions hold:

      *  The domain string is a suffix of the string.

      *  The last character of the string that is not included in the
         domain string is a %x2E (".") character.

      *  The string is a host name (i.e., not an IP address).
```
