### PR TITLE
Mojo::URL->query: arrayref should append and hashref should merge

### DIFF
--- a/lib/Mojo/URL.pm
+++ b/lib/Mojo/URL.pm
@@ -116,16 +116,16 @@ sub query {
   # Replace with list
   if (@_ > 1) { $q->params([])->parse(@_) }
 
-  # Merge with array
-  elsif (ref $_[0] eq 'ARRAY') {
-    while (my $name = shift @{$_[0]}) {
-      my $value = shift @{$_[0]};
+  # Append array
+  elsif (ref $_[0] eq 'ARRAY') { $q->append(@{$_[0]}) }
+
+  # Merge with hash
+  elsif (ref $_[0] eq 'HASH') {
+    for my $name (keys %{$_[0]}) {
+      my $value = $_[0]->{$name};
       defined $value ? $q->param($name => $value) : $q->remove($name);
     }
   }
-
-  # Append hash
-  elsif (ref $_[0] eq 'HASH') { $q->append(%{$_[0]}) }
 
   # New parameters
   else { $self->{query} = ref $_[0] ? $_[0] : $q->parse($_[0]) }
@@ -411,14 +411,14 @@ Normalized version of L</"scheme">.
 =head2 query
 
   my $query = $url->query;
-  $url      = $url->query([merge => 'with']);
-  $url      = $url->query({append => 'to'});
+  $url      = $url->query({merge => 'with'});
+  $url      = $url->query([append => 'to']);
   $url      = $url->query(replace => 'with');
   $url      = $url->query('a=1&b=2');
   $url      = $url->query(Mojo::Parameters->new);
 
-Query part of this URL, pairs in an array will be merged and pairs in a hash
-appended, defaults to a L<Mojo::Parameters> object.
+Query part of this URL, pairs in an array will be appended and pairs in a hash
+merged, defaults to a L<Mojo::Parameters> object.
 
   # "2"
   Mojo::URL->new('http://example.com?a=1&b=2')->query->param('b');
@@ -430,13 +430,13 @@ appended, defaults to a L<Mojo::Parameters> object.
   Mojo::URL->new('http://example.com?a=1&b=2')->query(a => [2, 3]);
 
   # "http://example.com?a=2&b=2&c=3"
-  Mojo::URL->new('http://example.com?a=1&b=2')->query([a => 2, c => 3]);
+  Mojo::URL->new('http://example.com?a=1&b=2')->query({a => 2, c => 3});
 
   # "http://example.com?b=2"
-  Mojo::URL->new('http://example.com?a=1&b=2')->query([a => undef]);
+  Mojo::URL->new('http://example.com?a=1&b=2')->query({a => undef});
 
   # "http://example.com?a=1&b=2&a=2&c=3"
-  Mojo::URL->new('http://example.com?a=1&b=2')->query({a => 2, c => 3});
+  Mojo::URL->new('http://example.com?a=1&b=2')->query([a => 2, c => 3]);
 
 =head2 to_abs
 

--- a/t/mojo/url.t
+++ b/t/mojo/url.t
@@ -61,21 +61,21 @@ is "$url", 'http://sri:foobar@example.com:8080?_monkey=biz%3B&_monkey=23#23',
   'right format';
 $url->query(monkey => 'foo');
 is "$url", 'http://sri:foobar@example.com:8080?monkey=foo#23', 'right format';
-$url->query([monkey => 'bar']);
+$url->query({monkey => 'bar'});
 is "$url", 'http://sri:foobar@example.com:8080?monkey=bar#23', 'right format';
-$url->query({foo => 'bar'});
+$url->query([foo => 'bar']);
 is "$url", 'http://sri:foobar@example.com:8080?monkey=bar&foo=bar#23',
   'right format';
 $url->query('foo');
 is "$url", 'http://sri:foobar@example.com:8080?foo#23', 'right format';
 $url->query('foo=bar');
 is "$url", 'http://sri:foobar@example.com:8080?foo=bar#23', 'right format';
-$url->query([foo => undef]);
+$url->query({foo => undef});
 is "$url", 'http://sri:foobar@example.com:8080#23', 'right format';
 $url->query([foo => 23, bar => 24, baz => 25]);
 is "$url", 'http://sri:foobar@example.com:8080?foo=23&bar=24&baz=25#23',
   'right format';
-$url->query([foo => 26, bar => undef, baz => undef]);
+$url->query({foo => 26, bar => undef, baz => undef});
 is "$url", 'http://sri:foobar@example.com:8080?foo=26#23', 'right format';
 $url->query(c => 3);
 is "$url", 'http://sri:foobar@example.com:8080?c=3#23', 'right format';

--- a/t/mojolicious/lite_app.t
+++ b/t/mojolicious/lite_app.t
@@ -1157,10 +1157,10 @@ app layout <%= content %><%= app->mode %>
 Not a favicon!
 
 @@ url_with.html.ep
-%== url_with->query([foo => 'bar'])
+%== url_with->query({foo => 'bar'})
 %== url_with('http://mojolicio.us/test')
-%== url_with('/test')->query([foo => undef])
-%== url_with('bartest', test => 23)->query([foo => 'yada'])
+%== url_with('/test')->query({foo => undef})
+%== url_with('bartest', test => 23)->query({foo => 'yada'})
 
 __END__
 This is not a template!


### PR DESCRIPTION
As far as array is an ordered list and hash is unordered list, the meaning of arrayref and hashref as a parameter for Mojo::URL->query should be replaced.

With current sematic it is impossible to append an ordered list of parameters.

Main inconvenience of this change is that it can broke existing applications (see lite_app.t in this patch).
