### PR TITLE
Attribute Selector fails for defined attributes with wrong values in Mojo::DOM::CSS

### DIFF
--- a/lib/Mojo/DOM/CSS.pm
+++ b/lib/Mojo/DOM/CSS.pm
@@ -43,6 +43,7 @@ sub _attr {
   my $attrs = $current->[2];
   for my $name (keys %$attrs) {
     next unless $name =~ $name_re;
+    next if !defined $attrs->{$name} && defined $value_re;
     return 1 unless defined $attrs->{$name} && defined $value_re;
     return 1 if $attrs->{$name} =~ $value_re;
   }

--- a/t/mojo/dom.t
+++ b/t/mojo/dom.t
@@ -348,7 +348,7 @@ is $dom->at('script')->text, "alert('lalala');", 'right script content';
 
 # HTML5 (unquoted values)
 $dom = Mojo::DOM->new(
-  '<div id = test foo ="bar" class=tset bar=/baz/ baz=//>works</div>');
+  '<div id = test foo ="bar" class=tset bar=/baz/ baz=// value>works</div>');
 is $dom->at('#test')->text,                'works', 'right text';
 is $dom->at('div')->text,                  'works', 'right text';
 is $dom->at('[foo=bar][foo="bar"]')->text, 'works', 'right text';
@@ -358,6 +358,8 @@ is $dom->at('[foo=ba]'), undef, 'no result';
 is $dom->at('.tset')->text,       'works', 'right text';
 is $dom->at('[bar=/baz/]')->text, 'works', 'right text';
 is $dom->at('[baz=//]')->text,    'works', 'right text';
+is $dom->at('[value]')->text,     'works', 'right text';
+ok !$dom->at('[value=baz]'), 'not found';
 
 # HTML1 (single quotes, uppercase tags and whitespace in attributes)
 $dom = Mojo::DOM->new(q{<DIV id = 'test' foo ='bar' class= "tset">works</DIV>});


### PR DESCRIPTION
Given a tag with a defined but value-less attribute like

``` html
<input type="text" name="example" value>
```

(for example generated using the taghelper plugin with ```$c->text_field('example', value => undef)```),
the CSS selector

``` CSS
input[value="myname"]
```

will match regardless of the non-fitting value.
I tested the behaviour in Firefox and assume the selector should not match.
I added a test and a patch (although I doubt the patch is optimal).

Thank you!