### PR TITLE
specify `socktype' option for getaddrinfo() to get predictable result

### DIFF
--- a/lib/Mojo/IOLoop/Client.pm
+++ b/lib/Mojo/IOLoop/Client.pm
@@ -5,7 +5,7 @@ use Errno 'EINPROGRESS';
 use IO::Socket::IP;
 use Mojo::IOLoop;
 use Scalar::Util 'weaken';
-use Socket qw(IPPROTO_TCP TCP_NODELAY);
+use Socket qw(IPPROTO_TCP SOCK_STREAM TCP_NODELAY);
 
 # Non-blocking name resolution requires Net::DNS::Native
 use constant NDN => $ENV{MOJO_NO_NDN}
@@ -48,8 +48,8 @@ sub connect {
     if !NDN || $args->{handle};
 
   # Non-blocking name resolution
-  my $handle = $self->{dns}
-    = $NDN->getaddrinfo($address, _port($args), {protocol => IPPROTO_TCP});
+  my $handle = $self->{dns} = $NDN->getaddrinfo($address, _port($args),
+    {protocol => IPPROTO_TCP, socktype => SOCK_STREAM});
   $reactor->io(
     $handle => sub {
       my $reactor = shift;


### PR DESCRIPTION
Today Adura on #mojo found that Mojolicious can't pass tests when Net::DNS::Native installed on Windows with strawberry perl: http://irclog.perlgeek.de/mojo/2014-12-16#i_9813122
Tracking it down showed that problem starts from ... my favorite IO::Socket::IP
This test script always showed "can't connect in 10 sec"

``` Perl
use strict;
use IO::Socket::IP;
use Socket 'IPPROTO_TCP';
use IO::Select;

my ($err, @res) = Socket::getaddrinfo("www.google.com", 80, {protocol => IPPROTO_TCP});
die $err if $err;

my $ip = IO::Socket::IP->new(Blocking => 0, PeerAddrInfo => \@res) or die $@;
my $sel = IO::Select->new($ip);
$sel->can_write(10) or die "can't connect in 10 sec";

warn "Connected!";
```

Some debug showed that getaddrinfo() on this Windows box always returns resolved address with `socktype' flag equals to 0, but for TCP protocol this flag should be SOCK_STREAM=1.
So changing flags for getaddrinfo to {protocol => IPPROTO_TCP, socktype => SOCK_STREAM} fixes the problem
