### PR TITLE
Fix IE bug with decoding json response without encoding.

### DIFF
--- a/lib/Mojolicious/Types.pm
+++ b/lib/Mojolicious/Types.pm
@@ -15,7 +15,7 @@ has mapping => sub {
     jpeg     => ['image/jpeg'],
     jpg      => ['image/jpeg'],
     js       => ['application/javascript'],
-    json     => ['application/json'],
+    json     => ['application/json;charset=UTF-8'],
     mp3      => ['audio/mpeg'],
     mp4      => ['video/mp4'],
     ogg      => ['audio/ogg'],

--- a/lib/Mojolicious/Types.pm
+++ b/lib/Mojolicious/Types.pm
@@ -92,7 +92,7 @@ L<Mojolicious::Types> manages MIME types for L<Mojolicious>.
   jpeg     -> image/jpeg
   jpg      -> image/jpeg
   js       -> application/javascript
-  json     -> application/json
+  json     -> application/json;charset=UTF-8
   mp3      -> audio/mpeg
   mp4      -> video/mp4
   ogg      -> audio/ogg

--- a/t/mojo/cgi.t
+++ b/t/mojo/cgi.t
@@ -157,7 +157,7 @@ $msg = '';
 $res = Mojo::Message::Response->new->parse("HTTP/1.1 200 OK\x0d\x0a$msg");
 is $res->code, 200, 'right status';
 is $res->headers->status, '200 OK', 'right "Status" value';
-is $res->headers->content_type, 'application/json',
+is $res->headers->content_type, 'application/json;charset=UTF-8',
   'right "Content-Type" value';
 is $res->headers->content_length, 27, 'right "Content-Length" value';
 is $res->json->{lalala}, 23,    'right value';

--- a/t/mojo/psgi.t
+++ b/t/mojo/psgi.t
@@ -68,7 +68,8 @@ my %headers = @{$res->[1]};
 ok keys(%headers) >= 3, 'enough headers';
 ok $headers{Date}, 'has "Date" value';
 is $headers{'Content-Length'}, 43, 'right "Content-Length" value';
-is $headers{'Content-Type'}, 'application/json', 'right "Content-Type" value';
+is $headers{'Content-Type'}, 'application/json;charset=UTF-8',
+  'right "Content-Type" value';
 my $params = '';
 while (defined(my $chunk = $res->[2]->getline)) { $params .= $chunk }
 is $ENV{MOJO_HELLO}, undef, 'finish event has not been emitted';
@@ -104,7 +105,8 @@ is $res->[0], 200, 'right status';
 ok keys(%headers) >= 3, 'enough headers';
 ok $headers{Date}, 'has "Date" value';
 is $headers{'Content-Length'}, 43, 'right "Content-Length" value';
-is $headers{'Content-Type'}, 'application/json', 'right "Content-Type" value';
+is $headers{'Content-Type'}, 'application/json;charset=UTF-8',
+  'right "Content-Type" value';
 $params = '';
 while (defined(my $chunk = $res->[2]->getline)) { $params .= $chunk }
 is $ENV{MOJO_HELLO}, undef, 'finish event has not been emitted';

--- a/t/mojolicious/charset_lite_app.t
+++ b/t/mojolicious/charset_lite_app.t
@@ -90,12 +90,14 @@ $t->get_ok("/.$yatta")->status_is(404);
 $t->post_ok('/data', $yatta_sjis)->status_is(200)->content_is($yatta_sjis);
 
 # JSON data
-$t->get_ok('/json')->status_is(200)->content_type_is('application/json')
+$t->get_ok('/json')->status_is(200)
+  ->content_type_is('application/json;charset=UTF-8')
   ->json_is({test => $yatta});
 
 # IRI
 $t->get_ok('/привет/мир')->status_is(200)
-  ->content_type_is('application/json')->json_is({foo => $yatta});
+  ->content_type_is('application/json;charset=UTF-8')
+  ->json_is({foo => $yatta});
 
 # Shift_JIS parameters
 my $url

--- a/t/mojolicious/group_lite_app.t
+++ b/t/mojolicious/group_lite_app.t
@@ -430,7 +430,8 @@ $t->get_ok('/some_formats.txt')->status_is(200)
 
 # Format "json" has been detected
 $t->get_ok('/some_formats.json')->status_is(200)
-  ->content_type_is('application/json')->content_is('Some format detection.');
+  ->content_type_is('application/json;charset=UTF-8')
+  ->content_is('Some format detection.');
 
 # Invalid format
 $t->get_ok('/some_formats.xml')->status_is(404)

--- a/t/mojolicious/lite_app.t
+++ b/t/mojolicious/lite_app.t
@@ -878,7 +878,8 @@ $t->post_ok('/malformed_utf8' =>
 
 # JSON (with a lot of different tests)
 $t->get_ok('/json')->status_is(200)->header_is(Server => 'Mojolicious (Perl)')
-  ->content_type_is('application/json')->json_is({foo => [1, -2, 3, 'b☃r']})
+  ->content_type_is('application/json;charset=UTF-8')
+  ->json_is({foo => [1, -2, 3, 'b☃r']})
   ->json_is('/foo' => [1, -2, 3, 'b☃r'])
   ->json_is('/foo/3', 'b☃r', 'with description')->json_has('/foo')
   ->json_has('/foo', 'with description')->json_hasnt('/bar')
@@ -890,7 +891,8 @@ $t->get_ok('/json')->status_is(200)->header_is(Server => 'Mojolicious (Perl)')
 # JSON ("null")
 $t->get_ok('/json' => json => undef)->status_is(200)
   ->header_is(Server => 'Mojolicious (Perl)')
-  ->content_type_is('application/json')->json_is(undef)->content_is('null');
+  ->content_type_is('application/json;charset=UTF-8')->json_is(undef)
+  ->content_is('null');
 
 # Stash values in template
 $t->get_ok('/autostash?bar=23')->status_is(200)

--- a/t/mojolicious/restful_lite_app.t
+++ b/t/mojolicious/restful_lite_app.t
@@ -51,19 +51,21 @@ $t->post_ok('/json/echo' => json => {hello => 'world'})->status_is(204)
 # Hash with "json" format
 $t->post_ok(
   '/json/echo' => {Accept => 'application/json'} => json => {hello => 'world'})
-  ->status_is(200)->content_type_is('application/json')
+  ->status_is(200)->content_type_is('application/json;charset=UTF-8')
   ->json_is({hello => 'world'});
 my $tx
   = $t->ua->build_tx(
   PUT => '/json/echo' => {Accept => 'application/json'} => json =>
     {hello => 'world'});
-$t->request_ok($tx)->status_is(200)->content_type_is('application/json')
+$t->request_ok($tx)->status_is(200)
+  ->content_type_is('application/json;charset=UTF-8')
   ->json_is({hello => 'world'});
 
 # Array with "json" format
 $tx = $t->ua->build_tx(
   PUT => '/json/echo' => {Accept => 'application/json'} => json => [1, 2, 3]);
-$t->request_ok($tx)->status_is(200)->content_type_is('application/json')
+$t->request_ok($tx)->status_is(200)
+  ->content_type_is('application/json;charset=UTF-8')
   ->json_is([1, 2, 3]);
 
 # Nothing
@@ -158,45 +160,53 @@ $t->get_ok('/rest.html?format=html' => {Accept => 'text/html'})
   ->text_is('html > body', 'works');
 
 # "json" format
-$t->get_ok('/rest.json')->status_is(200)->content_type_is('application/json')
+$t->get_ok('/rest.json')->status_is(200)
+  ->content_type_is('application/json;charset=UTF-8')
   ->json_is({just => 'works'});
 
 # Accept "json"
 $t->get_ok('/rest' => {Accept => 'application/json'})->status_is(200)
-  ->content_type_is('application/json')->json_is({just => 'works'});
+  ->content_type_is('application/json;charset=UTF-8')
+  ->json_is({just => 'works'});
 
 # Accept "json" again
 $t->get_ok('/rest' => {Accept => 'APPLICATION/JSON'})->status_is(200)
-  ->content_type_is('application/json')->json_is({just => 'works'});
+  ->content_type_is('application/json;charset=UTF-8')
+  ->json_is({just => 'works'});
 
 # Accept "json" with format
 $t->get_ok('/rest.json' => {Accept => 'application/json'})->status_is(200)
-  ->content_type_is('application/json')->json_is({just => 'works'});
+  ->content_type_is('application/json;charset=UTF-8')
+  ->json_is({just => 'works'});
 
 # Accept "json" with wrong format
 $t->get_ok('/rest.png' => {Accept => 'application/json'})->status_is(200)
-  ->content_type_is('application/json')->json_is({just => 'works'});
+  ->content_type_is('application/json;charset=UTF-8')
+  ->json_is({just => 'works'});
 
 # Accept "json" with quality
 $t->get_ok('/rest' => {Accept => 'application/json;q=9'})->status_is(200)
-  ->content_type_is('application/json')->json_is({just => 'works'});
+  ->content_type_is('application/json;charset=UTF-8')
+  ->json_is({just => 'works'});
 
 # "json" query
 $t->get_ok('/rest?format=json')->status_is(200)
-  ->content_type_is('application/json')->json_is({just => 'works'});
+  ->content_type_is('application/json;charset=UTF-8')
+  ->json_is({just => 'works'});
 
 # "json" format with query
 $t->get_ok('/rest.json?format=json')->status_is(200)
-  ->content_type_is('application/json')->json_is({just => 'works'});
+  ->content_type_is('application/json;charset=UTF-8')
+  ->json_is({just => 'works'});
 
 # Accept "json" with query
 $t->get_ok('/rest?format=json' => {Accept => 'application/json'})
-  ->status_is(200)->content_type_is('application/json')
+  ->status_is(200)->content_type_is('application/json;charset=UTF-8')
   ->json_is({just => 'works'});
 
 # Accept "json" with everything
 $t->get_ok('/rest.json?format=json' => {Accept => 'application/json'})
-  ->status_is(200)->content_type_is('application/json')
+  ->status_is(200)->content_type_is('application/json;charset=UTF-8')
   ->json_is({just => 'works'});
 
 # "xml" format
@@ -321,65 +331,75 @@ $t->post_ok(
   ->text_is('html > body', 'works too');
 
 # "json" format
-$t->post_ok('/rest.json')->status_is(200)->content_type_is('application/json')
+$t->post_ok('/rest.json')->status_is(200)
+  ->content_type_is('application/json;charset=UTF-8')
   ->json_is({just => 'works too'});
 
 # Accept "json"
 $t->post_ok('/rest' => {Accept => 'application/json'})->status_is(200)
-  ->content_type_is('application/json')->json_is({just => 'works too'});
+  ->content_type_is('application/json;charset=UTF-8')
+  ->json_is({just => 'works too'});
 
 # Accept "json" again
 $t->post_ok('/rest' => {Accept => 'APPLICATION/JSON'})->status_is(200)
-  ->content_type_is('application/json')->json_is({just => 'works too'});
+  ->content_type_is('application/json;charset=UTF-8')
+  ->json_is({just => 'works too'});
 
 # Accept "json" with format
 $t->post_ok('/rest.json' => {Accept => 'application/json'})->status_is(200)
-  ->content_type_is('application/json')->json_is({just => 'works too'});
+  ->content_type_is('application/json;charset=UTF-8')
+  ->json_is({just => 'works too'});
 
 # Accept "json" with wrong format
 $t->post_ok('/rest.png' => {Accept => 'application/json'})->status_is(200)
-  ->content_type_is('application/json')->json_is({just => 'works too'});
+  ->content_type_is('application/json;charset=UTF-8')
+  ->json_is({just => 'works too'});
 
 # Accept "json" with quality
 $t->post_ok('/rest' => {Accept => 'application/json;q=9'})->status_is(200)
-  ->content_type_is('application/json')->json_is({just => 'works too'});
+  ->content_type_is('application/json;charset=UTF-8')
+  ->json_is({just => 'works too'});
 
 # "json" query
 $t->post_ok('/rest?format=json')->status_is(200)
-  ->content_type_is('application/json')->json_is({just => 'works too'});
+  ->content_type_is('application/json;charset=UTF-8')
+  ->json_is({just => 'works too'});
 
 # "json" format with query
 $t->post_ok('/rest.json?format=json')->status_is(200)
-  ->content_type_is('application/json')->json_is({just => 'works too'});
+  ->content_type_is('application/json;charset=UTF-8')
+  ->json_is({just => 'works too'});
 
 # Accept "json" with query
 $t->post_ok('/rest?format=json' => {Accept => 'application/json'})
-  ->status_is(200)->content_type_is('application/json')
+  ->status_is(200)->content_type_is('application/json;charset=UTF-8')
   ->json_is({just => 'works too'});
 
 # Accept "json" with everything
 $t->post_ok('/rest.json?format=json' => {Accept => 'application/json'})
-  ->status_is(200)->content_type_is('application/json')
+  ->status_is(200)->content_type_is('application/json;charset=UTF-8')
   ->json_is({just => 'works too'});
 
 # "json" form
 $t->post_ok('/rest' => form => {format => 'json'})->status_is(200)
-  ->content_type_is('application/json')->json_is({just => 'works too'});
+  ->content_type_is('application/json;charset=UTF-8')
+  ->json_is({just => 'works too'});
 
 # "json" format with form
 $t->post_ok('/rest.json' => form => {format => 'json'})->status_is(200)
-  ->content_type_is('application/json')->json_is({just => 'works too'});
+  ->content_type_is('application/json;charset=UTF-8')
+  ->json_is({just => 'works too'});
 
 # Accept "json" with form
 $t->post_ok(
   '/rest' => {Accept => 'application/json'} => form => {format => 'json'})
-  ->status_is(200)->content_type_is('application/json')
+  ->status_is(200)->content_type_is('application/json;charset=UTF-8')
   ->json_is({just => 'works too'});
 
 # Accept "json" with everything, form alternative
 $t->post_ok(
   '/rest.json' => {Accept => 'application/json'} => form => {format => 'json'})
-  ->status_is(200)->content_type_is('application/json')
+  ->status_is(200)->content_type_is('application/json;charset=UTF-8')
   ->json_is({just => 'works too'});
 
 # "xml" format
@@ -500,7 +520,7 @@ $t->get_ok('/rest?format=html' => {Accept => $chrome})->status_is(200)
 my $jquery = 'application/json, text/javascript, */*; q=0.01';
 $t->get_ok(
   '/rest' => {Accept => $jquery, 'X-Requested-With' => 'XMLHttpRequest'})
-  ->status_is(200)->content_type_is('application/json')
+  ->status_is(200)->content_type_is('application/json;charset=UTF-8')
   ->json_is({just => 'works'});
 
 done_testing();

--- a/t/mojolicious/types.t
+++ b/t/mojolicious/types.t
@@ -5,7 +5,7 @@ use Mojolicious::Types;
 
 # Basic functionality
 my $t = Mojolicious::Types->new;
-is $t->type('json'), 'application/json', 'right type';
+is $t->type('json'), 'application/json;charset=UTF-8', 'right type';
 is $t->type('foo'), undef, 'no type';
 $t->type(foo => 'foo/bar');
 is $t->type('foo'), 'foo/bar', 'right type';


### PR DESCRIPTION
IE 7,8,9 has bug with decoding of json response without encoding.
See http://stackoverflow.com/questions/8481453/jquery-ajax-request-doesnt-success-with-json-on-ie

The default encoding of application/json is UTF-8.
http://www.ietf.org/rfc/rfc4627.txt

That means, we can specify encoding in response without any trouble.