### PR TITLE
Chomp messages

### DIFF
--- a/lib/Mojolicious/Command/cpanify.pm
+++ b/lib/Mojolicious/Command/cpanify.pm
@@ -30,6 +30,7 @@ sub run {
   unless ($tx->success) {
     my $code = $tx->res->code // 0;
     my $msg = $tx->error->{message};
+    chomp $msg;
     if    ($code == 401) { $msg = 'Wrong username or password.' }
     elsif ($code == 409) { $msg = 'File already exists on CPAN.' }
     die qq{Problem uploading file "$file". ($msg)\n};


### PR DESCRIPTION
Some server responses will add new lines, like "SSL connect attempt failed error:14077410:SSL routines:SSL23_GET_SERVER_HELLO:sslv3 alert handshake failure", so the closing bracket will be on another line. (Don't know if there is a reasonable way to test that.)
