### PR TITLE
Allow to include templates which are extending same template

### DIFF
--- a/lib/Mojolicious/Renderer.pm
+++ b/lib/Mojolicious/Renderer.pm
@@ -89,6 +89,8 @@ sub render {
   my $stash = $c->stash;
   local $stash->{layout}  = $stash->{layout}  if exists $stash->{layout};
   local $stash->{extends} = $stash->{extends} if exists $stash->{extends};
+  local $stash->{ 'mojo.content' } ||=  {};
+
 
   # Rendering to string
   local @{$stash}{keys %$args} if my $string = delete $args->{'mojo.string'};


### PR DESCRIPTION
```
$ cat t1.html.ep
% content test => begin
   BASE
% end
$ cat t2.html.ep
% extends 't1';
% content test => begin
  T2
%
$ cat t3.html.ep
% extends 't1';
% content test => begin
  T3
%
$ cat t4.thml.ep
%= include 't2';
%= include 't3';
```
Trying ot rendre 't4' will result:
T2
T2

Insteand of expected:
T2
T3


I have not change, but you should pay attention to Renderer.pm:136 and Plugin/DefaultHelpers.pm:58 lines. This is critical. 
If template we are including (T2) will define 'mojo.content' ( % content test in example ) this will have global effect and will prevent 'content test' definition in template (T3) in same way as it prevent for extending tempalte (T1)

Same effect exists also for 'layout', 'extends' so you should check Renderer.pm:90-91 lines.