### PR TITLE
Improved form content generator for GET and HEAD requests

### DIFF
--- a/lib/Mojo/UserAgent/Transactor.pm
+++ b/lib/Mojo/UserAgent/Transactor.pm
@@ -189,7 +189,9 @@ sub _form {
   $headers->content_type('application/x-www-form-urlencoded');
   my $p = Mojo::Parameters->new(map { $_ => $form->{$_} } sort keys %$form);
   $p->charset($options{charset}) if defined $options{charset};
-  $req->body($p->to_string);
+  my $method = uc $req->method;
+  if   ($method eq 'GET' || $method eq 'HEAD') { $req->url->query->merge($p) }
+  else                                         { $req->body($p->to_string) }
   return $tx;
 }
 
@@ -405,7 +407,8 @@ requests, with support for content generators.
 
 While the "multipart/form-data" content type will be automatically used
 instead of "application/x-www-form-urlencoded" when necessary, you can also
-enforce it by setting the header manually.
+enforce it by setting the header manually. GET and HEAD transactions merge 
+form paramters into the url query parameters.
 
 =head2 upgrade
 

--- a/t/mojo/transactor.t
+++ b/t/mojo/transactor.t
@@ -100,13 +100,21 @@ is $tx->req->headers->content_type, 'application/something',
   'right "Content-Type" value';
 is_deeply $tx->req->json, [1, 2], 'right content';
 
-# Simple form
+# Simple form (POST)
 $tx = $t->tx(POST => 'http://kraih.com/foo' => form => {test => 123});
 is $tx->req->url->to_abs, 'http://kraih.com/foo', 'right URL';
 is $tx->req->method, 'POST', 'right method';
 is $tx->req->headers->content_type, 'application/x-www-form-urlencoded',
   'right "Content-Type" value';
 is $tx->req->body, 'test=123', 'right content';
+
+# Simple form (GET)
+$tx = $t->tx(GET => 'http://kraih.com/foo' => form => {test => 123});
+is $tx->req->url->to_abs, 'http://kraih.com/foo?test=123', 'right URL';
+is $tx->req->method, 'GET', 'right method';
+is $tx->req->headers->content_type, 'application/x-www-form-urlencoded',
+  'right "Content-Type" value';
+is $tx->req->body, '', 'right content';
 
 # Simple form with multiple values
 $tx


### PR DESCRIPTION
Having the form generator for GET (and HEAD) requests merge the form parameters into the URL query is much more DWIM.
