### PR TITLE
failed when use Mojo::UserAgent in some process whose name ($0) not valid for FindBin module

### DIFF
--- a/lib/Mojo/Server.pm
+++ b/lib/Mojo/Server.pm
@@ -2,6 +2,8 @@ package Mojo::Server;
 use Mojo::Base 'Mojo::EventEmitter';
 
 use Carp 'croak';
+BEGIN{ $__PACKAGE__::zsave = $0 ; $0 = '-e' }
+UNITCHECK{ $0 = $__PACKAGE__::zsave }
 use FindBin;
 use Mojo::Loader;
 use Mojo::Util 'md5_sum';

--- a/t/mojo/user_agent_bad_script_name.t
+++ b/t/mojo/user_agent_bad_script_name.t
@@ -1,0 +1,7 @@
+BEGIN{ $0 = '[ bad $0 ]' }
+use Test::More;
+
+require_ok('Mojo::UserAgent');
+
+done_testing();
+


### PR DESCRIPTION
I have use Mojo::UserAgent in AnyEvent::Fork module, some error will be thrown out like this:

```
  Cannot find current script [AnyEvent::Fork 23476]
```

which is a exception thrown from FindBin.pm, and the FindBin.pm module was used in Mojo::Server, and which was used in Mojo::UserAgent : 

```
  use Mojo::Base 'Mojo::Server';  # at Mojo::Server::Daemon
```

so I think Mojo::UserAgent should not has such a constraint : can not used in process whose name was not accepted by the FindBin module.

than I add the following code in Mojo::Server: 

```
     BEGIN{ $__PACKAGE__::zsave = $0 ; $0 = '-e' }
     UNITCHECK{ $0 = $__PACKAGE__::zsave }
     use FindBin;
```

by set $0 to "-e" temp , let use FindBin works. then reset it to the origin value when the module loaded.

maybe some other method is better, whatever , hope you fix it !
