### PR TITLE
added remove_all in Mojo::Parameters

### DIFF
--- a/lib/Mojo/Parameters.pm
+++ b/lib/Mojo/Parameters.pm
@@ -127,6 +127,13 @@ sub remove {
   return $self;
 }
 
+sub remove_all {
+  my ($self) = @_;
+  my $pairs = $self->pairs;
+  @$pairs=();
+  return $self;
+}
+
 sub to_hash {
   my $self = shift;
 
@@ -331,6 +338,12 @@ Remove parameters. Note that this method will normalize the parameters.
 
   # "bar=yada"
   Mojo::Parameters->new('foo=bar&foo=baz&bar=yada')->remove('foo');
+
+=head2 remove_all
+
+  $params = $params->remove_all;
+
+Remove all parameters. This is the equivalent of delete_all in CGI module.
 
 =head2 to_hash
 

--- a/t/mojo/parameters.t
+++ b/t/mojo/parameters.t
@@ -17,6 +17,8 @@ is $params->to_string, 'foo=b%3Bar&baz=23&a=4&a=5&b=6&b=7&c=f%3Boo',
   'right format';
 is $params->remove('a')->to_string, 'foo=b%3Bar&baz=23&b=6&b=7&c=f%3Boo',
   'right format';
+is $params->remove_all->to_string, '',
+  'right format';
 
 # Clone
 my $clone = $params->clone;


### PR DESCRIPTION
When converting a cgi script to mojo I notice that I needed 'delete_all' equivalent in CGI. This change added a simple method 'remove_all' in Mojo::Parameters which does that. It is a very simple but convenient method to wipe out all input parameters.