### PR TITLE
Move $VERSION to Mojo::Base, so it is available for each Mojo's package

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -10,7 +10,7 @@ use ExtUtils::MakeMaker;
 # IO::Socket::IP 0.26 first shipped with Perl 5.19.8
 WriteMakefile(
   NAME         => 'Mojolicious',
-  VERSION_FROM => 'lib/Mojolicious.pm',
+  VERSION_FROM => 'lib/Mojo/Base.pm',
   ABSTRACT     => 'Real-time web framework',
   AUTHOR       => 'Sebastian Riedel <sri@cpan.org>',
   LICENSE      => 'artistic_2',

--- a/lib/Mojo/Base.pm
+++ b/lib/Mojo/Base.pm
@@ -11,6 +11,9 @@ use Carp ();
 # Only Perl 5.14+ requires it on demand
 use IO::Handle ();
 
+our $CODENAME = 'Tiger Face';
+our $VERSION  = '5.69';
+
 # Protect subclasses using AUTOLOAD
 sub DESTROY { }
 

--- a/lib/Mojolicious.pm
+++ b/lib/Mojolicious.pm
@@ -42,8 +42,8 @@ has static    => sub { Mojolicious::Static->new };
 has types     => sub { Mojolicious::Types->new };
 has validator => sub { Mojolicious::Validator->new };
 
-our $CODENAME = 'Tiger Face';
-our $VERSION  = '5.69';
+our $CODENAME = $Mojo::Base::CODENAME;
+our $VERSION  = $Mojo::Base::VERSION;
 
 sub AUTOLOAD {
   my $self = shift;


### PR DESCRIPTION
Could you move $VERSION to Mojo::Base package, please?

This variable is accessible only by Mojolicious package which is unnecessary and problematic by CLI scripts. I noticed that Mojo::Base could be the best option as far as it is required by any Mojo's package.

It would be great if I could write:

``` perl
use Mojo::Base 5.67 -strict;
use Mojo::UserAgent;
my $tx = Mojo::UserAgent->new->get('http://mojolicio.us');
...
```
