### PR TITLE
Set all user groups of user in setuidgid

### DIFF
--- a/lib/Mojo/Server.pm
+++ b/lib/Mojo/Server.pm
@@ -92,8 +92,9 @@ sub setuidgid {
   unshift @gids, $gid unless grep { $_ == $gid } @gids;
 
   $( = $gid;
-  $) = join ' ', $gid, @gids;
   $self->_error(qq{Can't switch to group "$group": $!}) if $!;
+  $) = join ' ', $gid, @gids;
+  $self->_error(qq{Can't switch to groups "$gid @gids": $!}) if $!;
   $self->_error(qq{Can't switch to user "$user": $!})
     unless POSIX::setuid($uid);
 


### PR DESCRIPTION
I have inspected Apache 2.4.10 and nginx 1.6.3 and determined they both use the following behavior to set user and group of their worker processes.

Set user to specified user, and set groups to all groups of specified user, replacing the primary group with the specified group (default same name as user in nginx). Also add specified group as secondary group if not already listed.

This patch removes the ability to set the group without setting the user, or to set a user without a group change (defaulting to the user if unspecified), also matching the behavior of Apache and nginx.

The reason this is necessary is to allow the application to gain the secondary group permissions of the specified user, while still starting as root to bind to privileged ports like 80.

There are no tests or documentation included, but this feature currently has neither, and it would be impossible to test in an automated fashion. However, I have verified that this sets the groups correctly on Centos 6, in perl 5.10.1 and 5.20.2, using the following script (changing user/group/listen as needed).

    use Mojolicious::Lite;

    app->config(hypnotoad => {
        user => 'grinnz',
        group => 'nginx',
        listen => ['http://*:8081'],
    });

    get '/' => sub {
        my $c = shift;
        $c->render(json => {
                real_uid => $<,
                eff_uid => $>,
                real_gids => $(,
                eff_gids => $),
        });
    };

    app->start;
