### PR TITLE
Do not pass globals as arguments. They may be clobbered

### DIFF
--- a/lib/Mojolicious.pm
+++ b/lib/Mojolicious.pm
@@ -187,7 +187,7 @@ sub _exception {
   my ($next, $c) = @_;
   local $SIG{__DIE__}
     = sub { ref $_[0] ? CORE::die $_[0] : Mojo::Exception->throw(shift) };
-  $c->helpers->reply->exception($@) unless eval { $next->(); 1 };
+  $c->helpers->reply->exception(my $tmp = $@) unless eval { $next->(); 1 };
 }
 
 1;


### PR DESCRIPTION
### Summary
Error is clobbered before we process it

### Motivation
Arguments to functions are just aliases. When we process error we should copy $@ as soon as possible. When we pass $@ as argument we may implicitly loose its value

### References

sub test {
	$@ =  'Oops';
	my( $x ) =  @_;
	print $x; # Oops
}
$@ =  'Exception';
test( $@ );