### PR TITLE
validations turn single value array ref inputs into scalar outputs

### DIFF
--- a/lib/Mojolicious/Validator/Validation.pm
+++ b/lib/Mojolicious/Validator/Validation.pm
@@ -72,7 +72,7 @@ sub optional {
   for my $cb (map { $self->validator->filters->{$_} } @filters) {
     @input = map { $self->$cb($name, $_) } @input;
   }
-  $self->output->{$name} = @input > 1 ? \@input : $input[0]
+  $self->output->{$name} = ref $input eq 'ARRAY' ? \@input : @input > 1 ? \@input : $input[0] 
     unless grep { !length } @input;
 
   return $self->topic($name);

--- a/t/mojolicious/validation_lite_app.t
+++ b/t/mojolicious/validation_lite_app.t
@@ -40,7 +40,7 @@ any '/forgery' => sub {
 my $t = Test::Mojo->new;
 
 # Required and optional values
-my $validation = $t->app->validation->input({foo => 'bar', baz => 'yada'});
+my $validation = $t->app->validation->input({foo => 'bar', baz => 'yada', moo => ['test']});
 is_deeply $validation->passed, [], 'no names';
 is_deeply $validation->failed, [], 'no names';
 is $validation->param('foo'), undef, 'no value';
@@ -63,6 +63,8 @@ ok !$validation->required('does_not_exist')->is_valid, 'not valid';
 is_deeply $validation->output, {foo => 'bar', baz => 'yada'}, 'right result';
 ok $validation->has_error, 'has error';
 is_deeply $validation->error('does_not_exist'), ['required'], 'right error';
+ok $validation->required('moo')->is_valid, 'valid';
+is_deeply $validation->output->{moo}, ['test'], 'not disarrayed';
 
 # Equal to
 $validation


### PR DESCRIPTION
Just a quick fix to check the type of input when generating output instead of turning ['this'] into 'this'.