### PR TITLE
Changed Mojo::Util::trim()

### DIFF
--- a/lib/Mojo/Util.pm
+++ b/lib/Mojo/Util.pm
@@ -311,7 +311,9 @@ sub tablify {
 
 sub trim {
   my $str = shift;
-  $str =~ s/^\s+|\s+$//g;
+  return $str unless defined $str;
+  $str =~ s/\A\s+//;
+  $str =~ s/\s+\z//g;
   return $str;
 }
 

--- a/t/mojo/util.t
+++ b/t/mojo/util.t
@@ -310,6 +310,8 @@ is unquote('"foo 23 \"bar"'),     'foo 23 "bar',   'right unquoted result';
 is unquote('"\"foo 23 \"bar\""'), '"foo 23 "bar"', 'right unquoted result';
 
 # trim
+is trim(''), '', 'right trimmed result';
+is trim(undef), undef, 'right trimmed result';
 is trim(' la la  la '),      'la la  la', 'right trimmed result';
 is trim(" \n la la la \n "), 'la la la',  'right trimmed result';
 is trim("\n la\nla la \n"),  "la\nla la", 'right trimmed result';


### PR DESCRIPTION
trim() would not handle undefined values well before.  Granted, users should handle this themselves, but why not?

Also, I broke the ORed regular expression out into two separate expressions.  I didn't go so far as to get into this: http://www.perlmonks.org/?node_id=36684 but I thought handling the undef and splitting the expression into two parts was useful.

I added a test case for an empty string as well as undef.  Nothing really special.
