### PR TITLE
Do not pass globals as arguments. They may be clobbered

### DIFF
--- a/lib/Mojo/IOLoop/Delay.pm
+++ b/lib/Mojo/IOLoop/Delay.pm
@@ -46,7 +46,8 @@ sub _step {
   $self->{counter} = 0;
   if (my $cb = shift @{$self->remaining}) {
     eval { $self->$cb(@args); 1 }
-      or (++$self->{fail} and return $self->remaining([])->emit(error => $@));
+      or (++$self->{fail} and return $self->remaining([])
+                                ->emit(error => my $e = $@));
   }
 
   return $self->remaining([])->emit(finish => @args) unless $self->{counter};

--- a/lib/Mojo/Loader.pm
+++ b/lib/Mojo/Loader.pm
@@ -56,7 +56,7 @@ sub load_class {
   return 1 if $@ =~ /^Can't locate \Q@{[class_to_path $class]}\E in \@INC/;
 
   # Real error
-  return Mojo::Exception->new($@)->inspect;
+  return Mojo::Exception->new(my $e = $@)->inspect;
 }
 
 sub _all {

--- a/lib/Mojo/Template.pm
+++ b/lib/Mojo/Template.pm
@@ -145,7 +145,7 @@ sub process {
   unless ($compiled) {
     my $code = $self->_compile->code;
     monkey_patch $self->namespace, '_escape', $self->escape;
-    return Mojo::Exception->new($@)->inspect($self->unparsed, $code)
+    return Mojo::Exception->new(my $e = $@)->inspect($self->unparsed, $code)
       ->trace->verbose(1)
       unless $compiled = eval $self->_wrap($code, @_);
     $self->compiled($compiled);

--- a/lib/Mojolicious.pm
+++ b/lib/Mojolicious.pm
@@ -187,7 +187,7 @@ sub _exception {
   my ($next, $c) = @_;
   local $SIG{__DIE__}
     = sub { ref $_[0] ? CORE::die $_[0] : Mojo::Exception->throw(shift) };
-  $c->helpers->reply->exception($@) unless eval { $next->(); 1 };
+  $c->helpers->reply->exception(my $e = $@) unless eval { $next->(); 1 };
 }
 
 1;


### PR DESCRIPTION
### Summary
Error is clobbered before we process it

### Motivation
Arguments to functions are just aliases. When we process error we should copy $@ as soon as possible. When we pass $@ as argument we may implicitly loose its value

### References

sub test {
	$@ =  'Oops';
	my( $x ) =  @_;
	print $x; # Oops
}
$@ =  'Exception';
test( $@ );