### PR TITLE
Fix regression - some web frameworks terminate cookies with semicolons

### DIFF
--- a/lib/Mojo/Util.pm
+++ b/lib/Mojo/Util.pm
@@ -405,7 +405,7 @@ sub _header {
     elsif ($str =~ s/^=\s*([^;, ]*)//) { $token[-1] = $1 }
 
     # Separator
-    next unless $str =~ s/^\s*,\s*//;
+    next unless $str =~ s/^[;\s]*,\s*//;
     push @tree, [@token];
     @token = ();
   }

--- a/t/mojo/util.t
+++ b/t/mojo/util.t
@@ -99,6 +99,10 @@ is_deeply split_cookie_header(
   [['a', 'b', 'expires', 'Tuesday, 09-Nov-1999 23:12:40 GMT'], ['c', 'd']],
   'right result';
 is_deeply split_cookie_header(
+  'a=b; expires=Tuesday, 09-Nov-1999 23:12:40 GMT;, c=d;'),
+  [['a', 'b', 'expires', 'Tuesday, 09-Nov-1999 23:12:40 GMT'], ['c', 'd']],
+  'right result';
+is_deeply split_cookie_header(
   'a=b; expires=Sun,06  Nov  1994  08:49:37  UTC; path=/'),
   [['a', 'b', 'expires', 'Sun,06  Nov  1994  08:49:37  UTC', 'path', '/']],
   'right result';


### PR DESCRIPTION
For example, given an HTTP response containing:

Set-Cookie: a=b; expires=Wednesday, 17-Feb-2016 23:59:59 GMT;
Set-Cookie: c=d; expires=Wednesday, 17-Feb-2016 23:59:59 GMT;

Mojo::Message::Response::cookies in 5.77 returns both cookies but 5.79 only returns the first one.