### PR TITLE
throw exception on unhandled/failed "error" event

### DIFF
--- a/lib/Mojo/EventEmitter.pm
+++ b/lib/Mojo/EventEmitter.pm
@@ -14,7 +14,7 @@ sub emit {
   }
   else {
     warn "-- Emit $name in @{[blessed($self)]} (0)\n" if DEBUG;
-    warn $_[0] if $name eq 'error';
+    die qq{${\ref $self}: $_[0]} if $name eq 'error';
   }
 
   return $self;
@@ -30,7 +30,7 @@ sub emit_safe {
       unless (eval { $self->$cb(@_); 1 }) {
 
         # Error event failed
-        if ($name eq 'error') { warn qq{Event "error" failed: $@} }
+        if ($name eq 'error') { local $SIG{__DIE__}; die $@ }
 
         # Normal event failed
         else { $self->emit_safe('error', qq{Event "$name" failed: $@}) }
@@ -39,7 +39,7 @@ sub emit_safe {
   }
   else {
     warn "-- Emit $name in @{[blessed($self)]} safely (0)\n" if DEBUG;
-    warn $_[0] if $name eq 'error';
+    die qq{${\ref $self}: $_[0]} if $name eq 'error';
   }
 
   return $self;

--- a/t/mojo/eventemitter.t
+++ b/t/mojo/eventemitter.t
@@ -20,10 +20,11 @@ my $error;
 {
   local *STDERR;
   open STDERR, '>', \$error;
-  $e->emit(error => "just\n");
-  $e->emit_safe(error => "works\n");
+  local $SIG{__DIE__} = sub { warn pop };
+  ok !eval { $e->emit(error => "just\n"); 1 }, 'got exception';
+  ok !eval { $e->emit_safe(error => "works\n"); 1 }, 'got exception';
 }
-is $error, "just\nworks\n", 'right error';
+is $error, "Mojo::EventEmitter: just\nMojo::EventEmitter: works\n", 'right error';
 
 # Error fallback
 my ($echo, $err);


### PR DESCRIPTION
With this patch $EV::DIED will work as usually in EV-based apps. I suppose other event loops also will now handle Mojo exceptions in their usual ways. Plus we can now use reactor->on(error) as catch-all like $EV::DIED.

To restore original behaviour:

``` perl
Mojo::IOLoop->singleton->reactor->on(error => sub { warn pop });
```

I didn't included it in the patch because I'm not sure where it should be added.

I've added class names to error messages to make it easier for user to detect class where unhandled "error" event happens.
