### PR TITLE
JSON pointer: fix '/foo/'

### DIFF
--- a/lib/Mojo/JSON/Pointer.pm
+++ b/lib/Mojo/JSON/Pointer.pm
@@ -13,7 +13,7 @@ sub _pointer {
 
   my $data = $self->data;
   return $data unless $pointer =~ s!^/!!;
-  for my $p ($pointer eq '' ? ($pointer) : (split '/', $pointer)) {
+  for my $p ($pointer eq '' ? ($pointer) : (split '/', $pointer, -1)) {
     $p =~ s!~1!/!g;
     $p =~ s/~0/~/g;
 


### PR DESCRIPTION
`/foo/` must return `42` in `{'foo' => { '' => 42}}`.
The bug is due to an edge case of Perl's [`split`](http://perldoc.perl.org/perlfunc.html#split).