### PR TITLE
Mojo::Transaction::WebSocket::send forces stringification on object

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@
 3.92  2013-03-18
   - Improved documentation.
   - Improved tests.
+  - Improved WebSocket send method to force stringification on object.
 
 3.91  2013-03-17
   - Improved bad charset handling in Mojo::DOM::HTML.

--- a/lib/Mojo/Transaction/WebSocket.pm
+++ b/lib/Mojo/Transaction/WebSocket.pm
@@ -202,8 +202,8 @@ sub send {
       : [1, 0, 0, 0, BINARY, $frame->{binary}];
   }
 
-  # Text
-  elsif (!ref $frame) { $frame = [1, 0, 0, 0, TEXT, encode('UTF-8', $frame)] }
+  # Text or object (forcing stringification)
+  elsif (ref $frame ne 'ARRAY') { $frame = [1, 0, 0, 0, TEXT, encode('UTF-8', "$frame")] }
 
   $self->once(drain => $cb) if $cb;
   $self->{write} .= $self->build_frame(@$frame);
@@ -568,6 +568,7 @@ Resume C<handshake> transaction.
   $ws = $ws->send({text   => $bytes});
   $ws = $ws->send([$fin, $rsv1, $rsv2, $rsv3, $op, $bytes]);
   $ws = $ws->send($chars);
+  $ws = $ws->send(Mojo::ByteStream->new($chars));
   $ws = $ws->send($chars => sub {...});
 
 Send message or frame non-blocking via WebSocket, the optional drain callback


### PR DESCRIPTION
Allows send to stringify an object. This especially helps for Mojo::ByteStream objects returned by render_partial.
