### PR TITLE
Mojo::URL pod build example.

### DIFF
--- a/lib/Mojo/URL.pm
+++ b/lib/Mojo/URL.pm
@@ -243,7 +243,6 @@ Mojo::URL - Uniform Resource Locator
   $url->host('example.com');
   $url->port(3000);
   $url->path('/foo/bar');
-  $url->path('baz');
   $url->query->param(foo => 'bar');
   $url->fragment(23);
   say "$url";


### PR DESCRIPTION
Removed the extra path() statement in the pod so the build example
matches the parse example.
