### PR TITLE
Mojo::Cache gets stuck in a loop when max_keys is <= 0

### DIFF
--- a/lib/Mojo/Cache.pm
+++ b/lib/Mojo/Cache.pm
@@ -8,6 +8,8 @@ sub get { (shift->{cache} || {})->{shift()} }
 sub set {
   my ($self, $key, $value) = @_;
 
+  return unless $self->max_keys > 0;
+
   my $cache = $self->{cache} ||= {};
   my $queue = $self->{queue} ||= [];
   delete $cache->{shift @$queue} while @$queue >= $self->max_keys;

--- a/t/mojo/cache.t
+++ b/t/mojo/cache.t
@@ -40,4 +40,22 @@ is $cache->get('bar'),  'baz',  'right result';
 is $cache->get('baz'),  'yada', 'right result';
 is $cache->get('yada'), 23,     'right result';
 
+# Zero max_key cache effectively turns caching off
+$cache = Mojo::Cache->new(max_keys => 0);
+is $cache->get('foo'), undef, 'no result';
+$cache->set(foo => 'bar');
+is $cache->get('foo'), undef, 'no result';
+$cache->set(bar => 'baz');
+is $cache->get('foo'), undef, 'no result';
+is $cache->get('bar'), undef, 'no result';
+
+# Negative max_key doesn't make sense, but we shouldn't get stuck in a loop
+$cache = Mojo::Cache->new(max_keys => -1);
+is $cache->get('foo'), undef, 'no result';
+$cache->set(foo => 'bar');
+is $cache->get('foo'), undef, 'no result';
+$cache->set(bar => 'baz');
+is $cache->get('foo'), undef, 'no result';
+is $cache->get('bar'), undef, 'no result';
+
 done_testing();


### PR DESCRIPTION
- Setting max_keys <= 0 currently causes Mojo::Cache to get stuck in a
  loop when set() is called.
- Setting max_keys to 0 is a quick means of turning off caching (ie, if
  we want to recompile the templates every time during testing)
- Setting max_keys < 0 doesn't make much sense, but it we still
  shouldn't get stuck in a loop.
