### PR TITLE
Do not affect content of including template

### DIFF
--- a/lib/Mojolicious/Renderer.pm
+++ b/lib/Mojolicious/Renderer.pm
@@ -89,6 +89,8 @@ sub render {
   my $stash = $c->stash;
   local $stash->{layout}  = $stash->{layout}  if exists $stash->{layout};
   local $stash->{extends} = $stash->{extends} if exists $stash->{extends};
+  local $stash->{'mojo.content'} ||= {} if $args->{'mojo.string'};
+
 
   # Rendering to string
   local @{$stash}{keys %$args} if my $string = delete $args->{'mojo.string'};

--- a/t/mojolicious/include_extends.t
+++ b/t/mojolicious/include_extends.t
@@ -1,0 +1,64 @@
+use Mojo::Base -strict;
+
+BEGIN {
+  $ENV{MOJO_MODE}    = 'testing';
+  $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll';
+}
+
+use Test::More;
+use Mojolicious::Lite;
+use Test::Mojo;
+
+my $t = Test::Mojo->new;
+
+get '/' => 'main';
+
+# When we include some template we want its content. So $stash->{'mojo.content'}
+# shoould be localized.
+# Without that when our main template *occasionally* has content with same name
+# this will prevent the template we are inluding to generate its own
+# Even if we include two templates which have contents with same name the first
+# template will prevent following to generate right content. In large system
+# things goes too wired and complex to debug
+$t->get_ok('/')->status_is(200)
+  ->content_is(<<CONTENT);
+  MAIN
+
+  BASE
+
+
+  T1
+
+
+  T2
+
+
+CONTENT
+
+done_testing();
+
+
+__DATA__
+@@ base.html.ep
+% content test => begin
+  BASE
+% end
+%= content 'test';
+@@ t1.html.ep
+% extends 'base';
+% content test => begin
+  T1
+% end
+@@ t2.html.ep
+% extends 'base';
+% content test => begin
+  T2
+% end
+@@ main.html.ep
+% content test => begin
+  MAIN
+% end
+%= content 'test';
+%= include 'base';
+%= include 't1';
+%= include 't2';


### PR DESCRIPTION
When we include some template we want its content. So $stash->{'mojo.content'}
shoould be localized.

Without that when our main template **occasionally** has content with same name
this will prevent the template we are including to generate its own
Even if we include two templates which have contents with same name the first
one will prevent following to generate right content.
In large system things goes too wired and complex to debug


https://github.com/kraih/mojo/pull/902