### PR TITLE
Cookbook: Add WebSocket configuration to Apache example.

### DIFF
--- a/lib/Mojolicious/Guides/Cookbook.pod
+++ b/lib/Mojolicious/Guides/Cookbook.pod
@@ -195,6 +195,7 @@ newer versions.
 
 Another good reverse proxy is L<Apache|http://httpd.apache.org> with
 C<mod_proxy>, the configuration looks quite similar to the Nginx one above.
+If you want WebSocket support, newer versions come with C<mod_proxy_wstunnel>.
 
   <VirtualHost *:80>
     ServerName localhost
@@ -204,6 +205,8 @@ C<mod_proxy>, the configuration looks quite similar to the Nginx one above.
     </Proxy>
     ProxyRequests Off
     ProxyPreserveHost On
+    # If you need multiple ProxyPass definitions, list longest path first
+    ProxyPass /ws ws://localhost:8080/ws
     ProxyPass / http://localhost:8080/ keepalive=On
     ProxyPassReverse / http://localhost:8080/
     RequestHeader set X-Forwarded-Proto "http"


### PR DESCRIPTION
Apache mod_proxy and mod_proxy_wstunnel supports proxying WebSockets, so this adds a configuration example to the Cookbook.