### PR TITLE
clarify TagHelpers::tag content escaping

### DIFF
--- a/lib/Mojolicious/Plugin/TagHelpers.pm
+++ b/lib/Mojolicious/Plugin/TagHelpers.pm
@@ -690,8 +690,9 @@ Very useful for reuse in more specific tag helpers.
   $c->tag('div', id => 'foo');
   $c->tag(div => sub { 'Content' });
 
-Results are automatically wrapped in L<Mojo::ByteStream> objects to prevent
-accidental double escaping.
+Content will be escaped unless provided as a subroutine reference. Results are
+automatically wrapped in L<Mojo::ByteStream> objects to prevent accidental
+double escaping by the renderer.
 
 =head2 tag_with_error
 


### PR DESCRIPTION
Make it clear that the reference to ByteStream escaping is for the
template renderer rather than the tag helper and that providing
a subroutine is the only way to avoid escaping for the tag helper.
