### PR TITLE
Tell GitHub our test files are Perl 5, not Perl 6

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.t linguist-language=Perl

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .*
 *~
+!.gitattributes
 !.gitignore
 !.perltidyrc
 !.travis.yml


### PR DESCRIPTION
This fixes incorrect reporting by GitHub that our repo's test files are written in Perl 6:
![perl6](https://cloud.githubusercontent.com/assets/5747918/7966435/12800670-09f2-11e5-9fc1-203ef051c6ae.jpg)
