### PR TITLE
reset $. removes addendum

### DIFF
--- a/lib/Mojo/Loader.pm
+++ b/lib/Mojo/Loader.pm
@@ -84,7 +84,7 @@ sub _all {
     $all->{$name} = $name =~ s/\s*\(\s*base64\s*\)$//
       && ++$BIN{$class}{$name} ? b64_decode $data : $data;
   }
-
+  $. = 0;
   return $all;
 }
 

--- a/t/mojo/lib/Mojo/LoaderTest/C.pm
+++ b/t/mojo/lib/Mojo/LoaderTest/C.pm
@@ -3,3 +3,10 @@ package Mojo::LoaderTest::C;
 use Mojo::Base -base;
 
 1;
+__DATA__
+
+@@ basic.html
+<html>
+  <head><title></title></head>
+  <body>Hello World</body>
+</html>

--- a/t/mojo/loader.t
+++ b/t/mojo/loader.t
@@ -85,8 +85,13 @@ ok !!Mojo::LoaderTest::B->can('new'), 'loaded successfully';
 ok !!Mojo::LoaderTest::C->can('new'), 'loaded successfully';
 
 # Class does not exist
-is load_class('Mojo::LoaderTest'), 1, 'nothing to load';
-is load_class('Mojo::LoaderTest'), 1, 'nothing to load';
+# Symbol::delete_package is indeed too powerful - https://metacpan.org/pod/Symbol#BUGS
+# Using Mojo::LoaderTest wipes out Mojo::LoaderTest::{A,B,C} too!
+is load_class('Mojo::LoaderTest::Z'), 1, 'nothing to load';
+is load_class('Mojo::LoaderTest::Z'), 1, 'nothing to load';
+
+is load_class('Mojo::LoaderTest::C'), undef, 'loaded';
+ok !!Mojo::LoaderTest::C->can('new'), 'loaded successfully';
 
 # Invalid class
 is load_class('Mojolicious/Lite'),      1,     'nothing to load';
@@ -97,6 +102,11 @@ is load_class('::Mojolicious::Lite'),   1,     'nothing to load';
 is load_class('Mojolicious::Lite::'),   1,     'nothing to load';
 is load_class('::Mojolicious::Lite::'), 1,     'nothing to load';
 is load_class('Mojolicious::Lite'),     undef, 'loaded successfully';
+
+# DATA filehandle
+my $section = data_section('Mojo::LoaderTest::C', 'basic.html');
+eval "die 'not yet'";
+unlike $@, qr/<DATA> line/, 'no addendum thanks';
 
 # UNIX DATA templates
 {


### PR DESCRIPTION
### Summary
Further to the data-line-in-error branch, adding a solution and test.

### Motivation
In preparing this a small issue with `Symbol::delete_package` (called by `Mojo::Util::_teardown`) was discovered, though it appears to be already known as an overzealous approach to deleting everything, modules included, which leads to a few extra line changes in this patch.

### References
#989

