### PR TITLE
Request.pm: use $env->{HTTPS} = 'on' to detect SSL

### DIFF
--- a/lib/Mojo/Message/Request.pm
+++ b/lib/Mojo/Message/Request.pm
@@ -235,7 +235,7 @@ sub _parse_env {
   }
 
   # HTTPS
-  $base->scheme('https') if $env->{HTTPS};
+  $base->scheme('https') if ($env->{HTTPS} // 'off') =~ /^(?:on|1)$/i;
 
   # Path
   my $path = $url->path->parse($env->{PATH_INFO} ? $env->{PATH_INFO} : '');

--- a/t/mojo/request_cgi.t
+++ b/t/mojo/request_cgi.t
@@ -463,4 +463,29 @@ my $file = $req->upload('file');
 is $file->filename, 'file.txt',    'right filename';
 is $file->slurp,    '11023456789', 'right uploaded content';
 
+# Parse IIS 7.5 like CGI environment (HTTPS=off)
+$req = Mojo::Message::Request->new;
+$req->parse(
+  CONTENT_LENGTH => 0,
+  CONTENT_TYPE    => '',
+  PATH_INFO       => '/index.pl/',
+  PATH_TRANSLATED => 'C:\\inetpub\\wwwroot\\test\\www\\index.pl\\',
+  SERVER_SOFTWARE => 'Microsoft-IIS/7.5',
+  QUERY_STRING    => '',
+  REQUEST_METHOD  => 'GET',
+  SCRIPT_NAME     => '/index.pl',
+  HTTP_HOST       => 'test',
+  HTTPS           => 'off',
+  SERVER_PROTOCOL => 'HTTP/1.1'
+);
+ok $req->is_finished, 'request is done';
+is $req->method, 'GET', 'right method';
+ok !$req->is_secure, 'not secure';
+is $req->url->base->protocol, 'http', 'right protocol';
+is $req->url->path, '', 'right URL';
+is $req->url->base->path, '/index.pl/', 'right path';
+is $req->url->base->host, 'test',       'right host';
+ok !$req->url->query->to_string, 'no query';
+is $req->version, '1.1', 'right version';
+
 done_testing();


### PR DESCRIPTION
The standard method to check for https is to check the environment for
$ENV{HTTPS} eq 'on' ('1' is also used for some environments).  Although
most servers simply leave $ENV{HTTPS} empty when not using SSL, IIS, at
least, sets it to 'off', breaking the simple boolean check.

IIS documentation:
http://msdn.microsoft.com/en-us/library/ms524602%28v=vs.90%29.aspx

IBM documents similar behavior:
http://pic.dhe.ibm.com/infocenter/wasinfo/v8r5/topic/com.ibm.websphere.ihs.doc/ihs/rihs_sslhandshakeenvvar.html

Compatible implementations by other frameworks:
http://www.python.org/dev/peps/pep-0333/#the-server-gateway-side
https://metacpan.org/source/MIYAGAWA/Plack-1.0029/lib/Plack/Handler/CGI.pm#L94
https://metacpan.org/source/MARKSTOS/CGI.pm-3.63/lib/CGI.pm#L3332
