### PR TITLE
add an example of a json service

### DIFF
--- a/lib/Mojolicious/Guides/Tutorial.pod
+++ b/lib/Mojolicious/Guides/Tutorial.pod
@@ -168,6 +168,33 @@ L<Mojolicious::Command::get>.
 
   $ ./myapp.pl get -v -M POST -c 'test' /echo
 
+=head2 JSON Services
+
+JSON is a very common interchange format for web services. Mojolicious loves
+JSON and makes it very easy to use everywhere. In this example you can fetch
+module data from L<MetaCPAN|http://metacpan.org>.
+
+  use Mojolicious::Lite;
+
+  post '/module_info' => sub {
+    my $c = shift;
+    my $module = $c->req->json->{module};
+    my $info = $c->ua->get("http://api.metacpan.org/module/$module")->res->json;
+    $c->render(json => $info);
+  };
+
+  app->start;
+
+Now let's see the current distribution that contains L<Mojo>.
+
+  $ ./myapp.pl get -M POST -c '{"module":"Mojo"}' /module_info /release
+
+That trailing path is a L<"JSON pointer"|Mojo::JSON::Pointer> which helps dive
+into JSON documents quickly. The example above might have used one to get the
+module from the request.
+
+  my $module = $c->req->json('/module');
+
 =head2 Built-in C<exception> and C<not_found> pages
 
 During development you will encounter these pages whenever you make a mistake,

--- a/lib/Mojolicious/Guides/Tutorial.pod
+++ b/lib/Mojolicious/Guides/Tutorial.pod
@@ -171,8 +171,8 @@ L<Mojolicious::Command::get>.
 =head2 JSON Services
 
 JSON is a very common interchange format for web services. Mojolicious loves
-JSON and makes it very easy to use everywhere. In this example you can fetch
-module data from L<MetaCPAN|http://metacpan.org>.
+JSON and makes it very easy to both build and use JSON services. In this example
+you can fetch module data from L<MetaCPAN|http://metacpan.org>.
 
   use Mojolicious::Lite;
 


### PR DESCRIPTION
### Summary
Interestingly, the Request's json method does not appear in any of the guides. This PR adds an example that uses it and other common json service functionality

### Motivation
There does appear to be some confusion as to how to get the json representation of a request as evidenced by the google search results for "Mojolicious parse JSON body". Having a small example in the Tutorial seems like a simple place to start. I have chosen to place it after the GET and POST parameters section and the HTTP section since you need the concept of input parameters and also knowledge of the `->req` and `->res` methods to establish these concepts. The `json` stash value doesn't seem to be mentioned directly either but is rather introduced obliquely later, this also gives a nod in that direction.

### References
https://groups.google.com/forum/#!topic/mojolicious/_r-tzqKKtGI
https://github.com/kraih/mojo/issues/522#issuecomment-229823654
