### PR TITLE
lookup X-Forwarded-Proto for SSL

### DIFF
--- a/lib/Mojo/Message/Request.pm
+++ b/lib/Mojo/Message/Request.pm
@@ -169,9 +169,15 @@ sub parse {
   my $proxy_auth = _parse_basic_auth($headers->proxy_authorization);
   $self->proxy(Mojo::URL->new->userinfo($proxy_auth)) if $proxy_auth;
 
-  # "X-Forwarded-HTTPS"
-  $base->scheme('https')
-    if $self->reverse_proxy && $headers->header('X-Forwarded-HTTPS');
+  if ($self->reverse_proxy) {
+    # "X-Forwarded-HTTPS"
+    $base->scheme('https') if $headers->header('X-Forwarded-HTTPS');
+
+    # "X-Forwarded-Proto"
+    $base->scheme('https')
+        if defined $headers->header('X-Forwarded-Proto')
+        && $headers->header('X-Forwarded-Proto') eq 'https';
+  }
 
   return $self;
 }

--- a/t/mojolicious/lite_app.t
+++ b/t/mojolicious/lite_app.t
@@ -735,6 +735,15 @@ $t->get_ok('/.html')->status_is(200)
     ->content_unlike(qr!-192\.0\.2\.1-0$!);
 }
 
+# Reverse proxy with "X-Forwarded-Proto"
+{
+  local $ENV{MOJO_REVERSE_PROXY} = 1;
+  $t->ua->server->restart;
+  $t->get_ok('/0' => {'X-Forwarded-Proto' => 'https'})->status_is(200)
+    ->content_like(qr!^https://localhost:\d+/0-!)->content_like(qr/-0$/)
+    ->content_unlike(qr!-192\.0\.2\.1-0$!);
+}
+
 # "X-Forwarded-For"
 $t->ua->server->restart;
 $t->get_ok('/0' => {'X-Forwarded-For' => '192.0.2.2, 192.0.2.1'})
@@ -743,6 +752,11 @@ $t->get_ok('/0' => {'X-Forwarded-For' => '192.0.2.2, 192.0.2.1'})
 
 # "X-Forwarded-HTTPS"
 $t->get_ok('/0' => {'X-Forwarded-HTTPS' => 1})->status_is(200)
+  ->content_like(qr!^http://localhost:\d+/0-!)->content_like(qr/-0$/)
+  ->content_unlike(qr!-192\.0\.2\.1-0$!);
+
+# "X-Forwarded-Proto"
+$t->get_ok('/0' => {'X-Forwarded-Proto' => 'https'})->status_is(200)
   ->content_like(qr!^http://localhost:\d+/0-!)->content_like(qr/-0$/)
   ->content_unlike(qr!-192\.0\.2\.1-0$!);
 


### PR DESCRIPTION
Actually, AWS ELB that uses SSL requests with "X-Forwarded-Proto" to behind app servers.
So, set URL base scheme to "https" if request header has "X-Forwarded-Proto: https".

About "X-Forwarded-Proto" on AWS ELB:
http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/TerminologyandKeyConcepts.html
