### PR TITLE
added list names functionality for cookie in Mojolicious::Controller

### DIFF
--- a/lib/Mojolicious/Controller.pm
+++ b/lib/Mojolicious/Controller.pm
@@ -44,6 +44,13 @@ sub cookie {
   # Multiple names
   return map { $self->cookie($_) } @$name if ref $name eq 'ARRAY';
 
+  # List names
+  unless (defined $name) {
+    my %keys = map { $_->name => 1 } @{$self->req->cookies};
+    my @keys = map { $_ } keys %keys;
+    return sort @keys;
+  }
+
   # Response cookie
   if (@_) {
 


### PR DESCRIPTION
Hey, in CGI "cookie" returns a list of all cookies, just like "param" returns a list of parameters. Mojolicious returns parameters, but not cookies. Calling "cookie" without a parameter only raises an error, so I added CGI-like behaviour.
