### PR TITLE
make url encoding compliant with rfc 3986 sec 2.2

### DIFF
--- a/lib/Mojo/Parameters.pm
+++ b/lib/Mojo/Parameters.pm
@@ -167,9 +167,9 @@ sub to_string {
 
     # Escape and replace whitespace with "+"
     $name  = encode $charset,   $name if $charset;
-    $name  = url_escape $name,  '^A-Za-z0-9\-._~!$\'()*,:@/?';
+    $name  = url_escape $name,  '^A-Za-z0-9\-._~';
     $value = encode $charset,   $value if $charset;
-    $value = url_escape $value, '^A-Za-z0-9\-._~!$\'()*,:@/?';
+    $value = url_escape $value, '^A-Za-z0-9\-._~';
     s/\%20/\+/g for $name, $value;
 
     push @pairs, "$name=$value";

--- a/t/mojo/parameters.t
+++ b/t/mojo/parameters.t
@@ -190,8 +190,8 @@ $params = Mojo::Parameters->new('!$\'()*,:@/foo?=!$\'()*,:@/?&bar=23');
 is $params->param('!$\'()*,:@/foo?'), '!$\'()*,:@/?', 'right value';
 is $params->param('bar'),             23,             'right value';
 is "$params",
-   '%21%24%27%28%29%2A%2C%3A%40%2Ffoo%3F=%21%24%27%28%29%2A%2C%3A%40%2F' .
-   '%3F&bar=23', 'right result';
+  '%21%24%27%28%29%2A%2C%3A%40%2Ffoo%3F=%21%24%27%28%29%2A%2C%3A%40%2F'
+  . '%3F&bar=23', 'right result';
 
 # No charset
 $params = Mojo::Parameters->new('%E5=%E4')->charset(undef);

--- a/t/mojo/parameters.t
+++ b/t/mojo/parameters.t
@@ -189,7 +189,9 @@ is "$params", '%25foo%25=%25', 'right result';
 $params = Mojo::Parameters->new('!$\'()*,:@/foo?=!$\'()*,:@/?&bar=23');
 is $params->param('!$\'()*,:@/foo?'), '!$\'()*,:@/?', 'right value';
 is $params->param('bar'),             23,             'right value';
-is "$params", '%21%24%27%28%29%2A%2C%3A%40%2Ffoo%3F=%21%24%27%28%29%2A%2C%3A%40%2F%3F&bar=23', 'right result';
+is "$params",
+   '%21%24%27%28%29%2A%2C%3A%40%2Ffoo%3F=%21%24%27%28%29%2A%2C%3A%40%2F' .
+   '%3F&bar=23', 'right result';
 
 # No charset
 $params = Mojo::Parameters->new('%E5=%E4')->charset(undef);

--- a/t/mojo/parameters.t
+++ b/t/mojo/parameters.t
@@ -189,7 +189,7 @@ is "$params", '%25foo%25=%25', 'right result';
 $params = Mojo::Parameters->new('!$\'()*,:@/foo?=!$\'()*,:@/?&bar=23');
 is $params->param('!$\'()*,:@/foo?'), '!$\'()*,:@/?', 'right value';
 is $params->param('bar'),             23,             'right value';
-is "$params", '!$\'()*,:@/foo?=!$\'()*,:@/?&bar=23', 'right result';
+is "$params", '%21%24%27%28%29%2A%2C%3A%40%2Ffoo%3F=%21%24%27%28%29%2A%2C%3A%40%2F%3F&bar=23', 'right result';
 
 # No charset
 $params = Mojo::Parameters->new('%E5=%E4')->charset(undef);


### PR DESCRIPTION
The RFC Section is here http://tools.ietf.org/html/rfc3986#section-2.2

First paragraph of the section says any conflicting chars should be escaped:
If data for a URI component would conflict with a reserved character's purpose as a delimiter, **then the conflicting data must be percent-encoded before the URI is formed**.

In such case, the faulting delimiters were removed from the character class so the name and/or value of a given pair can be encoded according to section 2.2.

A test was changed to reflect this condition; it was the only test failing after making the change.  Interestingly, the change reflects the default character class for url_escape.  Further simplification is then probable.