### PR TITLE
use true/false functions instead of variables to allow monkey-patched Mojo::JSON

### DIFF
--- a/lib/Mojo/JSON.pm
+++ b/lib/Mojo/JSON.pm
@@ -198,10 +198,10 @@ sub _decode_value {
     if /\G([-]?(?:0|[1-9][0-9]*)(?:\.[0-9]*)?(?:[eE][+-]?[0-9]+)?)/gc;
 
   # True
-  return $TRUE if /\Gtrue/gc;
+  return true() if /\Gtrue/gc;
 
   # False
-  return $FALSE if /\Gfalse/gc;
+  return false() if /\Gfalse/gc;
 
   # Null
   return undef if /\Gnull/gc;


### PR DESCRIPTION
Fixes _decode_value() to use the true and false functions in case they have been monkey patched to return different boolean objects, e.g. by Mojo::JSON::MaybeXS.