### PR TITLE
Loading of the controller class

### DIFF
--- a/lib/Mojolicious.pm
+++ b/lib/Mojolicious.pm
@@ -4,6 +4,7 @@ use Mojo::Base 'Mojo';
 # "Fry: Shut up and take my money!"
 use Carp ();
 use Mojo::Exception;
+use Mojo::Loader qw(load_class);
 use Mojo::Util;
 use Mojolicious::Commands;
 use Mojolicious::Controller;
@@ -68,10 +69,12 @@ sub build_controller {
   $stash->{'mojo.secrets'} //= $self->secrets;
 
   # Build default controller
+  my $class = $self->controller_class;
+  my $e = load_class($class);
+  die ref $e ? $e : qq{Can't find controller class "$class" in \@INC. (@INC)\n} if $e;
   my $defaults = $self->defaults;
   @$stash{keys %$defaults} = values %$defaults;
-  my $c
-    = $self->controller_class->new(app => $self, stash => $stash, tx => $tx);
+  my $c = $class->new(app => $self, stash => $stash, tx => $tx);
   Scalar::Util::weaken $c->{app};
 
   return $c;

--- a/t/mojolicious/controller_class.t
+++ b/t/mojolicious/controller_class.t
@@ -1,0 +1,22 @@
+#!/usr/bin/env perl
+
+use Mojo::Base -strict;
+
+use FindBin;
+use lib "$FindBin::Bin/lib";
+
+use Test::Mojo;
+use Test::More;
+
+my $app = Test::Mojo->new('Mojolicious::Lite')->app;
+ok $app->build_controller;
+
+$app->controller_class('MojoliciousTest::Foo');
+ok $app->build_controller;
+
+$app->controller_class('MojoliciousTest::NonExistent');
+ok !eval { $app->build_controller };
+ok $@;
+like $@, qr/Can't find controller class "MojoliciousTest::NonExistent"/;
+
+done_testing();

--- a/t/mojolicious/controller_class.t
+++ b/t/mojolicious/controller_class.t
@@ -1,5 +1,3 @@
-#!/usr/bin/env perl
-
 use Mojo::Base -strict;
 
 use FindBin;


### PR DESCRIPTION
If default value of `$app->controller_class` has been changed then the error raises on the controller building: `Can't locate object method "new" via package "TestApp::Controller" (perhaps you forgot to load "TestApp::Controller"?)`. So, if we change `controller_class` to `TestApp::Controller` then we must add `use TestApp::Controller;` to the app package.

This patch brings the app to load the controller class before the app instantiate it. The test fails on current code.
