### PR TITLE
fix zero length header value bug in Mojolicious::Command::get

### DIFF
--- a/Changes
+++ b/Changes
@@ -10,6 +10,8 @@
     loaded.
   - Fixed trailing slash bug in Mojo::URL.
   - Fixed a few whitespace bugs in Mojo::DOM.
+  - Fixed a bug causing headers with zero length values to be ignored by the get
+    command. (jberger)
 
 6.66  2016-06-16
   - Fixed support for CONNECT requests without keep alive connections in

--- a/lib/Mojolicious/Command/get.pm
+++ b/lib/Mojolicious/Command/get.pm
@@ -29,7 +29,7 @@ sub run {
   my $selector = shift @args;
 
   # Parse header pairs
-  my %headers = map { /^\s*([^:]+)\s*:\s*(.+)$/ ? ($1, $2) : () } @headers;
+  my %headers = map { /^\s*([^:]+)\s*:\s*(.*+)$/ ? ($1, $2) : () } @headers;
 
   # Detect proxy for absolute URLs
   my $ua = Mojo::UserAgent->new(ioloop => Mojo::IOLoop->singleton);


### PR DESCRIPTION
### Summary
As reported by me on irc (http://irclog.perlgeek.de/mojo/2016-06-25#i_12734495) the get command ignores `-H` options passed to it for which the header is given no value (ie `-H X-Bender:`). The header is not built into the request at all. This patch adds that behavior

### References
Interesting to note that curl has this same problem and due to their api they cannot fix it (though it seems that the author would choose to if possible). See the email here https://curl.haxx.se/mail/lib-2010-08/0174.html . As we can fix it I vote that we should.

