### PR TITLE
add callback to uniq method of collection

### DIFF
--- a/lib/Mojo/Collection.pm
+++ b/lib/Mojo/Collection.pm
@@ -93,8 +93,11 @@ sub tap { shift->Mojo::Base::tap(@_) }
 sub to_array { [@{shift()}] }
 
 sub uniq {
+  my ($self, $cb) = @_;
   my %seen;
-  return $_[0]->new(grep { !$seen{$_}++ } @{$_[0]});
+  return $self->new(grep { !$seen{ $cb->($_) }++ } @$self)
+    if ref $cb eq 'CODE';
+  return $self->new(grep { !$seen{$_}++ } @$self);
 }
 
 sub _flatten {
@@ -333,11 +336,16 @@ Turn collection into array reference.
 =head2 uniq
 
   my $new = $collection->uniq;
+  my $new = $collection->uniq(sub {...});
 
-Create a new collection without duplicate elements.
+Create a new collection without duplicate elements, using the string
+representation of either the elements or the return value of the callback.
 
   # "foo bar baz"
   Mojo::Collection->new('foo', 'bar', 'bar', 'baz')->uniq->join(' ');
+
+  # [[1, 2, 3]]
+  Mojo::Collection->new([1, 2, 3], [3, 2, 1])->uniq(sub{ $_->[1] })->to_array;
 
 =head1 SEE ALSO
 

--- a/t/mojo/collection.t
+++ b/t/mojo/collection.t
@@ -153,6 +153,9 @@ $collection = c(1, 2, 3, 2, 3, 4, 5, 4);
 is_deeply $collection->uniq->to_array, [1, 2, 3, 4, 5], 'right result';
 is_deeply $collection->uniq->reverse->uniq->to_array, [5, 4, 3, 2, 1],
   'right result';
+$collection = c([1, 2, 3], [3, 2, 1], [3, 1, 2]);
+is_deeply $collection->uniq(sub { $_->[1] }), [[1, 2, 3], [3, 1, 2]],
+  'right result';
 
 # TO_JSON
 is encode_json(c(1, 2, 3)), '[1,2,3]', 'right result';


### PR DESCRIPTION
This change adds a callback to the uniq method in Mojo::Collection, allowing users to define what constitutes a unique element. This permits collections of hashes and arrays to be de-duplicated, rather than just elements which stringify reasonably (strings, numbers, overloaded objects).