### PR TITLE
More helpful diagnostic on failed connection

### DIFF
--- a/lib/Mojo/UserAgent.pm
+++ b/lib/Mojo/UserAgent.pm
@@ -116,7 +116,11 @@ sub _connect {
 
       # Connection error
       return unless $self;
-      return $self->_error($id, $err) if $err;
+      if ( $err ) {
+        return $self->_error( $id,
+          sprintf( 'Error connecting to %s://%s:%s/: %s',
+            $proto, $host, $port, $err ));
+      }
 
       # Connection established
       $stream->on(timeout => sub { $self->_error($id, 'Inactivity timeout') });


### PR DESCRIPTION
Consider:

    my $t = Test::Mojo->new('MyApp');
    $t->get_ok('admin_pages/my_page');

This fails on my Mac with the somewhat unhelpful error message:

    Can't connect: nodename nor servname provided, or not known

This change makes it clearer to the implementor that the problem is 'admin_pages' being treated as the hostname of a remote machine.