### PR TITLE
Add items_in helper

### DIFF
--- a/lib/Mojolicious/Plugin/DefaultHelpers.pm
+++ b/lib/Mojolicious/Plugin/DefaultHelpers.pm
@@ -34,6 +34,14 @@ sub register {
 
   $app->helper(dumper => sub { shift; dumper @_ });
   $app->helper(include => sub { shift->render_to_string(@_) });
+  $app->helper(
+    items_in => sub {
+      my ($c, $what) = @_;
+      return unless defined $what;
+      $what = $c->stash($what) // [] unless ref $what;
+      return @$what;
+    }
+  );
 
   $app->helper("reply.$_" => $self->can("_$_")) for qw(asset static);
 
@@ -374,6 +382,15 @@ response headers with L<Mojolicious::Static/"is_fresh">.
   $c->is_fresh(etag => 'abc', last_modified => 1424985708)
     ? $c->rendered(304)
     : $c->render(text => 'I ♥ Mojolicious!');
+
+=head2 items_in
+
+  % if  ( items_in 'stash_variable' ) { ... }
+  % for ( items_in $array_ref ) { ... }
+
+Dereference an array reference. If the passed argument is not a reference,
+it is given to L<Mojolicious::Controller/"stash"> and the return value
+is dereferenced instead.
 
 =head2 layout
 


### PR DESCRIPTION
This PR introduces the `items_in` Default Helper. I wasn't sure where the tests for it should be placed; let me know and I'll add them.

### Use Case

The use case is to make your templates code more concise and easier to read, when dealing with arrayrefs (potentially stored in the `stash`). Here are some of the examples that demonstrate the code with and without the proposed `items_in` helper:

Without:
```
% if ( @{stash('entries') || []} ) {
  % for ( @{stash('entries') || []} ) {
    ...
  % }
% }
```
With:
```
% if ( items_in 'entries' ) {
  % for ( items_in 'entries' ) {
    ...
  % }
% }
```

Without:
```
% for ( @{flash('entries') || []} ) {
  ...
% }
```

With:
```
% for ( items_in flash 'entries' ) {
  ...
% }
```

Without:
```
% for ( @{$some->{var} || []} ) {
  ...
% }
```

With:
```
% for ( items_in $some->{var} ) {
  ...
% }
```