### PR TITLE
Fixed typo in Mojolicious::Routes::Route documentation

### DIFF
--- a/lib/Mojolicious/Routes/Route.pm
+++ b/lib/Mojolicious/Routes/Route.pm
@@ -596,4 +596,3 @@ on L<Mojolicious::Routes::Route> objects.
 L<Mojolicious>, L<Mojolicious::Guides>, L<http://mojolicio.us>.
 
 =cut
-/user


### PR DESCRIPTION
Added a missing single quote in the SHORTCUTS-Section of the Mojolicious::Routes::Route documentation.
