### PR TITLE
Fixt custom message in status line

### DIFF
--- a/lib/Mojo/Message/Response.pm
+++ b/lib/Mojo/Message/Response.pm
@@ -131,12 +131,14 @@ sub get_start_line_chunk {
 sub is_empty {
   my $self = shift;
   return undef unless my $code = $self->code;
+  ($code) = split(' ',$code) unless ($code =~ m#^\d+$#);
   return $self->is_status_class(100) || $code == 204 || $code == 304;
 }
 
 sub is_status_class {
   my ($self, $class) = @_;
   return undef unless my $code = $self->code;
+  ($code) = split(' ',$code) unless ($code =~ m#^\d+$#);
   return $code >= $class && $code < ($class + 100);
 }
 


### PR DESCRIPTION
When attempting to use the following code:
return $self->render(json => { error_message => 'Wrong api key!' }, status => '430 Auth ERROR');
An error occurs:
Argument "430 Auth ERROR" isn't numeric in numeric ge (>=) at /usr/share/perl5/site_perl/Mojo/Message/Response.pm line 141.
Argument "430 Auth ERROR" isn't numeric in numeric eq (==) at /usr/share/perl5/site_perl/Mojo/Message/Response.pm line 135.
This patch fixes some warnings.
