### PR TITLE
close DATA to prevent strange addendum in subsequent error messages

### DIFF
--- a/lib/Mojo/Util.pm
+++ b/lib/Mojo/Util.pm
@@ -36,6 +36,7 @@ for my $line (split "\n", join('', <DATA>)) {
   next unless $line =~ /^(\S+)\s+U\+(\S+)(?:\s+U\+(\S+))?/;
   $ENTITIES{$1} = defined $3 ? (chr(hex $2) . chr(hex $3)) : chr(hex $2);
 }
+close DATA;
 
 # Characters that should be escaped in XML
 my %XML = (


### PR DESCRIPTION
### Summary
As reported on IRC (and indeed I've seen it too, just not had the inclination to look) there is a message appended to error messages saying ", at DATA line 2231".

### Motivation
Closing the DATA handle after using it in Mojo::Util suppresses this addendum.

### References
http://irclog.perlgeek.de/mojo/2016-08-15#i_13025043

