### PR TITLE
Fixed skipping validation of optional fields for multiple values

### DIFF
--- a/lib/Mojolicious/Validator/Validation.pm
+++ b/lib/Mojolicious/Validator/Validation.pm
@@ -26,7 +26,7 @@ sub check {
   my $cb          = $self->validator->checks->{$check};
   my $name        = $self->topic;
   my $input       = $self->input->{$name};
-  my $is_optional = $self->is_optional($name);
+  my $is_optional = $self->is_optional;
   for my $value (ref $input eq 'ARRAY' ? @$input : $input) {
     next if $is_optional && (!defined($value) || !length($value));
     next unless my $result = $self->$cb($name, $value, @_);

--- a/lib/Mojolicious/Validator/Validation.pm
+++ b/lib/Mojolicious/Validator/Validation.pm
@@ -72,7 +72,7 @@ sub optional {
   my @input = ref $input eq 'ARRAY' ? @$input : $input;
   $self->output->{$name} = $input if grep { defined($_) && length($_) } @input;
 
-  return $self->topic($name)->is_optional($name);
+  return $self->topic($name)->is_optional(1);
 }
 
 sub param { shift->every_param(shift)->[-1] }
@@ -160,7 +160,7 @@ L<Mojolicious::Validator> object this validation belongs to.
 =head2 is_optional
 
   my $is_optional = $validation->is_optional;
-  $validation     = $validation->is_optional('foo');
+  $validation     = $validation->is_optional(1);
 
 Flag, indicating optionality of field currently being validated.
 

--- a/lib/Mojolicious/Validator/Validation.pm
+++ b/lib/Mojolicious/Validator/Validation.pm
@@ -4,7 +4,7 @@ use Mojo::Base -base;
 use Carp         ();
 use Scalar::Util ();
 
-has [qw(csrf_token topic validator)];
+has [qw(csrf_token topic validator is_optional)];
 has [qw(input output)] => sub { {} };
 
 sub AUTOLOAD {
@@ -23,10 +23,12 @@ sub check {
 
   return $self unless $self->is_valid;
 
-  my $cb    = $self->validator->checks->{$check};
-  my $name  = $self->topic;
-  my $input = $self->input->{$name};
+  my $cb          = $self->validator->checks->{$check};
+  my $name        = $self->topic;
+  my $input       = $self->input->{$name};
+  my $is_optional = $self->is_optional($name);
   for my $value (ref $input eq 'ARRAY' ? @$input : $input) {
+    next if $is_optional && (!defined($value) || !length($value));
     next unless my $result = $self->$cb($name, $value, @_);
     return $self->error($name => [$check, $result, @_]);
   }
@@ -68,10 +70,9 @@ sub optional {
 
   my $input = $self->input->{$name};
   my @input = ref $input eq 'ARRAY' ? @$input : $input;
-  $self->output->{$name} = $input
-    unless grep { !defined($_) || !length($_) } @input;
+  $self->output->{$name} = $input if grep { defined($_) && length($_) } @input;
 
-  return $self->topic($name);
+  return $self->topic($name)->is_optional($name);
 }
 
 sub param { shift->every_param(shift)->[-1] }
@@ -80,7 +81,15 @@ sub passed { [sort keys %{shift->output}] }
 
 sub required {
   my ($self, $name) = @_;
-  return $self if $self->optional($name)->is_valid;
+
+  my $input = $self->input->{$name};
+  my @input = ref $input eq 'ARRAY' ? @$input : $input;
+  $self->output->{$name} = $input
+    unless grep { !defined($_) || !length($_) } @input;
+
+  $self->topic($name);
+
+  return $self if $self->is_valid;
   return $self->error($name => ['required']);
 }
 
@@ -147,6 +156,13 @@ Name of field currently being validated.
   $validation   = $validation->validator(Mojolicious::Validator->new);
 
 L<Mojolicious::Validator> object this validation belongs to.
+
+=head2 is_optional
+
+  my $is_optional = $validation->is_optional;
+  $validation     = $validation->is_optional('foo');
+
+Flag, indicating optionality of field currently being validated.
 
 =head1 METHODS
 

--- a/t/mojolicious/validation_lite_app.t
+++ b/t/mojolicious/validation_lite_app.t
@@ -164,6 +164,12 @@ is_deeply $validation->output, {}, 'right result';
 ok $validation->has_error, 'has error';
 is_deeply $validation->error('foo'), ['required'], 'right error';
 
+# Multiple empty optional values with check
+$validation = $t->app->validation;
+$validation->input({foo => ['', 'bar', '']});
+ok $validation->optional('foo')->in('bar')->is_valid, 'valid';
+ok $validation->optional('foo')->in('baz')->has_error, 'has_error';
+
 # "0"
 $validation = $t->app->validation->input({0 => 0});
 ok $validation->has_data, 'has data';


### PR DESCRIPTION
In case, when we have optional field with multiple values a validation is skipping, when one of this values is empty.

My opinion: if validation is optional for this field, it must skip empty values and check nonempty values.

I have fixed "required" method to its "original" functionality.

Fixed setup "output" of optional fields in case if there exists nonempty values.

And we skip check of empty values in case of "is_optional" flag.

Notice: we must persist order of values in optional field, so we store all values (even empty) in "output".