### PR TITLE
Sort hash keys on JSON encode

### DIFF
--- a/lib/Mojo/JSON.pm
+++ b/lib/Mojo/JSON.pm
@@ -225,7 +225,7 @@ sub _encode_array {
 sub _encode_object {
   my $object = shift;
   my @pairs = map { _encode_string($_) . ':' . _encode_value($object->{$_}) }
-    keys %$object;
+    sort keys %$object;  # Consistent, repeatable output
   return '{' . join(',', @pairs) . '}';
 }
 


### PR DESCRIPTION
Make sure JSON result stays the same for a given hash. This is necessary
for caching.
