### PR TITLE
Patch to disable layout for mojo/templates

### DIFF
--- a/lib/Mojolicious/resources/templates/mojo/debug.html.ep
+++ b/lib/Mojolicious/resources/templates/mojo/debug.html.ep
@@ -1,3 +1,4 @@
+% layout undef;
 <!DOCTYPE html>
 <html>
   <head>

--- a/lib/Mojolicious/resources/templates/mojo/exception.html.ep
+++ b/lib/Mojolicious/resources/templates/mojo/exception.html.ep
@@ -1,3 +1,4 @@
+% layout undef;
 <!DOCTYPE html>
 <html>
   <head><title>Server error</title></head>

--- a/lib/Mojolicious/resources/templates/mojo/not_found.html.ep
+++ b/lib/Mojolicious/resources/templates/mojo/not_found.html.ep
@@ -1,3 +1,4 @@
+% layout undef;
 <!DOCTYPE html>
 <html>
   <head><title>Page not found</title></head>


### PR DESCRIPTION
### Hello

in cases
*  ` $app->defaults(layout=>'foo',)`
*   or `$c->render(..., layout=>...)`

i think we needs prevent rendering mojo/templates trought layout

