### PR TITLE
Prevent "Subroutine redefined" warnings

### DIFF
--- a/lib/Mojo/ByteStream.pm
+++ b/lib/Mojo/ByteStream.pm
@@ -3,7 +3,7 @@ use Mojo::Base -strict;
 use overload bool => sub {1}, '""' => sub { ${$_[0]} }, fallback => 1;
 
 use Exporter 'import';
-use Mojo::Collection;
+require Mojo::Collection;
 use Mojo::Util;
 
 our @EXPORT_OK = ('b');

--- a/lib/Mojo/Collection.pm
+++ b/lib/Mojo/Collection.pm
@@ -4,7 +4,7 @@ use Mojo::Base -strict;
 use Carp 'croak';
 use Exporter 'import';
 use List::Util;
-use Mojo::ByteStream;
+require Mojo::ByteStream;
 use Scalar::Util 'blessed';
 
 our @EXPORT_OK = ('c');

--- a/lib/Mojo/IOLoop.pm
+++ b/lib/Mojo/IOLoop.pm
@@ -4,10 +4,10 @@ use Mojo::Base 'Mojo::EventEmitter';
 # "Professor: Amy, technology isn't intrinsically good or evil. It's how it's
 #             used. Like the death ray."
 use Carp 'croak';
-use Mojo::IOLoop::Client;
-use Mojo::IOLoop::Delay;
-use Mojo::IOLoop::Server;
-use Mojo::IOLoop::Stream;
+require Mojo::IOLoop::Client;
+require Mojo::IOLoop::Delay;
+require Mojo::IOLoop::Server;
+require Mojo::IOLoop::Stream;
 use Mojo::Reactor::Poll;
 use Mojo::Util qw(md5_sum steady_time);
 use Scalar::Util qw(blessed weaken);

--- a/lib/Mojo/IOLoop/Client.pm
+++ b/lib/Mojo/IOLoop/Client.pm
@@ -3,7 +3,7 @@ use Mojo::Base 'Mojo::EventEmitter';
 
 use Errno 'EINPROGRESS';
 use IO::Socket::IP;
-use Mojo::IOLoop;
+require Mojo::IOLoop;
 use Scalar::Util 'weaken';
 use Socket qw(IPPROTO_TCP SOCK_STREAM TCP_NODELAY);
 

--- a/lib/Mojo/IOLoop/Delay.pm
+++ b/lib/Mojo/IOLoop/Delay.pm
@@ -1,7 +1,7 @@
 package Mojo::IOLoop::Delay;
 use Mojo::Base 'Mojo::EventEmitter';
 
-use Mojo::IOLoop;
+require Mojo::IOLoop;
 use Mojo::Util;
 
 has ioloop    => sub { Mojo::IOLoop->singleton };

--- a/lib/Mojo/IOLoop/Server.pm
+++ b/lib/Mojo/IOLoop/Server.pm
@@ -5,7 +5,7 @@ use Carp 'croak';
 use File::Basename 'dirname';
 use File::Spec::Functions 'catfile';
 use IO::Socket::IP;
-use Mojo::IOLoop;
+require Mojo::IOLoop;
 use Scalar::Util 'weaken';
 use Socket qw(IPPROTO_TCP TCP_NODELAY);
 

--- a/lib/Mojo/IOLoop/Stream.pm
+++ b/lib/Mojo/IOLoop/Stream.pm
@@ -2,7 +2,7 @@ package Mojo::IOLoop::Stream;
 use Mojo::Base 'Mojo::EventEmitter';
 
 use Errno qw(EAGAIN ECONNRESET EINTR EWOULDBLOCK);
-use Mojo::IOLoop;
+require Mojo::IOLoop;
 use Mojo::Util;
 use Scalar::Util 'weaken';
 

--- a/lib/Mojo/Transaction/HTTP.pm
+++ b/lib/Mojo/Transaction/HTTP.pm
@@ -1,7 +1,7 @@
 package Mojo::Transaction::HTTP;
 use Mojo::Base 'Mojo::Transaction';
 
-use Mojo::Transaction::WebSocket;
+require Mojo::Transaction::WebSocket;
 
 has 'previous';
 

--- a/lib/Mojo/Transaction/WebSocket.pm
+++ b/lib/Mojo/Transaction/WebSocket.pm
@@ -4,7 +4,7 @@ use Mojo::Base 'Mojo::Transaction';
 use Compress::Raw::Zlib 'Z_SYNC_FLUSH';
 use Config;
 use Mojo::JSON qw(encode_json j);
-use Mojo::Transaction::HTTP;
+require Mojo::Transaction::HTTP;
 use Mojo::Util qw(b64_encode decode dumper encode sha1_bytes xor_encode);
 
 use constant DEBUG => $ENV{MOJO_WEBSOCKET_DEBUG} || 0;


### PR DESCRIPTION
```
$ find lib -name '*.pm' | xargs -n1 perl -Ilib -c
lib/Mojo/Reactor/Poll.pm syntax OK
Subroutine acceptor redefined at lib/Mojo/IOLoop.pm line 32.
Subroutine client redefined at lib/Mojo/IOLoop.pm line 49.
Subroutine delay redefined at lib/Mojo/IOLoop.pm line 71.
```

Mojo shows more than 100 warnings about redefined subroutines. It makes more difficult to develop Mojo in IDE like Padre or Eclipse+EPIC.