### PR TITLE
Test::Harness enables global warnings by default. Disable this behavior

### DIFF
--- a/lib/Mojolicious/Command/test.pm
+++ b/lib/Mojolicious/Command/test.pm
@@ -20,6 +20,7 @@ sub run {
 
   $ENV{HARNESS_OPTIONS} //= 'c';
   require Test::Harness;
+  $Test::Harness::switches = '';
   Test::Harness::runtests(sort @args);
 }
 


### PR DESCRIPTION
See also [this](https://github.com/Perl-Toolchain-Gang/Test-Harness/commit/18794a8565633ae08f048b9cf6c25b03be6e1020) and [this](https://rt.cpan.org/Public/Bug/Display.html?id=58229) discussions