### PR TITLE
Preserve explicit 'content' in template

### DIFF
--- a/lib/Mojolicious/Renderer.pm
+++ b/lib/Mojolicious/Renderer.pm
@@ -132,7 +132,8 @@ sub render {
 
   # Inheritance
   my $content = $stash->{'mojo.content'} ||= {};
-  local $content->{content} = $output if $stash->{extends} || $stash->{layout};
+  local $content->{content} = $content->{content} // $output
+    if $stash->{extends} || $stash->{layout};
   while ((my $next = _next($stash)) && !defined $inline) {
     @$options{qw(handler template)} = ($stash->{handler}, $next);
     $options->{format} = $stash->{format} || $self->default_format;

--- a/t/mojolicious/layouted_lite_app.t
+++ b/t/mojolicious/layouted_lite_app.t
@@ -51,6 +51,8 @@ get '/double_inheritance' =>
 
 get '/triple_inheritance';
 
+get '/triple_inheritance_explicit_content';
+
 get '/mixed_inheritance/first' => {template => 'first'};
 
 get '/mixed_inheritance/second' => {template => 'second', layout => 'green'};
@@ -197,6 +199,12 @@ $t->get_ok('/double_inheritance')->status_is(200)
 
 # Triple inheritance
 $t->get_ok('/triple_inheritance')->status_is(200)
+  ->header_is(Server => 'Mojolicious (Perl)')
+  ->content_is("<title>Works!</title>\n<br>\nSidebar too!\n"
+    . "New <content>.\nShared content!\n\nDefault footer!\n");
+
+# Triple inheritance with explicit content
+$t->get_ok('/triple_inheritance_explicit_content')->status_is(200)
   ->header_is(Server => 'Mojolicious (Perl)')
   ->content_is("<title>Works!</title>\n<br>\nSidebar too!\n"
     . "New <content>.\nShared content!\n\nDefault footer!\n");
@@ -391,6 +399,13 @@ Sidebar too!
 % extends 'double_inheritance';
 New <content>.
 %= content_for 'stuff'
+
+@@ triple_inheritance_explicit_content.html.ep
+% extends 'double_inheritance';
+% content content => begin
+New <content>.
+%= content_for 'stuff'
+% end
 
 @@ layouts/plugin_with_template.html.ep
 layout_with_template


### PR DESCRIPTION
if template which extends define its own content explicitly:
```
% extends 'base';




% content content => begin
TEST
%end
```

the content block will be unconditionally replaced by empty lines from this template.
Some output from debugger:
```
DBG>e $content
{ content => sub { ... } }
DBG>n
./lib/Mojolicious/Renderer.pm
105:   local $content->{content} = $output if $stash->{extends} || $stash->{layout};
DBG>e $content
{ content => "\n\n\n\n\n\n\n" }
```

https://github.com/kraih/mojo/commit/0f3f6d8b