### PR TITLE
Fix IE bug with decoding json response without encoding.

### DIFF
--- a/lib/Mojolicious/Types.pm
+++ b/lib/Mojolicious/Types.pm
@@ -15,7 +15,7 @@ has mapping => sub {
     jpeg     => ['image/jpeg'],
     jpg      => ['image/jpeg'],
     js       => ['application/javascript'],
-    json     => ['application/json'],
+    json     => ['application/json;charset=UTF-8'],
     mp3      => ['audio/mpeg'],
     mp4      => ['video/mp4'],
     ogg      => ['audio/ogg'],


### PR DESCRIPTION
IE 7,8,9 has bug with decoding of json response without encoding.
See http://stackoverflow.com/questions/8481453/jquery-ajax-request-doesnt-success-with-json-on-ie

The default encoding of application/json is UTF-8.
http://www.ietf.org/rfc/rfc4627.txt

That means, we can specify encoding in response without any trouble.