### PR TITLE
POD: no custom socket support here either.

### DIFF
--- a/lib/Mojo/Transaction/WebSocket.pm
+++ b/lib/Mojo/Transaction/WebSocket.pm
@@ -566,7 +566,7 @@ Write data client-side, used to implement user agents.
 
   my $connection = $ws->connection;
 
-Connection identifier or socket.
+Connection identifier.
 
 =head2 finish
 


### PR DESCRIPTION
Mojo::Transaction (and child classes) lost support for custom sockets in 1712764315fbee14c9a1d03de48833ed064191a5.