### PR TITLE
Removed warning when using undef values in tablify

### DIFF
--- a/lib/Mojo/Util.pm
+++ b/lib/Mojo/Util.pm
@@ -276,6 +276,7 @@ sub tablify {
   my @spec;
   for my $row (@$rows) {
     for my $i (0 .. $#$row) {
+      $row->[$i] //= '';
       $row->[$i] =~ s/[\r\n]//g;
       my $len = length $row->[$i];
       $spec[$i] = $len if $len >= ($spec[$i] // 0);

--- a/t/mojo/util.t
+++ b/t/mojo/util.t
@@ -464,6 +464,8 @@ is tablify([["  foo",        '  b a r']]), "  foo    b a r\n", 'right result';
 is tablify([['foo']]), "foo\n", 'right result';
 is tablify([['foo', 'yada'], ['yada', 'yada']]), "foo   yada\nyada  yada\n",
   'right result';
+is tablify([[undef, 'yada'], ['yada', undef]]), "      yada\nyada  \n",
+  'right result';
 is tablify([['foo', 'bar', 'baz'], ['yada', 'yada', 'yada']]),
   "foo   bar   baz\nyada  yada  yada\n", 'right result';
 is tablify([['a', '', 'b'], ['c', '', 'd']]), "a    b\nc    d\n",


### PR DESCRIPTION
Usefull with Mojo::Pg::Results::text and null values.