### PR TITLE
split_header not needed

### DIFF
--- a/lib/Mojo/Message.pm
+++ b/lib/Mojo/Message.pm
@@ -9,7 +9,7 @@ use Mojo::JSON 'j';
 use Mojo::JSON::Pointer;
 use Mojo::Parameters;
 use Mojo::Upload;
-use Mojo::Util qw(decode split_header);
+use Mojo::Util 'decode';
 
 has content => sub { Mojo::Content::Single->new };
 has default_charset  => 'UTF-8';


### PR DESCRIPTION
There is no need to import "split_header" in Mojo::Message.
