### PR TITLE
Typo fix

### DIFF
--- a/lib/Mojolicious/Guides/Rendering.pod
+++ b/lib/Mojolicious/Guides/Rendering.pod
@@ -199,7 +199,7 @@ too.
 Characters can be rendered to bytes with the C<text> stash value, the given
 content will be automatically encoded to bytes.
 
-  $self->render(text => 'Hello Wörld!');
+  $self->render(text => 'Hello World!');
 
 =head2 Rendering data
 


### PR DESCRIPTION
One letter typo fix, in my perldoc this german(?) characters looks bad.
