### PR TITLE
Update Routing.pod

### DIFF
--- a/lib/Mojolicious/Guides/Routing.pod
+++ b/lib/Mojolicious/Guides/Routing.pod
@@ -565,7 +565,7 @@ authentication.
     return 1 if $c->req->headers->header('X-Bender');
 
     # Not authenticated
-    $c->render(text => "You're not Bender.");
+    $c->render(text => "You're not Bender.", status => 401);
     return undef;
   });
   $auth->get('/blackjack')->to('hideout#blackjack');


### PR DESCRIPTION
`$t->post_ok('/blackjack')->status_code(200);`

The current "under" example in this guide, does not specify a specific status code.  So a test like this passes even though the "under" function failed which was not expected (could just be me).  I realize I could test the content of the failure but seems useful to check the status codes as well.

I thought it might be useful to show how the failure of the "under" function could be used to return a different status code.  

```
$t->get_ok('/blackjack')->status_code(401);
$t->get_ok('/blackjack' => { 'X-Bender' => 1 })->status_code(200);
```