### PR TITLE
add swat command

### DIFF
--- a/lib/Mojolicious/Command/swat.pm
+++ b/lib/Mojolicious/Command/swat.pm
@@ -1,0 +1,98 @@
+package Mojolicious::Command::swat;
+use Mojo::Base 'Mojolicious::Command';
+#use Data::Dumper;
+
+use re 'regexp_pattern';
+use Getopt::Long qw(GetOptionsFromArray :config no_auto_abbrev no_ignore_case);
+use Mojo::Util qw(encode tablify);
+
+has description => 'Generate swat tests for mojo routes';
+has usage => sub { shift->extract_usage };
+
+sub run {
+  my ($self, @args) = @_;
+
+  GetOptionsFromArray \@args, 'v|verbose' => \my $verbose;
+
+  my $rows = [];
+  _walk($_, 0, $rows, $verbose) for @{$self->app->routes->children};
+#  print encode('UTF-8', tablify($rows));
+    ROUTE: for my $i (@$rows){
+
+        my $http_method = $i->[1];
+        my $route  = $i->[0];
+
+        unless ($http_method=~/GET|POST/i){
+            warn "sorry, swat does not support $http_method methods yet ...";
+            next ROUTE;
+        }
+
+        print "generate swat route for $route ... \n";
+        mkdir "swat/$route";
+
+        print "generate swat data for $http_method $route ... \n";
+        my $filename = "swat/$route/"; 
+        $filename.=lc($http_method); $filename.=".txt";
+        open(my $fh, '>', $filename) or die "Could not open file '$filename' $!";
+        print $fh "200 OK\n";
+        close $fh;
+
+   }
+        print "\n---\nswat is ready to run: swat ./swat http://127.0.0.1:3000\n";        
+
+}
+
+sub _walk {
+  my ($route, $depth, $rows, $verbose) = @_;
+
+  # Pattern
+  my $prefix = '';
+  if (my $i = $depth * 2) { $prefix .= ' ' x $i . '+' }
+  push @$rows, my $row = [$prefix . ($route->pattern->unparsed || '/')];
+
+  # Flags
+  my @flags;
+  push @flags, @{$route->over || []} ? 'C' : '.';
+  push @flags, (my $partial = $route->partial) ? 'D' : '.';
+  push @flags, $route->inline       ? 'U' : '.';
+  push @flags, $route->is_websocket ? 'W' : '.';
+  push @$row, join('', @flags) if $verbose;
+
+  # Methods
+  my $via = $route->via;
+  push @$row, !$via ? '*' : uc join ',', @$via;
+
+  # Name
+  my $name = $route->name;
+  push @$row, $route->has_custom_name ? qq{"$name"} : $name;
+
+  # Regex (verbose)
+  my $pattern = $route->pattern;
+  $pattern->match('/', $route->is_endpoint && !$partial);
+  my $regex  = (regexp_pattern $pattern->regex)[0];
+  my $format = (regexp_pattern($pattern->format_regex))[0];
+  push @$row, $regex, $format ? $format : '' if $verbose;
+
+  $depth++;
+  _walk($_, $depth, $rows, $verbose) for @{$route->children};
+  $depth--;
+}
+
+1;
+
+=encoding utf8
+
+=head1 NAME
+
+Mojolicious::Command::swat - Generate swat tests for mojo routes
+
+=head1 DESCRIPTION
+
+L<Mojolicious::Command::swat> generate swat tests for mojo routes.
+
+=head1 SEE ALSO
+
+L<Mojolicious>, L<Mojolicious::Guides>, L<http://mojolicio.us>.
+
+=cut
+


### PR DESCRIPTION
HI @kraih !  [Swat](https://github.com/melezhik/swat) is a Simple Web Application Tests (API).
I found this interesting to generate swat tests for a existed mojo application using routes introspection embedded into mojo core. 

This is very first draft as swat could be integrated with, and could refined latter. 

Now swat command does this:

- walk through all available GET|POST mojo routes   and creates a swat test for every one
- when it is done one may run swat tests kept under ./swat directory 

---

Full documentation for SWAT is available here - https://github.com/melezhik/swat

Here is the example of swat command usage:

```

$ cat myapp.pl

#!/usr/bin/env perl
use Mojolicious::Lite;

# Documentation browser under "/perldoc"
plugin 'PODRenderer';

get '/' => sub {
  my $c = shift;
  $c->render(template => 'index');
};

get '/foo' => sub {
    my $c = shift;
    $c->render(text => 'Hello World!');
  };


post '/foo/bar' => sub {
 "OK"
};


app->start;
__DATA__

@@ index.html.ep
% layout 'default';
% title 'Welcome';
<h1>Welcome to the Mojolicious real-time web framework!</h1>
To learn more, you can browse through the documentation
<%= link_to 'here' => '/perldoc' %>.

@@ foobar.html.ep
% layout 'default';
% title 'Foo Bar';
Foo Bar

@@ layouts/default.html.ep
<!DOCTYPE html>
<html>
  <head><title><%= title %></title></head>
  <body>

$ PERL5LIB=~/perl5/lib/perl5/ ./myapp.pl  swat
sorry, swat does not support * methods yet ... at Mojolicious/Command/swat.pm line 26, <DATA> line 43.
generate swat route for / ...
generate swat data for GET / ...
generate swat route for /foo ...
generate swat data for GET /foo ...
generate swat route for /foo/bar ...
generate swat data for POST /foo/bar ...

---
swat is ready to run: swat ./swat http://127.0.0.1:3000

$ PERL5LIB=~/perl5/lib/perl5/ ~/perl5/bin/morbo ./myapp.pl
Server available at http://127.0.0.1:3000

$ swat ./swat http://127.0.0.1:3000
/home/vagrant/.swat/reports/http://127.0.0.1:3000/00.t ...............
# start swat for http://127.0.0.1:3000// | is swat package 0
# swat version v0.1.19 | debug 0 | try num 2 | ignore http errors 0
ok 1 - successfull response from GET http://127.0.0.1:3000/
# data file: /home/vagrant/.swat/reports/http://127.0.0.1:3000///content.GET.txt
ok 2 - GET / returns 200 OK
1..2
ok
/home/vagrant/.swat/reports/http://127.0.0.1:3000/foo/00.t ...........
# start swat for http://127.0.0.1:3000//foo | is swat package 0
# swat version v0.1.19 | debug 0 | try num 2 | ignore http errors 0
ok 1 - successfull response from GET http://127.0.0.1:3000/foo
# data file: /home/vagrant/.swat/reports/http://127.0.0.1:3000//foo/content.GET.txt
ok 2 - GET /foo returns 200 OK
1..2
ok
/home/vagrant/.swat/reports/http://127.0.0.1:3000/foo/bar/00.post.t ..
# start swat for http://127.0.0.1:3000//foo/bar | is swat package 0
# swat version v0.1.19 | debug 0 | try num 2 | ignore http errors 0
ok 1 - successfull response from POST http://127.0.0.1:3000/foo/bar
# data file: /home/vagrant/.swat/reports/http://127.0.0.1:3000//foo/bar/content.POST.txt
ok 2 - POST /foo/bar returns 200 OK
1..2
ok
All tests successful.
Files=3, Tests=6,  0 wallclock secs ( 0.00 usr  0.01 sys +  0.04 cusr  0.01 csys =  0.06 CPU)
Result: PASS


```