### PR TITLE
allow setting of heartbeat timeout for prefork server via an environm…

### DIFF
--- a/lib/Mojo/Server/Prefork.pm
+++ b/lib/Mojo/Server/Prefork.pm
@@ -9,7 +9,8 @@ use Scalar::Util 'weaken';
 
 has accepts => 10000;
 has cleanup => 1;
-has [qw(graceful_timeout heartbeat_timeout)] => 20;
+has graceful_timeout => 20;
+has heartbeat_timeout => sub { $ENV{MOJO_HEARTBEAT_TIMEOUT} // 20 };
 has heartbeat_interval => 5;
 has pid_file           => sub { catfile tmpdir, 'prefork.pid' };
 has workers            => 4;
@@ -388,7 +389,8 @@ Heartbeat interval in seconds, defaults to C<5>.
   $prefork    = $prefork->heartbeat_timeout(2);
 
 Maximum amount of time in seconds before a worker without a heartbeat will be
-stopped gracefully, defaults to C<20>.
+stopped gracefully, defaults to the value of the C<MOJO_HEARTBEAT_TIMEOUT>
+environment variable or C<20>.
 
 =head2 pid_file
 


### PR DESCRIPTION
### Summary
Allow setting of the `heartbeat_timeout` attribute of `Mojo::Server::Prefork` from an environment variable, or default it to 20s.

### Motivation
Most of the other timeout attributes of Mojolicious modules (namely `inactivity_timeout`) can be set via an environment variable, the heartbeat_timeout also impacts the servers response capabilities, so for applications that require a bit more time it may be a good idea to allow it to be defined on a per application basis.

My intended usage is in the app.pl script:

```
#!/usr/bin/env perl

use strict;
use warnings;

use FindBin;
BEGIN { unshift @INC, "$FindBin::Bin/../lib" }

# Mojo home directory is one level up
# see Mojo::Home for how it detects the home directory
$ENV{MOJO_HOME} = "$FindBin::Bin/..";

$ENV{MOJO_HEARTBEAT_TIMEOUT} = 300;

# Start command line interface for application.
require Mojolicious::Commands;
Mojolicious::Commands->start_app('MyApp');
```