### PR TITLE
Monotonic clock support

### DIFF
--- a/lib/Mojo/IOLoop/Stream.pm
+++ b/lib/Mojo/IOLoop/Stream.pm
@@ -2,8 +2,8 @@ package Mojo::IOLoop::Stream;
 use Mojo::Base 'Mojo::EventEmitter';
 
 use Errno qw(EAGAIN ECONNRESET EINTR EPIPE EWOULDBLOCK);
+use Mojo::Util 'steady_time';
 use Scalar::Util 'weaken';
-use Time::HiRes 'time';
 
 has reactor => sub {
   require Mojo::IOLoop;
@@ -13,7 +13,7 @@ has timeout => 15;
 
 sub DESTROY { shift->close }
 
-sub new { shift->SUPER::new(handle => shift, buffer => '', active => time) }
+sub new { shift->SUPER::new(handle => shift, buffer => '') }
 
 sub close {
   my $self = shift;
@@ -32,7 +32,7 @@ sub handle { shift->{handle} }
 
 sub is_readable {
   my $self = shift;
-  $self->{active} = time;
+  $self->{active} = steady_time;
   return $self->{handle} && $self->reactor->is_readable($self->{handle});
 }
 
@@ -92,7 +92,7 @@ sub _read {
   # EOF
   return $self->close if $read == 0;
 
-  $self->emit_safe(read => $buffer)->{active} = time;
+  $self->emit_safe(read => $buffer)->{active} = steady_time;
 }
 
 sub _startup {
@@ -108,6 +108,7 @@ sub _startup {
     }
   );
 
+  $self->{active} = steady_time;
   $reactor->io($self->{handle}, sub { pop() ? $self->_write : $self->_read });
 }
 
@@ -130,7 +131,7 @@ sub _write {
     }
 
     $self->emit_safe(write => substr($self->{buffer}, 0, $written, ''));
-    $self->{active} = time;
+    $self->{active} = steady_time;
   }
 
   $self->emit_safe('drain') if !length $self->{buffer};

--- a/lib/Mojo/Server/Hypnotoad.pm
+++ b/lib/Mojo/Server/Hypnotoad.pm
@@ -7,6 +7,7 @@ use Cwd 'abs_path';
 use File::Basename 'dirname';
 use File::Spec::Functions 'catfile';
 use Mojo::Server::Prefork;
+use Mojo::Util 'steady_time';
 use POSIX 'setsid';
 use Scalar::Util 'weaken';
 
@@ -62,7 +63,7 @@ sub run {
   }
 
   # Start accepting connections
-  local $SIG{USR2} = sub { $self->{upgrade} ||= time };
+  local $SIG{USR2} = sub { $self->{upgrade} ||= steady_time };
   $prefork->run;
 }
 
@@ -123,7 +124,7 @@ sub _manage {
 
     # Timeout
     kill 'KILL', $self->{new}
-      if $self->{upgrade} + $self->{upgrade_timeout} <= time;
+      if $self->{upgrade} + $self->{upgrade_timeout} <= steady_time;
   }
 }
 

--- a/lib/Mojo/Server/Prefork.pm
+++ b/lib/Mojo/Server/Prefork.pm
@@ -5,6 +5,7 @@ use Fcntl ':flock';
 use File::Spec::Functions qw(catfile tmpdir);
 use IO::Poll 'POLLIN';
 use List::Util 'shuffle';
+use Mojo::Util 'steady_time';
 use POSIX 'WNOHANG';
 use Scalar::Util 'weaken';
 use Time::HiRes ();
@@ -70,7 +71,7 @@ sub run {
   local $SIG{TTOU} = sub {
     $self->workers($self->workers - 1) if $self->workers > 0;
     return unless $self->workers;
-    $self->{pool}{shuffle keys %{$self->{pool}}}{graceful} ||= time;
+    $self->{pool}{shuffle keys %{$self->{pool}}}{graceful} ||= steady_time;
   };
 
   # Preload application and start accepting connections
@@ -89,7 +90,8 @@ sub _heartbeat {
   return unless $self->{reader}->sysread(my $chunk, 4194304);
 
   # Update heartbeats
-  $self->{pool}{$1} and $self->emit(heartbeat => $1)->{pool}{$1}{time} = time
+  my $time = steady_time;
+  $self->{pool}{$1} and $self->emit(heartbeat => $1)->{pool}{$1}{time} = $time
     while $chunk =~ /(\d+)\n/g;
 }
 
@@ -113,17 +115,18 @@ sub _manage {
     # No heartbeat (graceful stop)
     my $interval = $self->heartbeat_interval;
     my $timeout  = $self->heartbeat_timeout;
-    if (!$w->{graceful} && ($w->{time} + $interval + $timeout <= time)) {
+    my $time     = steady_time;
+    if (!$w->{graceful} && ($w->{time} + $interval + $timeout <= $time)) {
       $log->info("Worker $pid has no heartbeat, restarting.");
-      $w->{graceful} = time;
+      $w->{graceful} = $time;
     }
 
     # Graceful stop with timeout
-    $w->{graceful} ||= time if $self->{graceful};
+    $w->{graceful} ||= $time if $self->{graceful};
     if ($w->{graceful}) {
       $log->debug("Trying to stop worker $pid gracefully.");
       kill 'QUIT', $pid;
-      $w->{force} = 1 if $w->{graceful} + $self->graceful_timeout <= time;
+      $w->{force} = 1 if $w->{graceful} + $self->graceful_timeout <= $time;
     }
 
     # Normal stop
@@ -161,7 +164,8 @@ sub _spawn {
 
   # Manager
   die "Can't fork: $!" unless defined(my $pid = fork);
-  return $self->emit(spawn => $pid)->{pool}{$pid} = {time => time} if $pid;
+  return $self->emit(spawn => $pid)->{pool}{$pid} = {time => steady_time}
+    if $pid;
 
   # Prepare lock file
   my $file = $self->{lock_file};

--- a/lib/Mojo/Util.pm
+++ b/lib/Mojo/Util.pm
@@ -8,6 +8,11 @@ use Encode 'find_encoding';
 use File::Basename 'dirname';
 use File::Spec::Functions 'catfile';
 use MIME::Base64 qw(decode_base64 encode_base64);
+use Time::HiRes ();
+
+# Check for monotonic clock support
+use constant MONOTONIC => eval
+  '!!Time::HiRes::clock_gettime(Time::HiRes::CLOCK_MONOTONIC())';
 
 # Punycode bootstring parameters
 use constant {
@@ -45,7 +50,8 @@ our @EXPORT_OK = (
   qw(decode deprecated encode get_line hmac_md5_sum hmac_sha1_sum),
   qw(html_unescape md5_bytes md5_sum monkey_patch punycode_decode),
   qw(punycode_encode quote secure_compare sha1_bytes sha1_sum slurp spurt),
-  qw(squish trim unquote url_escape url_unescape xml_escape xor_encode)
+  qw(squish steady_time trim unquote url_escape url_unescape xml_escape),
+  qw(xor_encode)
 );
 
 # DEPRECATED in Rainbow!
@@ -292,6 +298,12 @@ sub squish {
   my $string = trim(@_);
   $string =~ s/\s+/ /g;
   return $string;
+}
+
+sub steady_time {
+  MONOTONIC
+    ? Time::HiRes::clock_gettime(Time::HiRes::CLOCK_MONOTONIC())
+    : Time::HiRes::time;
 }
 
 sub trim {
@@ -606,6 +618,12 @@ Write all data at once to file.
 
 Trim whitespace characters from both ends of string and then change all
 consecutive groups of whitespace into one space each.
+
+=head2 steady_time
+
+  my $time = steady_time;
+
+High resolution time, monotonic if possible.
 
 =head2 trim
 

--- a/t/mojo/util.t
+++ b/t/mojo/util.t
@@ -12,8 +12,8 @@ use Mojo::Util
   qw(b64_decode b64_encode camelize class_to_file class_to_path decamelize),
   qw(decode encode get_line hmac_md5_sum hmac_sha1_sum html_unescape),
   qw(md5_bytes md5_sum monkey_patch punycode_decode squish trim unquote),
-  qw(secure_compare sha1_bytes sha1_sum slurp spurt punycode_encode quote),
-  qw(url_escape url_unescape xml_escape xor_encode);
+  qw(secure_compare sha1_bytes sha1_sum slurp spurt steady_time),
+  qw(punycode_encode quote url_escape url_unescape xml_escape xor_encode);
 
 # camelize
 is camelize('foo_bar_baz'), 'FooBarBaz', 'right camelized result';
@@ -377,6 +377,9 @@ my $dir = tempdir CLEANUP => 1;
 my $file = catfile $dir, 'test.txt';
 spurt "just\nworks!", $file;
 is slurp($file), "just\nworks!", 'successful roundtrip';
+
+# steady_time
+like steady_time, qr/^\d+\.\d+$/, 'high resolution time';
 
 # monkey_patch
 {


### PR DESCRIPTION
It would be really nice if we could make Mojolicious more resilient to time jumps with monotonic clock support. This pull request is not quite ready yet, but should be rather easy to finish once the patch for OS X support has been applied to Time::HiRes.

https://rt.cpan.org/Public/Bug/Display.html?id=78656

The EV reactor already uses a monotonic clock internally (through libev), but there is no public API, which we would need to make timeouts work properly on all layers.
