### PR TITLE
Make Mojo::Asset::File writable to the existed files.

### DIFF
--- a/lib/Mojo/Asset/File.pm
+++ b/lib/Mojo/Asset/File.pm
@@ -3,7 +3,7 @@ use Mojo::Base 'Mojo::Asset';
 
 use Carp 'croak';
 use Errno 'EEXIST';
-use Fcntl qw(O_CREAT O_EXCL O_RDWR);
+use Fcntl qw(O_CREAT O_EXCL O_RDWR O_APPEND);
 use File::Copy 'move';
 use File::Spec::Functions 'catfile';
 use IO::File;
@@ -17,7 +17,7 @@ has handle => sub {
   my $handle = IO::File->new;
   my $path   = $self->path;
   if (defined $path && -f $path) {
-    $handle->open($path, O_APPEND | O_RDWR)
+    $handle->open($path, -w $path ? O_APPEND | O_RDWR : O_RDONLY)
       or croak qq{Can't open file "$path": $!};
     return $handle;
   }

--- a/t/mojo/asset.t
+++ b/t/mojo/asset.t
@@ -3,7 +3,7 @@ use Mojo::Base -strict;
 use Test::More;
 use File::Basename 'dirname';
 use File::Spec::Functions qw(catdir catfile);
-use File::Temp qw/tempfile tempdir/;
+use File::Temp qw(tempfile tempdir);
 use Mojo::Asset::File;
 use Mojo::Asset::Memory;
 
@@ -209,7 +209,7 @@ ok !$asset->is_file, 'stored in memory';
   ok !-e $path, 'file has been cleaned up';
 }
 
-# Custom Existing file
+# Custom existing file
 my ($fh, $tmppath) = tempfile();
 ok -e $tmppath, 'file exists';
 $file = Mojo::Asset::File->new(path => $tmppath);


### PR DESCRIPTION
After debugging for days, I figured it out finally and fixed my code.
This patch is to make the Mojo::Asset::File more flexible, it gives the write permission to the module when handling uploading/downloading files.
