### PR TITLE
Removed old api usage from document

### DIFF
--- a/lib/Mojo/Parameters.pm
+++ b/lib/Mojo/Parameters.pm
@@ -308,7 +308,6 @@ Parsed parameter pairs. Note that this method will normalize the parameters.
 
 =head2 param
 
-  my @names = $params->param;
   my $value = $params->param('foo');
   $params   = $params->param(foo => 'ba&r');
   $params   = $params->param(foo => qw(ba&r baz));


### PR DESCRIPTION
$params->param() is removed and I sould use $params->names instead. right?
