### PR TITLE
add ->modified_files, deprecate ->check

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 
 6.55  2016-03-07
+  - Added modified_files method to Mojo::Server::Morbo.
+  - Deprecated Mojo::Server::Morbo::check.
 
 6.54  2016-03-06
   - Deprecated Mojo::Template::build and Mojo::Template::compile.

--- a/t/mojo/morbo.t
+++ b/t/mojo/morbo.t
@@ -25,7 +25,7 @@ my $script = catfile $dir, 'myapp.pl';
 my $subdir = catdir $dir, 'test', 'stuff';
 mkpath $subdir;
 my $morbo = Mojo::Server::Morbo->new(watch => [$subdir, $script]);
-is $morbo->check, undef, 'file has not changed';
+ok !@{$morbo->modified_files}, 'file has not changed';
 spurt <<EOF, $script;
 use Mojolicious::Lite;
 
@@ -67,7 +67,7 @@ get '/hello' => {text => 'Hello World!'};
 
 app->start;
 EOF
-is $morbo->check, $script, 'file has changed';
+is $morbo->modified_files->[0], $script, 'file has changed';
 ok((stat $script)[9] > $mtime, 'modify time has changed');
 is((stat $script)[7], $size, 'still equal size');
 sleep 3;
@@ -86,7 +86,7 @@ is $tx->res->body, 'Hello World!', 'right content';
 
 # Update script without changing mtime
 ($size, $mtime) = (stat $script)[7, 9];
-is $morbo->check, undef, 'file has not changed';
+ok !@{$morbo->modified_files}, 'file has not changed';
 spurt <<EOF, $script;
 use Mojolicious::Lite;
 
@@ -97,7 +97,7 @@ get '/hello' => {text => 'Hello!'};
 app->start;
 EOF
 utime $mtime, $mtime, $script;
-is $morbo->check, $script, 'file has changed';
+is $morbo->modified_files->[0], $script, 'file has changed';
 ok((stat $script)[9] == $mtime, 'modify time has not changed');
 isnt((stat $script)[7], $size, 'size has changed');
 sleep 3;
@@ -114,12 +114,13 @@ ok $tx->is_finished, 'transaction is finished';
 is $tx->res->code, 200,      'right status';
 is $tx->res->body, 'Hello!', 'right content';
 
-# New file
-is $morbo->check, undef, 'directory has not changed';
-my $new = catfile $subdir, 'test.txt';
-spurt 'whatever', $new;
-is $morbo->check, $new, 'directory has changed';
-is $morbo->check, undef, 'directory has not changed again';
+# New file(s)
+ok !@{$morbo->modified_files}, 'directory has not changed';
+my @new = map { catfile $subdir, "$_.txt" } qw/test testing/;
+spurt 'whatever', $_ for @new;
+my %modified_files = map { $_ => 1 } @{$morbo->modified_files};
+ok $modified_files{$_}, 'directory has changed' for @new;
+ok !@{$morbo->modified_files}, 'directory has not changed again';
 
 # Stop
 kill 'INT', $pid;


### PR DESCRIPTION
Squashed commit of the following:

commit a210794ca2b27848fb03857be131b4a24b771899
Author: Lee Johnson <lee@givengain.ch>
Date:   Tue Mar 8 09:28:24 2016 +0100

    add ->modified_files, deprecate ->check

    in Mojo::Server::Morbo - allows retrieval of entire list of files
    changed (or undef) preventing morbo getting into a restart loop if
    many files have changed. ->check is now redundant so deprecated

    update tests in t/mojo/morbo.t tp reflect above changes

commit 3345a9d48e9f43d1111ae7e20b589ec1a9fd6d2c
Author: Andrew Nugged <nugged@gmail.com>
Date:   Mon Mar 7 23:00:19 2016 +0200

    Handle multiple changed files at once for restart

    If you change numerous files at once or one-by-one in second(s),
    Morbo saw first file changed and tried to restart right away
    (though meanwhile restart process started, it can catch few files
    more on next "sleep 1"), but then after restart Morbo finds next one
    or next few changed files, not updated in cache, and restarts again
    until all cached files iterated.

    That causes Morbo to restart many times if you, for example, do checkout
    for git branch where many files different or upload/sync pack of files
    through sftp at once, etc.

    Changes in code: now changed files names packed in array in one pass,
    not returning after first met, and only returning that array. That
    updates cache for all files, then calls restart.

    Also notification message printed to console with one file name if only
    one changed, that is for our usual work mode (when we uploaded one file
    from editor), or give number of changed files only if we do mass change
    (branch checkout, mass sync).