### PR TITLE
Fix a warning from Mojo::Exception->throw when $e->message is undef

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 
 6.62  2016-05-02
+  - Fixed a warning from Mojo::Exception->throw that could occur in
+    pathological cases where the exception message was undefined. (autarch)
 
 6.61  2016-04-30
   - Improved Mojo::Server::Daemon to no longer log when a connection has been

--- a/lib/Mojo/Exception.pm
+++ b/lib/Mojo/Exception.pm
@@ -12,7 +12,9 @@ sub inspect {
   # Extract file and line from message
   my @files;
   my $msg = $self->lines_before([])->line([])->lines_after([])->message;
-  while ($msg =~ /at\s+(.+?)\s+line\s+(\d+)/g) { unshift @files, [$1, $2] }
+  while (defined $msg && $msg =~ /at\s+(.+?)\s+line\s+(\d+)/g) {
+    unshift @files, [$1, $2];
+  }
 
   # Extract file and line from stack trace
   if (my $zero = $self->frames->[0]) { push @files, [$zero->[1], $zero->[2]] }

--- a/t/mojo/exception.t
+++ b/t/mojo/exception.t
@@ -88,4 +88,13 @@ Works!
 4: die;
 EOF
 
+{
+  my $warn;
+  local $SIG{__WARN__} = sub { $warn = shift };
+  $e = Mojo::Exception->new(undef);
+  my $thrown = eval { $e->throw };
+  is $warn, undef,
+    'calling ->throw on an exception with an undefined message does not warn';
+}
+
 done_testing();


### PR DESCRIPTION
This is pathological, but it managed to occur in some $WORK code, and it's
worth avoiding warnings from the exception system.