### PR TITLE
Fix incorrect html_unescape behaviour when $/ is set to \0 (Fixes #849)

### DIFF
--- a/lib/Mojo/Util.pm
+++ b/lib/Mojo/Util.pm
@@ -31,9 +31,12 @@ use constant {
 # To generate a new HTML entity table run this command
 # perl examples/entities.pl
 my %ENTITIES;
-while (my $line = <DATA>) {
-  next unless $line =~ /^(\S+)\s+U\+(\S+)(?:\s+U\+(\S+))?/;
-  $ENTITIES{$1} = defined $3 ? (chr(hex $2) . chr(hex $3)) : chr(hex $2);
+{
+  local $/ = "\n";
+  while (my $line = <DATA>) {
+    next unless $line =~ /^(\S+)\s+U\+(\S+)(?:\s+U\+(\S+))?/;
+    $ENTITIES{$1} = defined $3 ? (chr(hex $2) . chr(hex $3)) : chr(hex $2);
+  }
 }
 
 # Characters that should be escaped in XML

--- a/t/mojo/util-extra.t
+++ b/t/mojo/util-extra.t
@@ -1,0 +1,15 @@
+use Mojo::Base -strict;
+
+use FindBin;
+use lib "$FindBin::Bin/lib";
+use Test::More;
+
+{ # Test for https://github.com/kraih/mojo/issues/849
+  local $/ = "\0";
+  require Mojo::Util;
+  # html_unescape (nothing to unescape)
+  is Mojo::Util::html_unescape('&amp;'),
+    '&', 'right HTML unescaped result';
+}
+
+done_testing();


### PR DESCRIPTION
When `$/` is modified, `<DATA>` is read differently, and thus `%ENTITIES` is not populated correctly.

I created a new test file, because just putting that test into `util.t` did not work (since Mojo::Util was already loaded by that point using a different `$/`).

I grepped the distro for `__DATA__` and this instance seems to be the only one with this bug.