### PR TITLE
Mojo::IOLoop->client with "proto" option and UDP support

### DIFF
--- a/lib/Mojo/IOLoop/Client.pm
+++ b/lib/Mojo/IOLoop/Client.pm
@@ -83,6 +83,7 @@ sub _connect {
     $options{Proto} = $args->{proto};
     $options{Blocking} = 0;
     $options{LocalAddr} = $args->{local_address} if $args->{local_address};
+    $options{LocalPort} = $args->{local_port} if $args->{local_port};
     return $self->emit(error => "Can't connect: $@")
       unless $self->{handle} = $handle = IO::Socket::IP->new(%options);
   }
@@ -290,6 +291,12 @@ Use an already prepared handle.
   local_address => '127.0.0.1'
 
 Local address to bind to.
+
+=item local_port
+
+  local_address => 12345
+
+Local port to bind to.
 
 =item port
 

--- a/lib/Mojo/IOLoop/Client.pm
+++ b/lib/Mojo/IOLoop/Client.pm
@@ -5,7 +5,7 @@ use Errno 'EINPROGRESS';
 use IO::Socket::IP;
 use Mojo::IOLoop;
 use Scalar::Util 'weaken';
-use Socket qw(IPPROTO_TCP SOCK_STREAM TCP_NODELAY);
+use Socket qw(IPPROTO_TCP IPPROTO_UDP SOCK_DGRAM SOCK_STREAM TCP_NODELAY);
 
 # Non-blocking name resolution requires Net::DNS::Native
 use constant NDN => $ENV{MOJO_NO_NDN}
@@ -41,7 +41,8 @@ sub connect {
     sub { $self->emit(error => 'Connect timeout') });
 
   # Blocking name resolution
-  $args->{proto} ||= 'tcp';
+  $args->{proto} ||= IPPROTO_TCP;
+  $args->{type} ||= ($args->{proto} eq 'udp' || $args->{proto} eq IPPROTO_UDP) ? SOCK_DGRAM : SOCK_STREAM;
   $_ && s/[[\]]//g for @$args{qw(address socks_address)};
   my $address = $args->{socks_address} || ($args->{address} ||= '127.0.0.1');
   return $reactor->next_tick(sub { $self && $self->_connect($args) })
@@ -49,7 +50,7 @@ sub connect {
 
   # Non-blocking name resolution
   my $handle = $self->{dns} = $NDN->getaddrinfo($address, _port($args),
-    {protocol => IPPROTO_TCP, socktype => SOCK_STREAM});
+    {protocol => $args->{proto}, socktype => $args->{type}});
   $reactor->io(
     $handle => sub {
       my $reactor = shift;
@@ -81,6 +82,7 @@ sub _connect {
     my %options = (PeerAddr => $address, PeerPort => _port($args));
     %options = (PeerAddrInfo => $args->{addr_info}) if $args->{addr_info};
     $options{Proto} = $args->{proto};
+    $options{Type} = $args->{type};
     $options{Blocking} = 0;
     $options{LocalAddr} = $args->{local_address} if $args->{local_address};
     $options{LocalPort} = $args->{local_port} if $args->{local_port};
@@ -108,7 +110,7 @@ sub _ready {
 
   # Disable Nagle's algorithm
   setsockopt $handle, IPPROTO_TCP, TCP_NODELAY, 1
-    if $args->{proto} eq 'tcp';
+    if $args->{proto} eq 'tcp' or $args->{proto} eq IPPROTO_TCP;
 
   $self->_try_socks($args);
 }
@@ -364,6 +366,12 @@ Path to the TLS certificate file.
   tls_key => '/etc/tls/client.key'
 
 Path to the TLS key file.
+
+=item type
+
+  type => SOCK_STREAM
+
+Socket type number (SOCK_STREAM, SOCK_DGRAM).
 
 =back
 

--- a/t/mojo/ioloop_client_udp.t
+++ b/t/mojo/ioloop_client_udp.t
@@ -1,0 +1,52 @@
+use Mojo::Base -strict;
+
+BEGIN { $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll' }
+
+use Test::More;
+use Mojo::IOLoop::Stream;
+use Mojo::IOLoop::Client;
+
+use Mojo::IOLoop;
+use IO::Socket::IP;
+
+my $delay = Mojo::IOLoop->delay;
+my ($server, $client);
+my $end = $delay->begin;
+
+my $port = 54321;
+my $sock = IO::Socket::IP->new(
+    LocalPort => $port,
+    Proto => 'udp',
+    Blocking => 0,
+) or die "socket: $@";
+
+my $id;
+$id = Mojo::IOLoop->recurring(0 => sub {
+    my $chunk;
+    $sock->recv($chunk, 1024);
+    if ($chunk) {
+        $server .= $chunk;
+        $sock->send('PONG');
+        Mojo::IOLoop->remove($id);
+    };
+});
+Mojo::IOLoop->timer(0.5 => sub { Mojo::IOLoop->remove($id) if $id });
+
+my $end2 = $delay->begin;
+Mojo::IOLoop->client(
+  {address => '127.0.0.1', port => $port, proto => 'udp'} => sub {
+    my ($loop, $err, $stream) = @_;
+    $stream->write('PING');
+    $stream->on(close => $end2);
+    $stream->on(read => sub {
+      $client .= pop;
+      $stream->close;
+    });
+    $stream->timeout(0.5);
+  }
+);
+$delay->wait;
+is $server, 'PING', 'right content';
+is $client, 'PONG', 'right content';
+
+done_testing();


### PR DESCRIPTION
Please, allow to use UDP protocol in ``Mojo::IOLoop::Client``. It makes possible to create ie. DNS client.

Proof of concept:

```perl
use Mojo::IOLoop;
use Net::DNS::Packet;

my $address = $ARGV[0] || 'mojolicio.us';

Mojo::IOLoop->client({address => '8.8.8.8', port => 53, proto => 'udp'} => sub {
    my ($loop, $err, $stream) = @_;
    $stream->on('read' => sub {
      my ($stream, $bytes) = @_;
      my $ans = Net::DNS::Packet->new(\$bytes, 1);
      $stream->close;
    });
    my $packet = Net::DNS::Packet->new($address);
    $stream->write($packet->data);
});

Mojo::IOLoop->start unless Mojo::IOLoop->is_running;
```
