### PR TITLE
Fix verify param of Mojo::Server::Daemon::listen.

### DIFF
--- a/lib/Mojo/IOLoop/Server.pm
+++ b/lib/Mojo/IOLoop/Server.pm
@@ -98,7 +98,7 @@ sub listen {
     SSL_honor_cipher_order => 1,
     SSL_key_file           => $args->{tls_key} || $KEY,
     SSL_startHandshake     => 0,
-    SSL_verify_mode => $args->{tls_verify} // $args->{tls_ca} ? 0x03 : 0x00
+    SSL_verify_mode => $args->{tls_verify} // ($args->{tls_ca} ? 0x03 : 0x00)
   };
   $tls->{SSL_ca_file} = $args->{tls_ca}
     if $args->{tls_ca} && -T $args->{tls_ca};


### PR DESCRIPTION
An order of operations error was preventing

```
$daemon->listen(['https://*:443?verify=1']);
```

from setting SSL_verify_mode to 0x01.
