### PR TITLE
Allow developers to override url_escape() chars

### DIFF
--- a/lib/Mojo/Path.pm
+++ b/lib/Mojo/Path.pm
@@ -10,6 +10,9 @@ use Mojo::Util qw(decode encode url_escape url_unescape);
 
 has charset => 'UTF-8';
 
+# Allow developers to override which characters AREN'T url_escape()-ed
+our $url_escape_chars = '^A-Za-z0-9\-._~!$&\'*+,;=:@()';
+
 sub canonicalize {
   my $self = shift;
 
@@ -90,14 +93,14 @@ sub to_string {
   my $charset = $self->charset;
   if (defined(my $path = $self->{path})) {
     $path = encode $charset, $path if $charset;
-    return url_escape $path, '^A-Za-z0-9\-._~!$&\'()*+,;=%:@/';
+    return url_escape $path, $url_escape_chars . '%/';
   }
 
   # Build path
   my @parts = @{$self->parts};
   @parts = map { encode $charset, $_ } @parts if $charset;
   my $path = join '/',
-    map { url_escape $_, '^A-Za-z0-9\-._~!$&\'()*+,;=:@' } @parts;
+    map { url_escape $_, $url_escape_chars } @parts;
   $path = "/$path" if $self->leading_slash;
   $path = "$path/" if $self->trailing_slash;
   return $path;


### PR DESCRIPTION
This is to "fix" a problem with URLs that included %28/%29 parentheses.  For example:
```
  $self->redirect_to("http://example.org/foo%20%28bar%29.txt");
```
would always send back:
```
  302 Found
  Location: http://example.org/foo%20(bar).txt
```
Although that's not *strictly* invalid, I was having trouble downstream, where a third-party app [over which I have no control] was cutting it off, thusly:
```
  BAD:  <a href="http://example.org/foo%20">foo </a>(bar).txt

  GOOD: <a href="http://example.org/foo%20%28bar%29.txt">foo (bar).txt</a>
```
Rather than hard-coding a different set of escape characters globally, which has the potential to break something, this patch allows developers to remove those characters -- or add other ones -- if they choose:
```
  $app->hook( after_dispatch => sub {
      $Mojo::Path::url_escape_chars =~ s/[()]//g;
  } );
```