### PR TITLE
"Friendly" Error Pages in MSIE

### DIFF
--- a/lib/Mojolicious/templates/exception.html.ep
+++ b/lib/Mojolicious/templates/exception.html.ep
@@ -16,3 +16,5 @@
     </style>
   <body><div id="raptor"></div></body>
 </html>
+<!-- padding to disable MSIE and Chrome friendly error page -->
+<!-- padding to disable MSIE and Chrome friendly error page -->

--- a/lib/Mojolicious/templates/not_found.html.ep
+++ b/lib/Mojolicious/templates/not_found.html.ep
@@ -27,9 +27,3 @@
     <div id="notfound"></div>
   </body>
 </html>
-<!-- a padding to disable MSIE and Chrome friendly error page -->
-<!-- a padding to disable MSIE and Chrome friendly error page -->
-<!-- a padding to disable MSIE and Chrome friendly error page -->
-<!-- a padding to disable MSIE and Chrome friendly error page -->
-<!-- a padding to disable MSIE and Chrome friendly error page -->
-<!-- a padding to disable MSIE and Chrome friendly error page -->


### PR DESCRIPTION
As per [MS kb294807](https://support.microsoft.com/en-us/kb/294807), if the error pages are below 512 bytes in size, a "friendly" error page will be displayed. This means:
1) Our not_found template has extraneous HTML comments, as without them the page is already above the minimum size
2) Our exception template is below the size and currently triggers the "friendly" error pages.

This PR fixes both of these issues.

The claims and the solution in this PR were tested in IE8, using BrowserStack.