### PR TITLE
Debug static file actions

### DIFF
--- a/lib/Mojolicious/Static.pm
+++ b/lib/Mojolicious/Static.pm
@@ -39,11 +39,15 @@ sub dispatch {
 }
 
 sub file {
-  my ($self, $rel) = @_;
+  my ($self, $rel, $c) = @_;
 
   # Search all paths
   for my $path (@{$self->paths}) {
-    next unless my $asset = $self->_get_file(catfile $path, split('/', $rel));
+    my $asset;
+    unless( $asset = $self->_get_file(catfile $path, split('/', $rel)) ) {
+      $c->app->log->debug("Did not find $rel in $path") if $c;
+      next;
+    }
     return $asset;
   }
 
@@ -78,7 +82,7 @@ sub is_fresh {
 sub serve {
   my ($self, $c, $rel) = @_;
 
-  return undef unless my $asset = $self->file($rel);
+  return undef unless my $asset = $self->file($rel, $c);
   my $headers = $c->res->headers;
   return !!$self->serve_asset($c, $asset) if $headers->content_type;
 
@@ -215,6 +219,11 @@ doesn't exist. Note that this method does not protect from traversing to
 parent directories.
 
   my $content = $static->file('foo/bar.html')->slurp;
+
+With a controller as the second argument, C<file> can log debugging 
+information.
+
+  my $asset = $static->file('images/logo.png', $c);
 
 =head2 is_fresh
 

--- a/lib/Mojolicious/Static.pm
+++ b/lib/Mojolicious/Static.pm
@@ -48,6 +48,7 @@ sub file {
       $c->app->log->debug("Did not find $rel in $path") if $c;
       next;
     }
+    $c->app->log->debug("Found $rel in $path") if $c;
     return $asset;
   }
 


### PR DESCRIPTION
When I've used static files, I've sometimes forgot to put stuff under public (or whatever directories I added to the paths). I bang my head on this a few times before I remember. Since I commented in Stackoverflow (http://stackoverflow.com/a/28132139/2766176) that I'd like some debugging statements showing where *::Static looks, here's a patch.

This would have solved a couple problems I had in the past:

* Mojo finds a file in a path I didn't intend (and I'm editing the other one!)
* The file is not there at all, but I know it's looking in the right places ( .jpeg versus .jpg was a problem once)

I'm not particularly thrilled with what I actually did. I've always thought it was inconvenient to get at the logger for places I wanted logging but didn't get a controller. I can't override file() because it's all the places that call it that need to include the controller argument.

I don't need this for anything I'm working on, so if a similar fix makes it into the next major version I'd be content.
