### PR TITLE
websocket_proxy.t: fix warning on perl 5.10.1

### DIFF
--- a/examples/connect-proxy.pl
+++ b/examples/connect-proxy.pl
@@ -14,7 +14,7 @@ Mojo::IOLoop->server(
 
         # Write chunk from client to server
         my $server = $buffer{$id}{connection};
-        return Mojo::IOLoop->stream($server)->write($chunk) if length $server;
+        return Mojo::IOLoop->stream($server)->write($chunk) if defined $server;
 
         # Read connect request from client
         my $buffer = $buffer{$id}{client} .= $chunk;

--- a/t/mojo/daemon_ipv6_tls.t
+++ b/t/mojo/daemon_ipv6_tls.t
@@ -40,7 +40,7 @@ my $id = Mojo::IOLoop->server(
 
         # Write chunk from client to server
         my $server = $buffer{$id}{connection};
-        return Mojo::IOLoop->stream($server)->write($chunk) if length $server;
+        return Mojo::IOLoop->stream($server)->write($chunk) if defined $server;
 
         # Read connect request from client
         my $buffer = $buffer{$id}{client} .= $chunk;

--- a/t/mojo/websocket_proxy.t
+++ b/t/mojo/websocket_proxy.t
@@ -54,7 +54,7 @@ my $id    = Mojo::IOLoop->server(
 
         # Write chunk from client to server
         my $server = $buffer{$id}{connection};
-        return Mojo::IOLoop->stream($server)->write($chunk) if length $server;
+        return Mojo::IOLoop->stream($server)->write($chunk) if defined $server;
 
         # Read connect request from client
         my $buffer = $buffer{$id}{client} .= $chunk;

--- a/t/mojo/websocket_proxy_tls.t
+++ b/t/mojo/websocket_proxy_tls.t
@@ -72,7 +72,7 @@ my $id    = Mojo::IOLoop->server(
 
         # Write chunk from client to server
         my $server = $buffer{$id}{connection};
-        return Mojo::IOLoop->stream($server)->write($chunk) if length $server;
+        return Mojo::IOLoop->stream($server)->write($chunk) if defined $server;
 
         # Read connect request from client
         my $buffer = $buffer{$id}{client} .= $chunk;


### PR DESCRIPTION
### Summary
Fix an issue in the testsuite (t/mojo/websocket_proxy.t): the `$server` variable contains either an object or `undef`. Using `defined` instead of `length` is the right thing (whatever perl version).

### Motivation
The original code provokes a warning when running the testsuite on perl 5.10.1.