### PR TITLE
made it harder to break log tests

### DIFF
--- a/t/mojo/log.t
+++ b/t/mojo/log.t
@@ -6,6 +6,8 @@ use File::Temp 'tempdir';
 use Mojo::Log;
 use Mojo::Util qw(decode slurp);
 
+delete $ENV{MOJO_LOG_LEVEL};
+
 # Logging to file
 my $dir = tempdir CLEANUP => 1;
 my $path = catfile $dir, 'test.log';


### PR DESCRIPTION
### Summary
A number of people have found it hard to understand the symptoms of having MOJO_LOG_LEVEL set when trying to run tests (many log tests fail).

### Motivation
Originally I was going to flag (and break) if the env var was set, but ribasushi suggested avoiding the problem entirely by unsetting the env var.  Unsetting it in this one file is currently enough to avoid the problem.

### References
http://irclog.perlgeek.de/mojo/2016-07-15#i_12846041