### PR TITLE
Do not load FindBin until it is needed in Mojo::Home

### DIFF
--- a/lib/Mojo/Home.pm
+++ b/lib/Mojo/Home.pm
@@ -5,7 +5,6 @@ use overload bool => sub {1}, '""' => sub { shift->to_string }, fallback => 1;
 use Cwd 'abs_path';
 use File::Basename 'dirname';
 use File::Spec::Functions qw(abs2rel catdir catfile splitdir);
-use FindBin;
 use Mojo::Util qw(class_to_path files);
 
 has parts => sub { [] };
@@ -27,6 +26,12 @@ sub detect {
     # Turn into absolute path
     return $self->parts([splitdir abs_path catdir(@home) || '.']);
   }
+
+  # We don't want to load this unconditionally. When FindBin is loaded it will
+  # die if $0 does not point to an actual file. Since we may not need FindBin
+  # at all, we can make using Mojo::Home safer by not loading it unless it's
+  # absolutely necessary.
+  require FindBin;
 
   # FindBin fallback
   return $self->parts([split '/', $FindBin::Bin]);

--- a/t/mojo/home_findbin.t
+++ b/t/mojo/home_findbin.t
@@ -1,0 +1,10 @@
+use Mojo::Base -strict;
+
+use Test::More;
+
+local $0 = 'not a path to a file';
+
+eval { require Mojo::Home };
+is $@, '', 'no exception loading Mojo::Home when $0 is not a file';
+
+done_testing();


### PR DESCRIPTION
FindBin will die if $0 is not a file on disk. If, for example, you set $0 in
your tests to make debugging hanging tests easier, then even loading
Mojo::Home in the test suite causes an error, even if Mojo::Home would be able
to work without FindBin.

This was a real issue at $work and I can confirm that this PR fixes the problem. We load a Mojo app in our tests but we don't ever reach the code path that would need FindBin.