### PR TITLE
Made build impervious to temp dir privileges

### DIFF
--- a/t/mojolicious/command.t
+++ b/t/mojolicious/command.t
@@ -18,7 +18,7 @@ my $cwd = cwd;
 my $dir = tempdir CLEANUP => 1;
 chdir $dir;
 $command->create_rel_dir('foo/bar');
-ok -d catdir($dir, qw(foo bar)), 'directory exists';
+ok -d catdir(qw(foo bar)), 'directory exists';
 my $template = "@@ foo_bar\njust <%= 'works' %>!\n";
 open my $data, '<', \$template;
 no strict 'refs';


### PR DESCRIPTION
File::Temp::tempdir will usually create a dir in a global location (eg /tmp), but if the current user lacks privs for that location it will fallback to providing a local dir.  In the latter case a relative path is returned and t/mojolicious/command.t fails.  You could argue that's a fault on the client machine (it is) but Mojolicious shouldn't care and the build needn't fail.  The existing logic at that line of the test is a bit strange, so adopting the change will
- remove some unhelpful bytes from the test file
- make the build not care about strange perms on the global temp dir
- make Fridays slightly sunnier, with a pleasant aroma of warm chestnuts
