### PR TITLE
Return right default value for checkbox/radiobutton

### DIFF
--- a/lib/Mojolicious/Plugin/TagHelpers.pm
+++ b/lib/Mojolicious/Plugin/TagHelpers.pm
@@ -71,7 +71,7 @@ sub _input {
   if (@values && $type ne 'submit') {
 
     # Checkbox or radiobutton
-    my $value = $attrs{value} // '';
+    my $value = $attrs{value} // 'on';
     if ($type eq 'checkbox' || $type eq 'radio') {
       $attrs{value} = $value;
       delete $attrs{checked} if @values;

--- a/t/mojolicious/tag_helper_lite_app.t
+++ b/t/mojolicious/tag_helper_lite_app.t
@@ -24,6 +24,8 @@ get '/basicform';
 
 post '/text';
 
+post '/check_box_no_value';
+
 get '/multibox';
 
 get 'form/:test' => 'form';
@@ -209,6 +211,13 @@ $t->post_ok(
 EOF
 
 # Checkboxes
+$t->post_ok('/check_box_no_value' => form => { foo => 'on' }
+)->status_is(200)->content_is(<<EOF);
+<form action="/check_box_no_value" method="POST">
+  <input checked name="foo" type="checkbox" value="on">
+</form>
+EOF
+
 $t->get_ok('/multibox')->status_is(200)->content_is(<<EOF);
 <form action="/multibox">
   <input name="foo" type="checkbox" value="one">
@@ -584,6 +593,11 @@ __DATA__
   %= url_field url => 'http://mojolicious.org', class => 'foo'
   %= week_field week => '2012-W16', class => 'foo'
   %= submit_button
+%= end
+
+@@ check_box_no_value.html.ep
+%= form_for check_box_no_value => begin
+  %= check_box 'foo'
 %= end
 
 @@ multibox.html.ep


### PR DESCRIPTION
As stated at: https://www.w3.org/TR/html5/forms.html#input-type-attr-summary
for checkbox/radiobutton to IDL attribute 'value' should be applied 'default/on'
method: https://www.w3.org/TR/html5/forms.html#dom-input-value-default-on

On getting, if the element has a value attribute, it must return that
attribute's value; otherwise, it must return the string "on"