### PR TITLE
Make Mojolicious::Validator supports named routes

### DIFF
--- a/lib/Mojolicious/Controller.pm
+++ b/lib/Mojolicious/Controller.pm
@@ -365,6 +365,8 @@ sub validation {
   my $header = $req->headers->header('X-CSRF-Token');
   my $hash   = $req->params->to_hash;
   $hash->{csrf_token} //= $header if $token && $header;
+  my $captures = $stash->{'mojo.captures'} ||= {};
+  @$hash{grep { !$RESERVED{$_} } keys %$captures} = values %$captures;
   my $validation = $self->app->validator->validation->input($hash);
   return $stash->{'mojo.validation'} = $validation->csrf_token($token);
 }


### PR DESCRIPTION
At the moment, by default Mojolicious::Validator only preload parameters from GET's url or POST's body. When the parameters are from a named route, you have to call $validation->input explicitly for all parameters before the validation.

This commit lets Mojolicious::Validator preload the parameters from named routes as well.
