### PR TITLE
make dom rendering more compatible

### DIFF
--- a/lib/Mojo/DOM/HTML.pm
+++ b/lib/Mojo/DOM/HTML.pm
@@ -234,7 +234,7 @@ sub _render {
     $result .= join ' ', '', @attrs if @attrs;
 
     # Element without end tag
-    return $xml ? "$result />" : $EMPTY{$tag} ? "$result>" : "$result></$tag>"
+    return $EMPTY{$tag} ? $xml ? "$result />" : "$result>" : "$result></$tag>"
       unless $tree->[4];
 
     # Close tag

--- a/t/mojo/dom.t
+++ b/t/mojo/dom.t
@@ -752,6 +752,11 @@ is_deeply \@div, [qw(A B 0)], 'found all div elements with id';
 $dom = Mojo::DOM->new->parse('<hr /><br/><br id="br"/><br />');
 is "$dom", '<hr><br><br id="br"><br>', 'right result';
 is $dom->at('br')->content, '', 'empty result';
+$dom = Mojo::DOM->new->parse('<script></script>');
+ok !$dom->xml, 'XML mode not detected';
+is "$dom", '<script></script>', 'right result';
+$dom->xml(1);
+is "$dom", '<script></script>', 'right result';
 
 # Inner XML
 $dom = Mojo::DOM->new->parse('<a>xxx<x>x</x>xxx</a>');
@@ -1860,7 +1865,8 @@ is $element->parent->type, 'XMLTest', 'right parent';
 ok $element->root->xml, 'XML mode active';
 $dom->replace('<XMLTest2 /><XMLTest3 just="works" />');
 ok $dom->xml, 'XML mode active';
-is $dom, '<XMLTest2 /><XMLTest3 just="works" />', 'right result';
+is $dom, '<XMLTest2></XMLTest2><XMLTest3 just="works"></XMLTest3>',
+  'right result';
 
 # Ensure HTML semantics
 ok !Mojo::DOM->new->xml(undef)->parse('<?xml version="1.0"?>')->xml,


### PR DESCRIPTION
Mojo::DOM::HTML minimizes empty script tag at rendering phase.

my $dom = Mojo::DOM->new('<script src="foo"></script>');
$dom->xml(1);
warn $dom; # <script src="foo" />

The resulted HTML isn't parsed as expected by Firefox and Chrome with content
type text/html.

W3C's compatibility guideline says as follows.

http://www.w3.org/TR/xhtml1/guidelines.html
http://www.w3.org/TR/xhtml1/dtds.html#a_dtd_XHTML-1.0-Strict

> Given an empty instance of an element whose content model is not EMPTY
> (for example, an empty title or paragraph) do not use the minimized form
> (e.g. use <p> </p> and not <p />).

EMPTY tag names are already listed in Mojo::DOM::HTML as %EMPTY 
so it may be better not to minimize none EMPTY tags.
