### PR TITLE
fix POD links to Mojo::Cookie::* classes

### DIFF
--- a/lib/Mojo/Cookie.pm
+++ b/lib/Mojo/Cookie.pm
@@ -28,8 +28,8 @@ Mojo::Cookie - HTTP cookie base class
 =head1 DESCRIPTION
 
 L<Mojo::Cookie> is an abstract base class for HTTP cookie containers based on
-L<RFC 6265|http://tools.ietf.org/html/rfc6265>, like
-L<Mojolicious::Cookie::Request> and L<Mojolicious::Cookie::Response>.
+L<RFC 6265|http://tools.ietf.org/html/rfc6265>, like L<Mojo::Cookie::Request>
+and L<Mojo::Cookie::Response>.
 
 =head1 ATTRIBUTES
 


### PR DESCRIPTION
Self-explanatory - broken links in POD to non-existent classes.

thanks,
Michael