### PR TITLE
fix substr outside of string in Mojo::Asset::Memory

### DIFF
--- a/lib/Mojo/Asset/Memory.pm
+++ b/lib/Mojo/Asset/Memory.pm
@@ -38,7 +38,8 @@ sub get_chunk {
     $max = $end + 1 - $offset if ($offset + $max) > $end;
   }
 
-  return substr shift->{content} // '', $offset, $max;
+  my $len = length($self->{content} //= '');
+  return substr $self->{content}, $offset > $len ? $len : $offset, $max;
 }
 
 sub move_to {

--- a/t/mojo/asset.t
+++ b/t/mojo/asset.t
@@ -48,6 +48,7 @@ is $file->contains('a'), -1, 'does not contain "a"';
 $mem = Mojo::Asset::Memory->new;
 is $mem->size, 0, 'asset is empty';
 is $mem->get_chunk(0), '', 'no content';
+is $mem->get_chunk(1), '', 'no content (offset outside of string)';
 is $mem->slurp, '', 'no content';
 ok !$mem->is_range, 'no range';
 is $mem->contains('a'), -1, 'does not contain "a"';


### PR DESCRIPTION
We updated to v6.62 (from v6.42) this morning and are seeing some odd behaviour, after a restart we sometimes get pages rendered as the raw HTML as if the headers are being sent through twice. We're still investigating this.

The one thing i do notice is `substr outside of string at lib/perl5/site_perl/5.16.3/Mojo/Asset/Memory.pm line 41` warnings since the update. I've included a PR here to fix this issue. The important point is that a substr outside of a string will return undef and if that is being fed into `length` then unexpected things might be happening, observe:

```
> perl -E 'say length(substr("foo",4))'

> perl -E 'say length(substr("foo",3))'
0
```