### PR TITLE
Add Version Badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# Mojolicious [![Build Status](https://travis-ci.org/kraih/mojo.svg?branch=master)](https://travis-ci.org/kraih/mojo)
+# Mojolicious [![CPAN version](https://badge.fury.io/pl/Mojolicious.svg)](http://badge.fury.io/pl/Mojolicious) [![Build Status](https://travis-ci.org/kraih/mojo.svg?branch=master)](https://travis-ci.org/kraih/mojo)
 
   Back in the early days of the web, many people learned Perl because of a
   wonderful Perl library called [CGI](http://metacpan.org/module/CGI). It was


### PR DESCRIPTION
Hello @kraih.  We are making an effort to standardize the way developers discover CPAN distributions from Github repos.  We've had quite a bit of [success and support](http://badge.fury.io/projects) from package authors for other languages, and wanted to contribute to the Perl and CPAN community.

It looks a little different than the Travis CI old PNG badge until they switch to their [new design](http://blog.travis-ci.com/2014-03-20-build-status-badges-support-svg/).
