### PR TITLE
Do not save format option between renders

### DIFF
--- a/lib/Mojolicious/Renderer.pm
+++ b/lib/Mojolicious/Renderer.pm
@@ -89,7 +89,7 @@ sub render {
   };
   my $inline = $options->{inline} = delete $stash->{inline};
   $options->{handler} //= $self->default_handler if defined $inline;
-  $options->{format} = $stash->{format} || $self->default_format;
+  $options->{format} = delete $stash->{format} || $self->default_format;
 
   # Data
   my $output;


### PR DESCRIPTION
I have a webpage that renders a text chunk to send an email. So I do the following:

my $txt = $self->render(template => 'lookup', format => 'txt', partial => 1);

Then later in my code, I render the actual page:

$self->render(template => 'incident/case_create');

I expect it to use the default format (html). But the format option is still in the stash, so it attempts to render a txt version of that template, which does not exist.

This change makes it so that render will always use either the default format, or the format supplied in the current call to render.

Forgive me if this is no the right way of going about this. This is my first pull request and my first contribution to mojo.
