### PR TITLE
Add "Learning Hypertext Transfer Protocol" to Guides.pod

### DIFF
--- a/lib/Mojolicious/Guides.pod
+++ b/lib/Mojolicious/Guides.pod
@@ -31,6 +31,9 @@ All web development starts with HTML, CSS and JavaScript, to learn the basics
 we recommend the
 L<Mozilla Developer Network|https://developer.mozilla.org/en-US/docs/Web>.
 
+=item Learning Hypertext Transfer Protocol
+http://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol
+
 =back
 
 =head1 TUTORIAL


### PR DESCRIPTION
This pull request is more indented to see if it is can be considered to add the HTTP protocol item for newbies to start with Mojolicious.
I once wanted to learn Mojolicous, but I had a hard time to understand
the example code, I tried again two days ago, still didn't get it,
later, I realized that the problem is that I didn't have a basic
understanding of the HTTP.  I'm a newbie to web development.  I probably
would have started my current little project with Mojolicioius instead
of asking colleagues(who has Perl programming experience but only has some experience in developing web site using PHP ) to develop the web site using PHP if I realized this earlier.
