### PR TITLE
Add 'enable_app' command to Mojolicious::Commands

### DIFF
--- a/lib/Mojolicious/Commands.pm
+++ b/lib/Mojolicious/Commands.pm
@@ -108,6 +108,13 @@ sub start_app {
   return Mojo::Server->new->build_app(shift)->start(@_);
 }
 
+sub enable_app {
+  my $self = shift;
+  my $app = Mojo::Server->new->build_app(shift);
+  $app->enable_app(@_) if $app->can('enable_app');
+  return $app->start;
+}
+
 sub _command {
   my ($module, $fatal) = @_;
   return $module->isa('Mojolicious::Command') ? $module : undef
@@ -322,6 +329,19 @@ Load application and start the command line interface for it.
 
   # Always start daemon for application and ignore @ARGV
   Mojolicious::Commands->start_app('MyApp', 'daemon', '-l', 'http://*:8080');
+
+=head2 enable_app
+  
+  # in plack app.psgi
+  use Plack::Builder;
+  use Mojolicious::Commands;
+  
+  builder {
+    ...  # your favourite plack middleware components
+    Mojolicious::Commands->enable_app('MyApp', @params);
+  };
+  
+Load application in plack builder and pass @arguments
 
 =head1 SEE ALSO
 


### PR DESCRIPTION
This command makes it easy to embed an mojolicious app in an plack app.psgi and pass `@params` to the mojo app (see pod in diff & example below).

plack app.psgi

```
use Plack::Builder;
use Mojolicious::Commands;

builder {
   ...  # your favourite plack middleware components
   Mojolicious::Commands->enable_app('MyApp', 'World');
};
```

MyApp.pm (Mojolicious)

```
package MyApp;

use Mojo::Base 'Mojolicious';

sub enable_app {
    my ($self,@params) = @_;
    $self->routes->get('/' => sub { shift->render(text => 'Hello ' . $params[0]) } );      
}

1;
```
