### PR TITLE
use abs_path to force do() to ignore @INC

### DIFF
--- a/lib/Mojo/Server.pm
+++ b/lib/Mojo/Server.pm
@@ -2,6 +2,7 @@ package Mojo::Server;
 use Mojo::Base 'Mojo::EventEmitter';
 
 use Carp 'croak';
+use Cwd 'abs_path';
 use Mojo::Loader;
 use Mojo::Util 'md5_sum';
 use POSIX;
@@ -40,6 +41,9 @@ sub daemonize {
 
 sub load_app {
   my ($self, $path) = @_;
+
+  # Make sure do() executes the file we expect (and not something from @INC)
+  $path = abs_path $path;
 
   # Clean environment (reset FindBin defensively)
   {


### PR DESCRIPTION
Fixes #683

I've run the tests with `TEST_HYPNOTOAD=1 TEST_MORBO=1` and everything passes here.  The `@INC` side effect isn't documented anywhere that I'm aware of, so I think this change is OK and generally causes things to be more in line with what people expect (as evidenced by #683).

The relevant precedent for this is that `hypnotoad` [already does this](https://github.com/kraih/mojo/blob/d456e685645689058e10692c793e7283cf26e981/lib/Mojo/Server/Hypnotoad.pm#L44).  I didn't want to remove that invocation though, because it seemed reasonable for `HYPNOTOAD_APP` to contain the `abs_path` version of the argument (and running `abs_path` twice and only during initialization seems pretty harmless).

Of course, I'm happy to rebase, amend, force push, modify, replace, etc. :smile:
