### PR TITLE
More documentation of helper content

### DIFF
--- a/lib/Mojolicious/Plugin/DefaultHelpers.pm
+++ b/lib/Mojolicious/Plugin/DefaultHelpers.pm
@@ -135,6 +135,13 @@ Alias for L<Mojo/"config">.
 
 Store partial rendered content in named buffer and retrieve it.
 
+When storing content, if the named buffer has already been set, new content
+is silently ignored.
+
+The default buffer name is content. The first template that returns non-blank
+content sets the default content buffer, if it has not already been set to
+non-blank content.
+
 =head2 content_for
 
   % content_for foo => begin

--- a/t/mojolicious/layouted_lite_app.t
+++ b/t/mojolicious/layouted_lite_app.t
@@ -99,6 +99,8 @@ get '/withblocklayout' => sub {
 
 get '/content_for';
 
+get '/content_first_come';
+
 get '/inline' => {inline => '<%= "inline!" %>'};
 
 get '/inline/again' => {inline => 0};
@@ -219,6 +221,11 @@ $t->get_ok('/withblocklayout')->status_is(200)
 $t->get_ok('/content_for')->status_is(200)
   ->header_is(Server => 'Mojolicious (Perl)')
   ->content_is("DefaultThis\n\nseems\nto\nHello    world!\n\nwork!\n\n");
+
+# Content first come
+$t->get_ok('/content_first_come')->status_is(200)
+  ->header_is(Server => 'Mojolicious (Perl)')
+  ->content_is("DefaultJust worksHelloThis <template> just works!\n\n");
 
 # Inline template
 $t->get_ok('/inline')->status_is(200)
@@ -363,3 +370,11 @@ seems
 to
 <%= content_for 'message' %>
 work!
+
+@@ content_first_come.html.ep
+% title 'Just works';
+<% content message => begin %>Hello<% end =%>
+<% content message => begin %> world!<% end =%>
+<%= content 'message' =%>
+This <template> just works!
+


### PR DESCRIPTION
I am very new to Mojolicious and had a little difficulty understanding what was happening with layout, extends and the content helper. Now I know. In retrospect, I think some additional documentation would have helped me get to this point sooner.

For your consideration, here is some additional documentation of the helper 'content', and an additional test for its 'first come' feature.

Regards,
Ian Goodacre
