### PR TITLE
Prevent possibility of deleting pid file by child

### DIFF
--- a/lib/Mojo/Server/Prefork.pm
+++ b/lib/Mojo/Server/Prefork.pm
@@ -160,7 +160,7 @@ sub _spawn {
     unless open my $handle, '>', $file;
 
   # Change user/group
-  $self->setuidgid->cleanup(0);
+  $self->cleanup(0)->setuidgid;
 
   # Accept mutex
   weaken $self;


### PR DESCRIPTION
Since setuidgid now may croak, we need to set cleanup(0) before calling setuidgid