### PR TITLE
update Makefile.PL to meta-spec v2 and set dynamic_config to 0

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -15,15 +15,21 @@ WriteMakefile(
   AUTHOR       => 'Sebastian Riedel <sri@cpan.org>',
   LICENSE      => 'artistic_2',
   META_MERGE   => {
-    requires  => {perl => '5.010001'},
-    resources => {
-      license    => 'http://www.opensource.org/licenses/artistic-license-2.0',
+    dynamic_config => 0,
+    'meta-spec'    => {version => 2},
+    no_index       => {directory => ['examples', 't']},
+    prereqs        => {runtime => {requires => {perl => '5.010001'}}},
+    resources      => {
+      license    => ['http://www.opensource.org/licenses/artistic-license-2.0'],
       homepage   => 'http://mojolicio.us',
-      bugtracker => 'https://github.com/kraih/mojo/issues',
-      repository => 'https://github.com/kraih/mojo.git',
+      bugtracker => {web => 'https://github.com/kraih/mojo/issues'},
+      repository => {
+        type => 'git',
+        url  => 'https://github.com/kraih/mojo.git',
+        web  => 'https://github.com/kraih/mojo',
+      },
       x_IRC      => 'irc://irc.perl.org/#mojo'
     },
-    no_index => {directory => ['examples', 't']}
   },
   PREREQ_PM => {
     'IO::Socket::IP' => '0.26',

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -20,9 +20,9 @@ WriteMakefile(
     no_index       => {directory => ['examples', 't']},
     prereqs        => {runtime => {requires => {perl => '5.010001'}}},
     resources      => {
-      license    => ['http://www.opensource.org/licenses/artistic-license-2.0'],
-      homepage   => 'http://mojolicio.us',
       bugtracker => {web => 'https://github.com/kraih/mojo/issues'},
+      homepage   => 'http://mojolicio.us',
+      license    => ['http://www.opensource.org/licenses/artistic-license-2.0'],
       repository => {
         type => 'git',
         url  => 'https://github.com/kraih/mojo.git',


### PR DESCRIPTION
`dynamic_config` should really be disabled so that CPAN tools know that Mojolicious has static prerequisities (as per https://metacpan.org/pod/CPAN::Meta::Spec#dynamic_config). To do this, the `META_MERGE` contents are updated to follow v2 of the META spec. The diff of the resulting META.json with the current META.json is linked below.

https://gist.github.com/Grinnz/ca3f85988463e34b8118