### PR TITLE
Add 'push' method to Mojo::Collection

### DIFF
--- a/lib/Mojo/Collection.pm
+++ b/lib/Mojo/Collection.pm
@@ -266,7 +266,7 @@ Construct a new array-based L<Mojo::Collection> object.
 
 =head2 push
 
-  $collection->push(6, 7, 8);
+  my $collection = $collection->push(6, 7, 8);
 
 Add elements to the existing L<Mojo::Collection> object.
 

--- a/lib/Mojo/Collection.pm
+++ b/lib/Mojo/Collection.pm
@@ -55,6 +55,12 @@ sub new {
   return bless [@_], ref $class || $class;
 }
 
+sub push {
+  my $self = shift;
+  push @$self, @_;
+  return $self;
+}
+
 sub reduce {
   my $self = shift;
   @_ = (@_, @$self);
@@ -257,6 +263,12 @@ passed to the callback and is also available as C<$_>.
   my $collection = Mojo::Collection->new(1, 2, 3);
 
 Construct a new array-based L<Mojo::Collection> object.
+
+=head2 push
+
+  $collection->push(6, 7, 8);
+
+Add elements to the existing L<Mojo::Collection> object.
 
 =head2 reduce
 

--- a/lib/Mojo/Collection.pm
+++ b/lib/Mojo/Collection.pm
@@ -101,6 +101,12 @@ sub uniq {
   return $_[0]->new(grep { !$seen{$_}++ } @{$_[0]});
 }
 
+sub unshift {
+  my $self = shift;
+  unshift @$self, @_;
+  return $self;
+}
+
 sub _flatten {
   map { _ref($_) ? _flatten(@$_) : $_ } @_;
 }
@@ -342,6 +348,16 @@ Create a new collection without duplicate elements.
 
   # "foo bar baz"
   Mojo::Collection->new('foo', 'bar', 'bar', 'baz')->uniq->join(' ');
+
+=head2 unshift
+
+  my $collection = $collection->unshift(1, 2, 3);
+
+Prepends an array to the collection in the specified order.
+
+  my $coundown = Mojo::Collection->new('BAM!');
+  my $count = Mojo::Collection->new(1, 2, 3);
+  $countdown->unshift( $count->reverse );
 
 =head1 SEE ALSO
 

--- a/t/mojo/collection.t
+++ b/t/mojo/collection.t
@@ -167,4 +167,22 @@ is_deeply $collection->uniq->to_array, [1, 2, 3, 4, 5], 'right result';
 is_deeply $collection->uniq->reverse->uniq->to_array, [5, 4, 3, 2, 1],
   'right result';
 
+# unshift
+$collection = c(1, 2, 3);
+is_deeply $collection->unshift(4, 5, 6), [4, 5, 6, 1, 2, 3], 'right result';
+$collection = c(1);
+is_deeply $collection->unshift([2])->flatten->to_array, [2, 1], 'right result';
+is_deeply $collection->unshift(3)->unshift(4), [4, 3, [2], 1], 'right result';
+$collection = c();
+is_deeply $collection->unshift(1)->unshift(2), [2, 1], 'right result';
+my $c2 = c(3, 4);
+my $c3 = c(5, 6);
+is_deeply $collection->unshift($c2)->unshift($c3)->flatten, [5, 6, 3, 4, 2, 1],
+  'right result';
+$collection = c(2, 1);
+is_deeply $collection
+  ->unshift($c2->reverse->to_array)
+  ->unshift($c3->reverse->to_array)->flatten, [6, 5, 4, 3, 2, 1],
+  'right result';
+
 done_testing();

--- a/t/mojo/collection.t
+++ b/t/mojo/collection.t
@@ -175,8 +175,8 @@ is_deeply $collection->unshift([2])->flatten->to_array, [2, 1], 'right result';
 is_deeply $collection->unshift(3)->unshift(4), [4, 3, [2], 1], 'right result';
 $collection = c();
 is_deeply $collection->unshift(1)->unshift(2), [2, 1], 'right result';
-my $c2 = c(3, 4);
-my $c3 = c(5, 6);
+$c2 = c(3, 4);
+$c3 = c(5, 6);
 is_deeply $collection->unshift($c2)->unshift($c3)->flatten, [5, 6, 3, 4, 2, 1],
   'right result';
 $collection = c(2, 1);

--- a/t/mojo/collection.t
+++ b/t/mojo/collection.t
@@ -90,6 +90,15 @@ is $collection->map('reverse')->map(join => "\n")->join("\n"),
 is $collection->map(join => '-')->join("\n"), "1-2-3\n4-5-6\n7-8-9",
   'right result';
 
+# push
+$collection = c(1, 2, 3);
+is_deeply $collection->push(4, 5, 6), [1, 2, 3, 4, 5, 6], 'right result';
+$collection = c(1);
+is_deeply $collection->push([2])->flatten->to_array, [1, 2], 'right result';
+is_deeply $collection->push(3)->push(4), [1, [2], 3, 4], 'right result';
+$collection = c();
+is_deeply $collection->push(1)->push(2), [1, 2], 'right result';
+
 # reverse
 $collection = c(3, 2, 1);
 is_deeply $collection->reverse->to_array, [1, 2, 3], 'right order';

--- a/t/mojo/collection.t
+++ b/t/mojo/collection.t
@@ -98,6 +98,10 @@ is_deeply $collection->push([2])->flatten->to_array, [1, 2], 'right result';
 is_deeply $collection->push(3)->push(4), [1, [2], 3, 4], 'right result';
 $collection = c();
 is_deeply $collection->push(1)->push(2), [1, 2], 'right result';
+my $c2 = c(3, 4);
+my $c3 = c(5, 6);
+is_deeply $collection->push($c2)->push($c3)->flatten, [1, 2, 3, 4, 5, 6],
+  'right result';
 
 # reverse
 $collection = c(3, 2, 1);


### PR DESCRIPTION
Easily add elements to an existing collection.

For me, the benefit is:

has foo => sub { c->new };

later...

$bar->foo->push('another');

I extended this class originally using 'add' but push is probably more perly.