### PR TITLE
use keys instead of each to workaround bug in perl

### DIFF
--- a/lib/Mojo/Server/Prefork.pm
+++ b/lib/Mojo/Server/Prefork.pm
@@ -110,7 +110,8 @@ sub _manage {
   # Manage workers
   $self->emit('wait')->_heartbeat;
   my $log = $self->app->log;
-  while (my ($pid, $w) = each %{$self->{pool}}) {
+  for my $pid (keys %{$self->{pool}}) {
+    my $w = $self->{pool}{$pid};
 
     # No heartbeat (graceful stop)
     my $interval = $self->heartbeat_interval;


### PR DESCRIPTION
We had a problem with our application running with Mojo::Server::Prefork -- on several occasions it exited with:

```
panic: attempt to copy freed scalar 821be90 to 77e4798 at /usr/share/perl5/Mojo/Server/Prefork.pm line 113.
```

We are using Debian/Squeeze with perl-5.10.1. After investigating a bit I came to conclusion that this is the same problem as reported in https://rt.perl.org/rt3//Public/Bug/Display.html?id=85026 The bug is present in perl-5.10.1 and 5.12.5 and may be demonstrated with the following code:

```
perl -wle '%a=("a".."z"); each %a; delete $a{w}; delete $a{e}; while(my ($x,$y) = each %a) {1}'
panic: attempt to copy freed scalar 843520 to 843820 at -e line 1.
Attempt to free non-existent shared string 'P', Perl interpreter: 0x819010 at -e line 1.
```

This branch workarounds the problem by replacing `each` with the `keys`.
