### PR TITLE
Allow test descriptions in 1-arg version of json_is and json_message_is

### DIFF
--- a/lib/Test/Mojo.pm
+++ b/lib/Test/Mojo.pm
@@ -164,7 +164,7 @@ sub json_hasnt {
 
 sub json_is {
   my $self = shift;
-  my ($p, $data) = @_ > 1 ? (shift, shift) : ('', shift);
+  my ($p, $data) = ref $_[0] ? ('', shift) : (shift, shift);
   my $desc = encode 'UTF-8', shift || qq{exact match for JSON Pointer "$p"};
   return $self->_test('is_deeply', $self->tx->res->json($p), $data, $desc);
 }
@@ -189,7 +189,7 @@ sub json_message_hasnt {
 
 sub json_message_is {
   my $self = shift;
-  my ($p, $data) = @_ > 1 ? (shift, shift) : ('', shift);
+  my ($p, $data) = ref $_[0] ? ('', shift) : (shift, shift);
   my $desc = encode 'UTF-8', shift || qq{exact match for JSON Pointer "$p"};
   return $self->_test('is_deeply', $self->_json(get => $p), $data, $desc);
 }

--- a/lib/Test/Mojo.pm
+++ b/lib/Test/Mojo.pm
@@ -164,7 +164,7 @@ sub json_hasnt {
 
 sub json_is {
   my $self = shift;
-  my ($p, $data) = ref $_[0] ? ('', shift) : (shift, shift);
+  my ($p, $data) = ref $_[0] || @_ == 1 ? ('', shift) : (shift, shift);
   my $desc = encode 'UTF-8', shift || qq{exact match for JSON Pointer "$p"};
   return $self->_test('is_deeply', $self->tx->res->json($p), $data, $desc);
 }
@@ -189,7 +189,7 @@ sub json_message_hasnt {
 
 sub json_message_is {
   my $self = shift;
-  my ($p, $data) = ref $_[0] ? ('', shift) : (shift, shift);
+  my ($p, $data) = ref $_[0] || @_ == 1 ? ('', shift) : (shift, shift);
   my $desc = encode 'UTF-8', shift || qq{exact match for JSON Pointer "$p"};
   return $self->_test('is_deeply', $self->_json(get => $p), $data, $desc);
 }


### PR DESCRIPTION
The '1-arg' version of json_is and json_message_is does not accept a description, due to how the params are pulled off of `@_`.

So what would seem intuitive:

`$t->json_is( { foo => [1, 2, 3] }, 'a simple test' );`

does not actually work.

This patch fixes that. All existing tests pass.

For this small change, additional tests may be unnecessary?