### PR TITLE
make csrf_protect handle multiple tokens

### DIFF
--- a/lib/Mojolicious/Validator/Validation.pm
+++ b/lib/Mojolicious/Validator/Validation.pm
@@ -37,6 +37,7 @@ sub check {
 sub csrf_protect {
   my $self  = shift;
   my $token = $self->input->{csrf_token};
+  $token = ref $token eq 'ARRAY' ? $token->[-1] : $token;
   $self->error(csrf_token => ['csrf_protect'])
     unless $token && $token eq ($self->csrf_token // '');
   return $self;

--- a/t/mojolicious/validation_lite_app.t
+++ b/t/mojolicious/validation_lite_app.t
@@ -227,6 +227,15 @@ $validation = $t->app->validation->input({csrf_token => 'abc', foo => 'bar'})
 ok !$validation->has_error, 'no error';
 ok $validation->required('foo')->is_valid, 'valid';
 is_deeply $validation->output, {foo => 'bar'}, 'right result';
+$validation = $t->app->validation->input({csrf_token => 'abc', csrf_token => 'def', foo => 'bar'})
+  ->csrf_token('abc')->csrf_protect;
+ok $validation->has_error, 'has error';
+is_deeply $validation->error('csrf_token'), ['csrf_protect'], 'right error';
+$validation = $t->app->validation->input({csrf_token => 'def', csrf_token => 'abc', foo => 'bar'})
+  ->csrf_token('abc')->csrf_protect;
+ok !$validation->has_error, 'no error';
+ok $validation->required('foo')->is_valid, 'valid';
+is_deeply $validation->output, {foo => 'bar'}, 'right result';
 
 # Missing method and function (AUTOLOAD)
 eval { $t->app->validation->missing };


### PR DESCRIPTION
Currently csrf_protect will always fail if more than one input called csrf_token is present. It would be more intuitive if it always checks the last value like param, which I have implemented in this pull request.

You could argue that it should be an error to have multiple csrf_token's, but then it should still be explicitly checked for in my opinion.