### PR TITLE
Ignore expression's comment in template.

### DIFF
--- a/lib/Mojo/Template.pm
+++ b/lib/Mojo/Template.pm
@@ -133,17 +133,17 @@ sub parse {
     = qr/^(\s*)\Q$start\E(?:(\Q$replace\E)|(\Q$cmnt\E)|(\Q$expr\E))?(.*)$/;
   my $token_re = qr/
     (
-      \Q$tag\E(?:\Q$replace\E|\Q$cmnt\E)                   # Replace
+      \Q$tag\E(?:\Q$replace\E|\Q$cmnt\E)                         # Replace
     |
-      \Q$tag$expr\E(?:\Q$escp\E)?(?:\s*\Q$cpen\E(?!\w))?   # Expression
+      \Q$tag$expr\E(?:\Q$escp\E)?(?:\s*\Q$cpen\E(?!\w))?         # Expression
     |
-      \Q$tag\E(?:\s*\Q$cpen\E(?!\w))?                      # Code
+      \Q$tag\E(?:\s*\Q$cpen\E(?!\w))?                            # Code
     |
-      (?:(?<!\w)\Q$cpst\E\s*)?(?:\Q$trim\E)?\Q$end\E       # End
+      (?:(?<!\w)\Q$cpst\E\s*)?(?:\#.*?)?(?:\Q$trim\E)?\Q$end\E   # End
     )
   /x;
-  my $cpen_re = qr/^\Q$tag\E(?:\Q$expr\E)?(?:\Q$escp\E)?\s*\Q$cpen\E(.*)$/;
-  my $end_re  = qr/^(?:(\Q$cpst\E)\s*)?(\Q$trim\E)?\Q$end\E$/;
+  my $cpen_re = qr/^\Q$tag\E(?:\Q$expr\E)?(?:\Q$escp\E)?\s*\Q$cpen\E(.*)(?:\#.*?)?$/;
+  my $end_re  = qr/^(?:(\Q$cpst\E)\s*)?(?:\#.*?)?(\Q$trim\E)?\Q$end\E$/;
 
   # Split lines
   my $op = 'text';

--- a/t/mojo/template.t
+++ b/t/mojo/template.t
@@ -85,6 +85,11 @@ $mt     = Mojo::Template->new;
 $output = $mt->render('    <%= "one" =%><%= "two" %>  three');
 is $output, "onetwo  three\n", 'expression tags trimmed';
 
+# Trim expression comments
+$mt     = Mojo::Template->new;
+$output = $mt->render('    <%= "one" # evil =%><%= "two" ## evil ## %>  three');
+is $output, "onetwo  three\n", 'expression comments trimmed';
+
 # Nothing to trim
 $mt     = Mojo::Template->new;
 $output = $mt->render('<% =%>');


### PR DESCRIPTION
We need to write comments with perl expression in template.

e.g.)
```perl
#!/usr/bin/env perl
use Mojolicious::Lite;

my @entries = ();

get '/' => sub {
    my $c = shift;
    $c->stash(entries => \@entries);
    $c->render(template => 'index');
};

post '/post' => sub {
    my $c = shift;
    my $entry = $c->param('body');
    push @entries => $entry;
    $c->stash(body => $entry);
    $c->redirect_to('/');
};

app->start;
__DATA__

@@ index.html.ep
% layout 'default';
% title 'note';
%= form_for '/post' => method => 'POST' => begin # comment...
  %= text_field 'body'
  %= submit_button 'POST'
% end

@@ layouts/default.html.ep
<!DOCTYPE html>
<html>
  <head><title><%= title %></title></head>
  <body><%= content %></body>
</html>
```

But, This application is failure.
And, I got error:
```
syntax error at template index.html.ep from DATA section line 6, near "} $_O "
Global symbol "$_O" requires explicit package name at template index.html.ep from DATA section line 6, <DATA> line 36.
Unmatched right curly bracket at template index.html.ep from DATA section line 6, at end of line
```

I fixed it.