### PR TITLE
type=text/css compat for older browsers and modules

### DIFF
--- a/lib/Mojolicious/Plugin/TagHelpers.pm
+++ b/lib/Mojolicious/Plugin/TagHelpers.pm
@@ -191,7 +191,7 @@ sub _stylesheet {
   # "link" or "style" tag
   my $href = @_ % 2 ? $self->url_for(shift) : undef;
   return $href
-    ? _tag('link', rel => 'stylesheet', href => $href, @_)
+    ? _tag('link', rel => 'stylesheet', href => $href, type=>"text/css", @_)
     : _tag('style', @_, $cb);
 }
 

--- a/t/mojolicious/rebased_lite_app.t
+++ b/t/mojolicious/rebased_lite_app.t
@@ -47,7 +47,7 @@ $t->get_ok('/')->status_is(200)->header_is('X-Route' => 'root')
 http://example.com/rebased/
 <script src="/rebased/mojo/jquery/jquery.js"></script>
 <img src="/rebased/images/test.png" />
-<link href="//example.com/base.css" rel="stylesheet" />
+<link href="//example.com/base.css" rel="stylesheet" type="text/css" />
 <a href="mailto:sri@example.com">Contact</a>
 http://example.com/rebased
 http://example.com/rebased/foo
@@ -61,7 +61,7 @@ EOF
 $t->get_ok('/foo')->status_is(200)->header_is('X-Route' => 'foo')
   ->content_is(<<EOF);
 http://example.com/rebased/
-<link href="/rebased/b.css" media="test" rel="stylesheet" />
+<link href="/rebased/b.css" media="test" rel="stylesheet" type="text/css" />
 <img alt="Test" src="/rebased/images/test.png" />
 http://example.com/rebased/foo
 http://example.com/rebased
@@ -81,7 +81,7 @@ ok $t->ua->cookie_jar->find($t->ua->server->url->path('/foo')),
 # Rebased route with message from flash
 $t->get_ok('/foo')->status_is(200)->content_is(<<EOF);
 http://example.com/rebased/works!too!
-<link href="/rebased/b.css" media="test" rel="stylesheet" />
+<link href="/rebased/b.css" media="test" rel="stylesheet" type="text/css" />
 <img alt="Test" src="/rebased/images/test.png" />
 http://example.com/rebased/foo
 http://example.com/rebased
@@ -96,7 +96,7 @@ $t->get_ok('/baz')->status_is(200)->header_is('X-Route' => 'baz')
 http://example.com/rebased/
 <script src="/rebased/mojo/jquery/jquery.js"></script>
 <img src="/rebased/images/test.png" />
-<link href="//example.com/base.css" rel="stylesheet" />
+<link href="//example.com/base.css" rel="stylesheet" type="text/css" />
 <a href="mailto:sri@example.com">Contact</a>
 http://example.com/rebased/baz
 http://example.com/rebased/foo

--- a/t/mojolicious/tag_helper_lite_app.t
+++ b/t/mojolicious/tag_helper_lite_app.t
@@ -134,7 +134,7 @@ EOF
 
 # Stylesheets
 $t->get_ok('/style')->status_is(200)->content_is(<<EOF);
-<link href="/foo.css" rel="stylesheet" />
+<link href="/foo.css" rel="stylesheet" type="text/css" />
 <style>/*<![CDATA[*/
 
   body {color: #000}


### PR DESCRIPTION
add type="text/css" to links - MIME type compatibility for some browsers, perl modules, etc.
