### PR TITLE
Fix utf8 comments for test

### DIFF
--- a/lib/Test/Mojo.pm
+++ b/lib/Test/Mojo.pm
@@ -323,7 +323,7 @@ sub _build_ok {
   return $self->_request_ok($self->ua->build_tx($method, $url, @_), $url);
 }
 
-sub _desc { encode 'UTF-8', shift || shift }
+sub _desc { shift || encode 'UTF-8', shift }
 
 sub _json {
   my ($self, $method, $p) = @_;


### PR DESCRIPTION
### Summary
Fix utf8 comments for test

### Motivation
Compromise for `use utf8; use open ':std :utf8'` users and mojo.
Everybody gets what they want.

### References
#995
8fdf806ff56520bd79dfe0fe8fc24315918bfd37

