### PR TITLE
Mojo::Pointer should throw an error when JSON Pointer is missing a s…

### DIFF
--- a/lib/Mojo/JSON/Pointer.pm
+++ b/lib/Mojo/JSON/Pointer.pm
@@ -1,5 +1,6 @@
 package Mojo::JSON::Pointer;
 use Mojo::Base -base;
+use Mojo::Exception;
 
 has 'data';
 
@@ -10,6 +11,8 @@ sub new { @_ > 1 ? shift->SUPER::new(data => shift) : shift->SUPER::new }
 
 sub _pointer {
   my ($self, $contains, $pointer) = @_;
+
+  Mojo::Exception->throw(__PACKAGE__.": Invalid JSON Pointer '$pointer'. Pointer must start with '/' or be undefined") if ($pointer && $pointer =~ /^[^\/].+/);
 
   my $data = $self->data;
   return $contains ? 1 : $data unless $pointer =~ s!^/!!;

--- a/t/mojo/json_pointer.t
+++ b/t/mojo/json_pointer.t
@@ -102,4 +102,10 @@ is $pointer->get('/k"l'),   6,     '"/k\\"l" is 6';
 is $pointer->get('/ '),     7,     '"/ " is 7';
 is $pointer->get('/m~0n'),  8,     '"/m~0n" is 8';
 
+# catch invalid pointer reference-tokens
+eval {
+  $pointer->get('no_slash');
+};
+ok $@ =~ /Invalid JSON Pointer 'no_slash'/, 'reference-token must start with "/"';
+
 done_testing();


### PR DESCRIPTION
…tarting '/' (against RFC 6901)

Hi!

I have a JSON object, which had a bug:

`
{
  "type": "object",
  "properties": {
    "listContentNumber": { "$ref": "../definitions.json#listContentNumber" },
    "biblionumber": { "$ref": "../definitions.json#/biblionumber" },
    "itemnumber": { "$ref": "../definitions.json#/itemnumber" },
    "borrowernumber": { "$ref" : "../definitions.json#/borrowernumber" }
  }
}
`

can you spot it?
Mojo::Pointer couldn't, and I hope you can accept my solution to improve it.

Looking into the ietf specification for JSON Pointer:
    http://tools.ietf.org/html/rfc6901#section-3
if the pointer has a 'reference-token', it MUST be prepended by a '/'-character.

  **>   json-pointer = *( "/" reference-token )   <**
  * any number of "/" + reference-token -tokens are allowed, but if the reference-token is defined,
  * the prepending "/" is mandatory and the JSON Pointer implementation SHOULD throw an error.

for example this is invalid:
    { "$ref": "../definitions.json#listContentNumber" }
whereas this is valid:
    { "$ref": "../definitions.json#/listContentNumber" }

If the reference-token doesn't 'start' with '/' then it returns the whole data-object!
It should check for pointer validity and die instead.