### PR TITLE
fixed a bug where max-age=0 cookies would not expires until next second

### DIFF
--- a/lib/Mojo/UserAgent/CookieJar.pm
+++ b/lib/Mojo/UserAgent/CookieJar.pm
@@ -16,7 +16,7 @@ sub add {
 
     # Convert max age to expires
     my $age = $cookie->max_age;
-    $cookie->expires($age + time) if looks_like_number $age;
+    $cookie->expires($age ? $age + time : 0) if looks_like_number $age;
 
     # Check cookie size
     next if length($cookie->value // '') > $size;
@@ -75,7 +75,7 @@ sub find {
       next unless $cookie->domain || $host eq $cookie->origin;
 
       # Check if cookie has expired
-      if (my $expires = $cookie->expires) { next if time > ($expires || 0) }
+      if (defined(my $expires = $cookie->expires)) { next if time > $expires }
       push @$new, $cookie;
 
       # Taste cookie

--- a/t/mojo/cookiejar.t
+++ b/t/mojo/cookiejar.t
@@ -144,6 +144,13 @@ $jar->add(
     name    => 'baz',
     value   => '24',
     max_age => -1
+  ),
+  Mojo::Cookie::Response->new(
+    domain  => 'labs.example.com',
+    path    => '/',
+    name    => 'qux',
+    value   => 'qux',
+    max_age => 0
   )
 );
 my $expired = Mojo::Cookie::Response->new(


### PR DESCRIPTION
They say set-cookie with Max-Age=0 means it expires immidiately but current Mojo::UserAgent doesn't handle it that way.

I found it in real world use case. PHP applications sometimes send cookies as follows for session renewal or something.

    HTTP/1.1 302 Found
    Content-Type: text/html; charset=UTF-8
    Server: nginx
    X-Powered-By: PHP/5.6.16
    Vary: Accept-Encoding
    Date: Sun, 12 Jun 2016 13:33:55 GMT
    Set-Cookie: PHPSESSIDADMIN=deleted; expires=Thu, 01-Jan-1970 00:00:01 GMT; Max-Age=0; path=/
    Set-Cookie: PHPSESSIDADMIN=qkm88lcmdt1bmls1ngb3e57ci3; expires=Sun, 12-Jun-2016 19:33:54 GMT; Max-Age=21600; path=/admin; HttpOnly
    Location: http://example.com/admin/

Recieving the response the ua unexpectedly sends back the Max-Age=0 cookie again within the same second in favor of redirection.

I checked [RFC6265](http://tools.ietf.org/html/rfc6265#section-5.2.2)

    5.2.2.  The Max-Age Attribute

    If delta-seconds is less than or equal to zero (0), let expiry-time
    be the earliest representable date and time.  Otherwise, let the
    expiry-time be the current date and time plus delta-seconds seconds.

If I'm getting it right, "earliest representable date and time" should be epoch 0.
Since negative values are suggested to be ignored earlier, delta-seconds can't be less than zero.
