### PR TITLE
pod_to_html helper now will remove spaces at the start of the line for code blocks

### DIFF
--- a/t/mojolicious/pod_renderer_lite_app.t
+++ b/t/mojolicious/pod_renderer_lite_app.t
@@ -39,6 +39,7 @@ $t->post_ok('/')->status_is(200)->content_like(qr!test123<h1 id="A">A</h1>!)
 # POD filter
 $t->post_ok('/block')->status_is(200)
   ->content_like(qr!test321<h2 id="lalala">lalala</h2>!)
+  ->content_like(qr!<pre><code>foo\(bar, bazz\)</code></pre>!)
   ->content_like(qr!<p><code>test</code></p>!)->content_like(qr/Gray/);
 
 # Empty
@@ -99,5 +100,7 @@ test123<%= pod_to_html "=head1 A\n\n=head1 B\n\nC<test>"%>
 
 @@ block.html.ep
 test321<%= pod_to_html begin %>=head2 lalala
+
+  foo(bar, bazz)
 
 C<test><% end %>


### PR DESCRIPTION
For now Mojolicious removes this spaces only when it renders /perldoc. Will be good if `pod_to_html` helper will also remove this useless whitespaces.

See also https://rt.cpan.org/Public/Bug/Display.html?id=103389