### PR TITLE
Make Mojo::Template support Devel::Cover

### DIFF
--- a/lib/Mojo/Template.pm
+++ b/lib/Mojo/Template.pm
@@ -18,6 +18,7 @@ has escape        => sub { \&Mojo::Util::xml_escape };
 has [qw(escape_mark expression_mark trim_mark)] => '=';
 has [qw(line_start replace_mark)] => '%';
 has name      => 'template';
+has path      => '';
 has namespace => 'Mojo::Template::SandBox';
 has tag_start => '<%';
 has tag_end   => '%>';
@@ -167,6 +168,7 @@ sub process {
     return Mojo::Exception->new($@)->inspect($self->unparsed, $code)
       ->trace->verbose(1)
       unless $compiled = eval $self->_wrap($code, @_);
+    monkey_patch $self->namespace, '_compiled', $compiled;
     $self->compiled($compiled);
   }
 
@@ -186,6 +188,7 @@ sub render { shift->parse(shift)->process(@_) }
 sub render_file {
   my ($self, $path) = (shift, shift);
 
+  $self->path($path) unless defined $self->{path};
   $self->name($path) unless defined $self->{name};
   my $template = slurp $path;
   my $encoding = $self->encoding;
@@ -256,9 +259,10 @@ sub _compile {
 }
 
 sub _line {
-  my $name = shift->name;
-  $name =~ y/"//d;
-  return qq{#line @{[shift]} "$name"};
+  my $self = shift;
+  my $path = $self->path || $self->name;
+  $path =~ y/"//d;
+  return qq{#line @{[shift]} "$path"};
 }
 
 sub _trim {

--- a/t/mojo/template.t
+++ b/t/mojo/template.t
@@ -1125,9 +1125,9 @@ is $output->lines_after->[0][0], 3,     'right number';
 is $output->lines_after->[0][1], '123', 'right line';
 like "$output", qr/exception\.mt line 2/, 'right result';
 
-# Exception in file (different name)
+# Exception in file (different path)
 $mt     = Mojo::Template->new;
-$output = $mt->name('"foo.mt" from DATA section')->render_file($file);
+$output = $mt->path('"foo.mt" from DATA section')->render_file($file);
 isa_ok $output, 'Mojo::Exception', 'right exception';
 like $output->message, qr/foo\.mt from DATA section line 2/,
   'message contains filename';

--- a/t/mojolicious/lite_app.t
+++ b/t/mojolicious/lite_app.t
@@ -595,7 +595,7 @@ $t->get_ok('/data/exception')->status_is(500)
 # Exception in template
 $t->get_ok('/template/exception')->status_is(500)
   ->header_is(Server => 'Mojolicious (Perl)')
-  ->content_is("Died at template dies_too.html.ep line 2.\n\n");
+  ->content_like(qr{^Died at .*t/mojolicious/templates/dies_too\.html\.ep line 2\.\n\n$});
 
 # Generate URL without format
 $t->get_ok('/with-format')->content_is("/without-format\n");


### PR DESCRIPTION
Add support for Devel::Cover in Mojo::Template, by monkey patching the compiled
template into its own namespace. This way the previously-anonymous sub exists
in the symbol table, and therefore Devel::Cover can see it.

As suggested by @haarg in pjcj/Devel--Cover#31

A path attribute is also added, to provide the path to the template instead of
using the name, which doesn't identify the template file.