### PR TITLE
Sort method names alphabetically in the code/documentation

### DIFF
--- a/lib/Mojo/Base.pm
+++ b/lib/Mojo/Base.pm
@@ -26,35 +26,6 @@ sub _monkey_patch {
   *{"${class}::$_"} = $NAME->("${class}::$_", $patch{$_}) for keys %patch;
 }
 
-sub import {
-  my $class = shift;
-  return unless my $flag = shift;
-
-  # Base
-  if ($flag eq '-base') { $flag = $class }
-
-  # Strict
-  elsif ($flag eq '-strict') { $flag = undef }
-
-  # Module
-  elsif ((my $file = $flag) && !$flag->can('new')) {
-    $file =~ s!::|'!/!g;
-    require "$file.pm";
-  }
-
-  # ISA
-  if ($flag) {
-    my $caller = caller;
-    no strict 'refs';
-    push @{"${caller}::ISA"}, $flag;
-    _monkey_patch $caller, 'has', sub { attr($caller, @_) };
-  }
-
-  # Mojo modules are strict!
-  $_->import for qw(strict warnings utf8);
-  feature->import(':5.10');
-}
-
 sub attr {
   my ($self, $attrs, $value) = @_;
   return unless (my $class = ref $self || $self) && $attrs;
@@ -88,6 +59,35 @@ sub attr {
         sub { return $_[0]{$attr} if @_ == 1; $_[0]{$attr} = $_[1]; $_[0] };
     }
   }
+}
+
+sub import {
+  my $class = shift;
+  return unless my $flag = shift;
+
+  # Base
+  if ($flag eq '-base') { $flag = $class }
+
+  # Strict
+  elsif ($flag eq '-strict') { $flag = undef }
+
+  # Module
+  elsif ((my $file = $flag) && !$flag->can('new')) {
+    $file =~ s!::|'!/!g;
+    require "$file.pm";
+  }
+
+  # ISA
+  if ($flag) {
+    my $caller = caller;
+    no strict 'refs';
+    push @{"${caller}::ISA"}, $flag;
+    _monkey_patch $caller, 'has', sub { attr($caller, @_) };
+  }
+
+  # Mojo modules are strict!
+  $_->import for qw(strict warnings utf8);
+  feature->import(':5.10');
 }
 
 sub new {

--- a/lib/Mojo/DOM.pm
+++ b/lib/Mojo/DOM.pm
@@ -47,9 +47,9 @@ sub attr {
   return $self;
 }
 
-sub children { _select($_[0]->_collect(_nodes($_[0]->tree, 1)), $_[1]) }
-
 sub child_nodes { $_[0]->_collect(_nodes($_[0]->tree)) }
+
+sub children { _select($_[0]->_collect(_nodes($_[0]->tree, 1)), $_[1]) }
 
 sub content {
   my $self = shift;

--- a/lib/Mojo/DOM.pm
+++ b/lib/Mojo/DOM.pm
@@ -509,18 +509,6 @@ This element's attributes.
   # List id attributes
   say $dom->find('*')->map(attr => 'id')->compact->join("\n");
 
-=head2 children
-
-  my $collection = $dom->children;
-  my $collection = $dom->children('div > p');
-
-Find all child elements of this element matching the CSS selector and return a
-L<Mojo::Collection> object containing these elements as L<Mojo::DOM> objects.
-All selectors from L<Mojo::DOM::CSS/"SELECTORS"> are supported.
-
-  # Show tag name of random child element
-  say $dom->children->shuffle->first->tag;
-
 =head2 child_nodes
 
   my $collection = $dom->child_nodes;
@@ -533,6 +521,18 @@ as L<Mojo::DOM> objects.
 
   # "<!-- Test -->"
   $dom->parse('<!-- Test --><b>123</b>')->child_nodes->first;
+
+=head2 children
+
+  my $collection = $dom->children;
+  my $collection = $dom->children('div > p');
+
+Find all child elements of this element matching the CSS selector and return a
+L<Mojo::Collection> object containing these elements as L<Mojo::DOM> objects.
+All selectors from L<Mojo::DOM::CSS/"SELECTORS"> are supported.
+
+  # Show tag name of random child element
+  say $dom->children->shuffle->first->tag;
 
 =head2 content
 

--- a/lib/Mojo/IOLoop/Stream.pm
+++ b/lib/Mojo/IOLoop/Stream.pm
@@ -278,17 +278,17 @@ Construct a new L<Mojo::IOLoop::Stream> object.
 
 Start watching for new data on the stream.
 
-=head2 stop
-
-  $stream->stop;
-
-Stop watching for new data on the stream.
-
 =head2 steal_handle
 
   my $handle = $stream->steal_handle;
 
 Steal handle from stream and prevent it from getting closed automatically.
+
+=head2 stop
+
+  $stream->stop;
+
+Stop watching for new data on the stream.
 
 =head2 timeout
 

--- a/lib/Mojo/IOLoop/Stream.pm
+++ b/lib/Mojo/IOLoop/Stream.pm
@@ -49,16 +49,16 @@ sub start {
   $reactor->io($self->timeout($self->{timeout})->{handle} => $cb);
 }
 
-sub stop {
-  my $self = shift;
-  $self->reactor->watch($self->{handle}, 0, $self->is_writing)
-    unless $self->{paused}++;
-}
-
 sub steal_handle {
   my $self = shift;
   $self->reactor->remove($self->{handle});
   return delete $self->{handle};
+}
+
+sub stop {
+  my $self = shift;
+  $self->reactor->watch($self->{handle}, 0, $self->is_writing)
+    unless $self->{paused}++;
 }
 
 sub timeout {

--- a/lib/Mojo/URL.pm
+++ b/lib/Mojo/URL.pm
@@ -34,19 +34,19 @@ sub authority {
   return _encode($info, '^A-Za-z0-9\-._~!$&\'()*+,;=:') . '@' . $authority;
 }
 
-sub host_port {
-  my $self = shift;
-  return undef unless defined(my $host = $self->ihost);
-  return $host unless my $port = $self->port;
-  return "$host:$port";
-}
-
 sub clone {
   my $self  = shift;
   my $clone = $self->new;
   @$clone{keys %$self} = values %$self;
   $clone->{$_} && ($clone->{$_} = $clone->{$_}->clone) for qw(base path query);
   return $clone;
+}
+
+sub host_port {
+  my $self = shift;
+  return undef unless defined(my $host = $self->ihost);
+  return $host unless my $port = $self->port;
+  return "$host:$port";
 }
 
 sub ihost {

--- a/lib/Mojolicious/Plugins.pm
+++ b/lib/Mojolicious/Plugins.pm
@@ -6,12 +6,6 @@ use Mojo::Util 'camelize';
 
 has namespaces => sub { ['Mojolicious::Plugin'] };
 
-sub emit_hook {
-  my $self = shift;
-  for my $cb (@{$self->subscribers(shift)}) { $cb->(@_) }
-  return $self;
-}
-
 sub emit_chain {
   my ($self, $name, @args) = @_;
 
@@ -22,6 +16,12 @@ sub emit_chain {
   }
 
   !$wrapper ? return : return $wrapper->();
+}
+
+sub emit_hook {
+  my $self = shift;
+  for my $cb (@{$self->subscribers(shift)}) { $cb->(@_) }
+  return $self;
 }
 
 sub emit_hook_reverse {

--- a/lib/Test/Mojo.pm
+++ b/lib/Test/Mojo.pm
@@ -580,13 +580,6 @@ Opposite of L</"content_is">.
 Check response content for similar match after retrieving it from
 L<Mojo::Message/"text">.
 
-=head2 content_unlike
-
-  $t = $t->content_unlike(qr/working!/);
-  $t = $t->content_unlike(qr/working!/, 'different content');
-
-Opposite of L</"content_like">.
-
 =head2 content_type_is
 
   $t = $t->content_type_is('text/html');
@@ -614,6 +607,13 @@ Check response C<Content-Type> header for similar match.
   $t = $t->content_type_unlike(qr/text/, 'different content type');
 
 Opposite of L</"content_type_like">.
+
+=head2 content_unlike
+
+  $t = $t->content_unlike(qr/working!/);
+  $t = $t->content_unlike(qr/working!/, 'different content');
+
+Opposite of L</"content_like">.
 
 =head2 delete_ok
 

--- a/lib/Test/Mojo.pm
+++ b/lib/Test/Mojo.pm
@@ -47,12 +47,6 @@ sub content_like {
   return $self->_test('like', $self->tx->res->text, $regex, $desc);
 }
 
-sub content_unlike {
-  my ($self, $regex, $desc) = @_;
-  $desc ||= 'content is not similar';
-  return $self->_test('unlike', $self->tx->res->text, $regex, $desc);
-}
-
 sub content_type_is {
   my ($self, $type, $desc) = @_;
   $desc ||= "Content-Type: $type";
@@ -79,6 +73,12 @@ sub content_type_unlike {
   $desc ||= 'Content-Type is not similar';
   return $self->_test('unlike', $self->tx->res->headers->content_type,
     $regex, $desc);
+}
+
+sub content_unlike {
+  my ($self, $regex, $desc) = @_;
+  $desc ||= 'content is not similar';
+  return $self->_test('unlike', $self->tx->res->text, $regex, $desc);
 }
 
 sub delete_ok { shift->_build_ok(DELETE => @_) }


### PR DESCRIPTION
I feel silly submitting this, but it's been nagging me in the brain, ever since `sri` mentioned it: http://irclog.perlgeek.de/mojo/search/?nick=sri&q=%22would+be+right%22

I've used a script to find unsorted methods and here's its output, to more easily see what was moved around. The lines starting with a `#` indicate blocks that contain unsorted methods:


```
/var/www/tmp/mojo/lib/Test/Mojo.pm has unsorted methods:
        ==Original=== | ===Sorted===
                  app | app
           content_is | content_is
         content_isnt | content_isnt
         content_like | content_like
#      content_unlike | content_type_is
#     content_type_is | content_type_isnt
#   content_type_isnt | content_type_like
#   content_type_like | content_type_unlike
# content_type_unlike | content_unlike
            delete_ok | delete_ok
     element_count_is | element_count_is
       element_exists | element_exists
   element_exists_not | element_exists_not
            finish_ok | finish_ok
          finished_ok | finished_ok
               get_ok | get_ok
              head_ok | head_ok
            header_is | header_is
          header_isnt | header_isnt
          header_like | header_like
        header_unlike | header_unlike
             json_has | json_has
           json_hasnt | json_hasnt
              json_is | json_is
            json_like | json_like
     json_message_has | json_message_has
   json_message_hasnt | json_message_hasnt
      json_message_is | json_message_is
    json_message_like | json_message_like
  json_message_unlike | json_message_unlike
          json_unlike | json_unlike
           message_is | message_is
         message_isnt | message_isnt
         message_like | message_like
           message_ok | message_ok
       message_unlike | message_unlike
                  new | new
           options_ok | options_ok
                   or | or
             patch_ok | patch_ok
              post_ok | post_ok
               put_ok | put_ok
           request_ok | request_ok
        reset_session | reset_session
              send_ok | send_ok
            status_is | status_is
          status_isnt | status_isnt
              text_is | text_is
            text_isnt | text_isnt
            text_like | text_like
          text_unlike | text_unlike
         websocket_ok | websocket_ok
            _build_ok | _build_ok
                _json | _json
             _message | _message
          _request_ok | _request_ok
                _test | _test
                _text | _text
                _wait | _wait



/var/www/tmp/mojo/lib/Mojolicious/Plugins.pm has unsorted methods:
      ==Original=== | ===Sorted===
#         emit_hook | emit_chain
#        emit_chain | emit_hook
  emit_hook_reverse | emit_hook_reverse
        load_plugin | load_plugin
    register_plugin | register_plugin
              _load | _load



/var/www/tmp/mojo/lib/Mojo/DOM.pm has unsorted methods:
     ==Original=== | ===Sorted===
          all_text | all_text
         ancestors | ancestors
            append | append
    append_content | append_content
                at | at
              attr | attr
#         children | child_nodes
#      child_nodes | children
           content | content
  descendant_nodes | descendant_nodes
              find | find
         following | following
   following_nodes | following_nodes
           matches | matches
         namespace | namespace
               new | new
              next | next
         next_node | next_node
            parent | parent
             parse | parse
         preceding | preceding
   preceding_nodes | preceding_nodes
           prepend | prepend
   prepend_content | prepend_content
          previous | previous
     previous_node | previous_node
            remove | remove
           replace | replace
              root | root
             strip | strip
               tag | tag
               tap | tap
              text | text
         to_string | to_string
              tree | tree
              type | type
              wrap | wrap
      wrap_content | wrap_content
               xml | xml
              _add | _add
              _all | _all
         _all_text | _all_text
        _ancestors | _ancestors
            _build | _build
          _collect | _collect
          _content | _content
              _css | _css
         _delegate | _delegate
             _link | _link
            _maybe | _maybe
            _nodes | _nodes
           _offset | _offset
           _parent | _parent
            _parse | _parse
          _replace | _replace
           _select | _select
         _siblings | _siblings
            _start | _start
             _text | _text
             _wrap | _wrap



/var/www/tmp/mojo/lib/Mojo/Base.pm has unsorted methods:
  ==Original=== | ===Sorted===
        DESTROY | DESTROY
# _monkey_patch | attr   <--------- I left this where it was
         import | import
#          attr | new
#           new | tap
#           tap | _monkey_patch



/var/www/tmp/mojo/lib/Mojo/URL.pm has unsorted methods:
  ==Original=== | ===Sorted===
      authority | authority
#     host_port | clone
#         clone | host_port
          ihost | ihost
         is_abs | is_abs
            new | new
          parse | parse
           path | path
     path_query | path_query
       protocol | protocol
          query | query
         to_abs | to_abs
      to_string | to_string
        _decode | _decode
        _encode | _encode



/var/www/tmp/mojo/lib/Mojo/IOLoop/Stream.pm has unsorted methods:
     ==Original=== | ===Sorted===
           DESTROY | DESTROY
             close | close
  close_gracefully | close_gracefully
            handle | handle
       is_readable | is_readable
        is_writing | is_writing
               new | new
             start | start
#             stop | steal_handle
#     steal_handle | stop
           timeout | timeout
             write | write
            _again | _again
             _read | _read
            _write | _write

```