### PR TITLE
TO_JSON for Mojo::Collection

### DIFF
--- a/lib/Mojo/Collection.pm
+++ b/lib/Mojo/Collection.pm
@@ -154,6 +154,12 @@ Construct a new array-based L<Mojo::Collection> object.
 
 L<Mojo::Collection> implements the following methods.
 
+=head2 TO_JSON
+
+  my $array = $collection->TO_JSON;
+
+Alias for L</"to_array">.
+
 =head2 compact
 
   my $new = $collection->compact;
@@ -323,12 +329,6 @@ Alias for L<Mojo::Base/"tap">.
   my $array = $collection->to_array;
 
 Turn collection into array reference.
-
-=head2 TO_JSON
-
-  my $array = $collection->TO_JSON;
-
-Alias for L</"to_array">.
 
 =head2 uniq
 

--- a/lib/Mojo/Collection.pm
+++ b/lib/Mojo/Collection.pm
@@ -90,6 +90,8 @@ sub tap { shift->Mojo::Base::tap(@_) }
 
 sub to_array { [@{shift()}] }
 
+sub TO_JSON { [@{shift()}] }
+
 sub uniq {
   my %seen;
   return $_[0]->new(grep { !$seen{$_}++ } @{$_[0]});

--- a/lib/Mojo/Collection.pm
+++ b/lib/Mojo/Collection.pm
@@ -9,6 +9,8 @@ use Scalar::Util 'blessed';
 
 our @EXPORT_OK = ('c');
 
+sub TO_JSON { [@{shift()}] }
+
 sub c { __PACKAGE__->new(@_) }
 
 sub compact {
@@ -89,8 +91,6 @@ sub sort {
 sub tap { shift->Mojo::Base::tap(@_) }
 
 sub to_array { [@{shift()}] }
-
-sub TO_JSON { [@{shift()}] }
 
 sub uniq {
   my %seen;
@@ -328,11 +328,7 @@ Turn collection into array reference.
 
   my $array = $collection->TO_JSON;
 
-Turn collection into array reference allowing conversion to JSON by
-L<Mojo::JSON>.
-
-  # {"baz":["foo","bar"]}
-  $c->render(json => { baz => Mojo::Collection->new('foo', 'bar') });
+Alias for L</"to_array">.
 
 =head2 uniq
 

--- a/lib/Mojo/Collection.pm
+++ b/lib/Mojo/Collection.pm
@@ -324,6 +324,16 @@ Alias for L<Mojo::Base/"tap">.
 
 Turn collection into array reference.
 
+=head2 TO_JSON
+
+  my $array = $collection->TO_JSON;
+
+Turn collection into array reference allowing conversion to JSON by
+L<Mojo::JSON>.
+
+  # {"baz":["foo","bar"]}
+  $c->render(json => { baz => Mojo::Collection->new('foo', 'bar') });
+
 =head2 uniq
 
   my $new = $collection->uniq;

--- a/t/mojo/collection.t
+++ b/t/mojo/collection.t
@@ -3,6 +3,7 @@ use Mojo::Base -strict;
 use Test::More;
 use Mojo::ByteStream 'b';
 use Mojo::Collection 'c';
+use Mojo::JSON 'encode_json';
 
 # Array
 is c(1, 2, 3)->[1], 2, 'right result';
@@ -153,5 +154,10 @@ $collection = c(1, 2, 3, 2, 3, 4, 5, 4);
 is_deeply $collection->uniq->to_array, [1, 2, 3, 4, 5], 'right result';
 is_deeply $collection->uniq->reverse->uniq->to_array, [5, 4, 3, 2, 1],
   'right result';
+
+# json
+$collection = c(1, 2, 3);
+my $bytes = encode_json $collection;
+is $bytes, '[1,2,3]', 'TO_JSON';
 
 done_testing();


### PR DESCRIPTION
Adds Mojo::Collection::TO_JSON

The name is slightly misleading as it doesn't convert to JSON, rather it returns an array reference in the same way as to_array. This lets Mojo::JSON and friends convert a Mojo::Collection to a JSON array.

Amongst other things it reduces noise when returning Mojo::Pg result sets as JSON:

    $c->render(json => {foo => $results->hashes});

vs

    $c->render(json => {foo => $results->hashes->to_array});