### PR TITLE
Fix JavaScript errors when links in TOC have special characters

### DIFF
--- a/lib/Mojolicious/resources/templates/mojo/menubar.html.ep
+++ b/lib/Mojolicious/resources/templates/mojo/menubar.html.ep
@@ -82,8 +82,11 @@
 <script>
   var mojobar = $('#mojobar');
   var mojobarHeight = mojobar.outerHeight();
+  function getElementByHash(hash){
+    return $(hash.replace(/(:|\.|\[|\]|,)/g, '\\$1'));
+  }
   function fixOffset() {
-    var offset = $(window.location.hash).offset();
+    var offset = getElementByHash(window.location.hash).offset();
     if (offset) {
       $('html, body').animate({scrollTop: offset.top - mojobarHeight}, 1);
     }
@@ -128,11 +131,11 @@
     $('.mojoscroll').click(function (e) {
       e.preventDefault();
       e.stopPropagation();
-      var anchor = this.href.split('#')[1];
-      var target = $(document.getElementById(anchor));
+      var anchor = '#' + this.href.split('#')[1];
+      var target = getElementByHash(anchor);
       var old    = target.attr('id');
       target.attr('id', '');
-      location.hash = '#' + anchor.replace(/(:|\.|\[|\]|,)/g, "\\$1");
+      location.hash = anchor;
       target.attr('id', old);
       fixOffset();
     });


### PR DESCRIPTION
This fixes the JS error when clicking on PODRenderer rendered table of contents, when links contain special characters. Relevant IRC Conversation: http://irclog.perlgeek.de/mojo/2015-11-03#i_11475962

Tested on:
* Palemoon 24.6.2
* IE10, Windows 7
* IE11, Windows 8.1
* Firefox 43
* Chrome 47 Dev
* Opera 32
* Safari 9, OSX EL Capitan
* Safari 5.1, Windows 10