### PR TITLE
Optional dependency on Unicode::UTF8

### DIFF
--- a/lib/Mojo/Util.pm
+++ b/lib/Mojo/Util.pm
@@ -566,7 +566,10 @@ Convert C<CamelCase> string to C<snake_case> and replace C<::> with C<->.
 
   my $chars = decode 'UTF-8', $bytes;
 
-Decode bytes to characters and return C<undef> if decoding failed.
+Decode bytes to characters and return C<undef> if decoding failed. The optional
+module L<Unicode::UTF8> (0.58+) will be used automatically for UTF-8 decoding
+if possible. This feature can be disabled with the C<MOJO_NO_UUTF8> environment
+variable.
 
 =head2 deprecated
 
@@ -585,7 +588,9 @@ Dump a Perl data structure with L<Data::Dumper>.
 
   my $bytes = encode 'UTF-8', $chars;
 
-Encode characters to bytes.
+Encode characters to bytes. The optional module L<Unicode::UTF8> (0.58+) will
+be used automatically for UTF-8 encoding if possible. This feature can be
+disabled with the C<MOJO_NO_UUTF8> environment variable.
 
 =head2 hmac_sha1_sum
 

--- a/lib/Mojo/Util.pm
+++ b/lib/Mojo/Util.pm
@@ -16,7 +16,7 @@ use Time::HiRes ();
 # Faster UTF-8 processing requires Unicode::UTF8
 use constant UUTF8 => $ENV{MOJO_NO_UUTF8}
   ? 0
-  : eval 'use Unicode::UTF8 0.60 (); 1';
+  : eval 'use Unicode::UTF8 0.58 (); 1';
 
 # Check for monotonic clock support
 use constant MONOTONIC =>

--- a/lib/Mojo/Util.pm
+++ b/lib/Mojo/Util.pm
@@ -102,7 +102,7 @@ sub decode {
   my $fallback = sub {die};
   return undef
     unless (UUTF8 and $encoding eq 'UTF-8')
-    ? eval { $bytes = Unicode::UTF8::decode_utf8("$bytes", $fallback); 1 }
+    ? eval { $bytes = Unicode::UTF8::decode_utf8($bytes, $fallback); 1 }
     : eval { $bytes = _encoding($encoding)->decode("$bytes", 1); 1 };
   return $bytes;
 }
@@ -118,7 +118,7 @@ sub dumper {
 
 sub encode {
   (UUTF8 and $_[0] eq 'UTF-8')
-    ? Unicode::UTF8::encode_utf8("$_[1]")
+    ? Unicode::UTF8::encode_utf8($_[1])
     : _encoding($_[0])->encode("$_[1]");
 }
 

--- a/lib/Mojo/Util.pm
+++ b/lib/Mojo/Util.pm
@@ -99,10 +99,10 @@ sub decamelize {
 
 sub decode {
   my ($encoding, $bytes) = @_;
-  my $fallback = sub {die};
+  use warnings FATAL => 'utf8';
   return undef
     unless (UUTF8 and $encoding eq 'UTF-8')
-    ? eval { $bytes = Unicode::UTF8::decode_utf8($bytes, $fallback); 1 }
+    ? eval { $bytes = Unicode::UTF8::decode_utf8($bytes); 1 }
     : eval { $bytes = _encoding($encoding)->decode("$bytes", 1); 1 };
   return $bytes;
 }

--- a/lib/Mojo/Util.pm
+++ b/lib/Mojo/Util.pm
@@ -99,7 +99,7 @@ sub decamelize {
 
 sub decode {
   my ($encoding, $bytes) = @_;
-  my $fallback = sub {undef};
+  my $fallback = sub {die};
   return undef
     unless (UUTF8 and $encoding eq 'UTF-8')
     ? eval { $bytes = Unicode::UTF8::decode_utf8("$bytes", $fallback); 1 }

--- a/lib/Mojolicious/Command/version.pm
+++ b/lib/Mojolicious/Command/version.pm
@@ -3,6 +3,7 @@ use Mojo::Base 'Mojolicious::Command';
 
 use Mojo::IOLoop::Client;
 use Mojolicious;
+use Mojo::Util;
 
 has description => 'Show versions of available modules';
 has usage => sub { shift->extract_usage };
@@ -15,6 +16,7 @@ sub run {
   my $socks = $class->SOCKS ? $IO::Socket::Socks::VERSION : 'n/a';
   my $tls   = $class->TLS ? $IO::Socket::SSL::VERSION : 'n/a';
   my $ndn   = $class->NDN ? $Net::DNS::Native::VERSION : 'n/a';
+  my $uutf8 = Mojo::Util->UUTF8 ? $Unicode::UTF8::VERSION : 'n/a';
 
   print <<EOF;
 CORE
@@ -26,6 +28,7 @@ OPTIONAL
   IO::Socket::Socks 0.64+ ($socks)
   IO::Socket::SSL 1.94+   ($tls)
   Net::DNS::Native 0.15+  ($ndn)
+  Unicode::UTF8 0.58+     ($uutf8)
 
 EOF
 


### PR DESCRIPTION
Halves UTF-8 encoding roundtrip time in my naive benchmark:

```
perl -Ilib -Mojo -MMojo::Util=decode,encode -E'my $str = "\x{f1}"; n { decode "UTF-8", encode "UTF-8", $str } 1000000'
```