### PR TITLE
Fixed url_for to handle route named against package namespaces

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,6 @@
 
 6.30  2015-11-04
+  - Fixed url_for to handle route named against package namespaces.
 
 6.29  2015-11-03
   - Fixed a few bugs in built-in templates. (Zoffix, sri)

--- a/lib/Mojolicious/Controller.pm
+++ b/lib/Mojolicious/Controller.pm
@@ -295,7 +295,7 @@ sub url_for {
 
   # Absolute URL
   return $target if Scalar::Util::blessed $target && $target->isa('Mojo::URL');
-  return Mojo::URL->new($target) if $target =~ m!^(?:[^:/?#]+:|//)!;
+  return Mojo::URL->new($target) if $target =~ m!^(?:[^:/?#]+:[^:]|//)!;
 
   # Base
   my $url  = Mojo::URL->new;

--- a/t/mojolicious/app.t
+++ b/t/mojolicious/app.t
@@ -68,6 +68,8 @@ is $t->app->build_controller->render_to_string('does_not_exist'), undef,
   'no result';
 is $t->app->build_controller->render_to_string(inline => '%= $c', c => 'foo'),
   "foo\n", 'right result';
+is ref $t->app->routes->find('Package::Namespace'), 'Mojolicious::Routes::Route',
+  'right class';
 
 # Missing methods and functions (AUTOLOAD)
 eval { $t->app->missing };
@@ -322,6 +324,10 @@ $t->get_ok('/somethingtest?_method=PUT' => {'X-Test' => 'Hi there!'})
 # Foo::url_for_missing
 $t->get_ok('/something_missing' => {'X-Test' => 'Hi there!'})->status_is(200)
   ->header_is(Server => 'Mojolicious (Perl)')->content_is('does_not_exist');
+
+# Foo::url_for_namespace
+$t->get_ok('/package/namespace' => {'X-Test' => 'Hi there!'})->status_is(200)
+  ->header_is(Server => 'Mojolicious (Perl)')->content_is('/package/namespace');
 
 # Foo::templateless
 $t->get_ok('/foo/templateless' => {'X-Test' => 'Hi there!'})->status_is(200)

--- a/t/mojolicious/lib/MojoliciousTest.pm
+++ b/t/mojolicious/lib/MojoliciousTest.pm
@@ -91,6 +91,9 @@ sub startup {
   # /something_missing (refer to a non-existing route with url_for)
   $r->route('/something_missing')->to('foo#url_for_missing');
 
+  # /package/namespace (use package namespace with url_for)
+  $r->route('/package/namespace')->to('foo#url_for_namespace')->name("Package::Namespace");
+
   # /test3 (no class, just a namespace)
   $r->route('/test3')
     ->to(namespace => 'MojoliciousTestController', action => 'index');

--- a/t/mojolicious/lib/MojoliciousTest/Foo.pm
+++ b/t/mojolicious/lib/MojoliciousTest/Foo.pm
@@ -90,6 +90,11 @@ sub url_for_missing {
   $self->render(text => $self->url_for('does_not_exist', something => '42'));
 }
 
+sub url_for_namespace {
+  my $self = shift;
+  $self->render(text => $self->url_for('Package::Namespace'));
+}
+
 sub willdie { die 'for some reason' }
 
 sub withBlock { shift->render(template => 'withblock') }

--- a/t/mojolicious/lite_app.t
+++ b/t/mojolicious/lite_app.t
@@ -300,6 +300,11 @@ any '/something' => sub {
   $c->render(text => 'Just works!');
 };
 
+any '/package/namespace' => sub {
+  my $c = shift;
+  $c->render(text => $c->url_for("Package::Namespace"));
+} => "Package::Namespace";
+
 any [qw(get post whatever)] => '/something/else' => sub {
   my $c = shift;
   $c->render(text => 'Yay!');
@@ -823,6 +828,12 @@ $t->request_ok($t->ua->build_tx(WHATEVER => '/something/else'))->status_is(200)
   ->header_is(Server => 'Mojolicious (Perl)')->content_is('Yay!');
 $t->delete_ok('/something/else')->status_is(404)
   ->header_is(Server => 'Mojolicious (Perl)')->content_like(qr/Oops!/);
+
+# Route named against package namespaces
+$t->get_ok('/package/namespace')->status_is(200)
+  ->header_is(Server => 'Mojolicious (Perl)')
+  ->content_is('/package/namespace');
+is $t->app->url_for("Package::Namespace"), "/package/namespace";
 
 # Regex constraint
 $t->get_ok('/regex/23')->status_is(200)

--- a/t/mojolicious/routes.t
+++ b/t/mojolicious/routes.t
@@ -129,6 +129,9 @@ $inline->route('/delete')
   ->to(controller => 'articles', action => 'delete', format => undef)
   ->name('articles_delete');
 
+# Two consecutive colons in route name
+$r->route('/package/namespace')->name("Package::Namespace");
+
 # GET /method/get
 $r->route('/method/get')->via('GET')
   ->to(controller => 'method', action => 'get');
@@ -258,6 +261,10 @@ is $r->find('articles_delete')->to_string, '/articles/:id/delete',
   'right pattern';
 is $r->find('nodetect')->pattern->constraints->{format}, 0, 'right value';
 is $r->find('nodetect')->to->{controller}, 'foo', 'right controller';
+
+# Package namespaces (with consecutive colons) as route name
+is $r->find("Package::Namespace")->to_string, '/package/namespace';
+is $r->lookup("Package::Namespace")->to_string, '/package/namespace';
 
 # Null route
 $m = Mojolicious::Routes::Match->new(root => $r);


### PR DESCRIPTION
My application uses route names generated by the package namespaces (REST framework).

My problem is I can't use `url_for` in controllers because the regex url considers colon presence as an absolute URL. The patch changes now the regex to refuse two consecutive colons in the URL detection.

Are you interested in merging this pull request ?

I tried to add some tests in the codebase but I fear unnecessary code.