### PR TITLE
handle all 303 redirects with a GET method

### DIFF
--- a/lib/Mojo/UserAgent/Transactor.pm
+++ b/lib/Mojo/UserAgent/Transactor.pm
@@ -90,7 +90,9 @@ sub redirect {
   }
   else {
     my $method = uc $req->method;
-    my $headers = $new->req->method($method eq 'POST' ? 'GET' : $method)
+    my $headers
+      = $new->req->method(
+      $code == 303 ? 'GET' : $method eq 'POST' ? 'GET' : $method)
       ->content->headers($req->headers->clone)->headers;
     $headers->remove($_) for grep {/^content-/i} @{$headers->names};
   }

--- a/t/mojo/transactor.t
+++ b/t/mojo/transactor.t
@@ -720,7 +720,7 @@ is $tx->res->code, undef, 'no status';
 is $tx->res->headers->location, undef, 'no "Location" value';
 
 # 303 redirect (dynamic)
-$tx = $t->tx(POST => 'http://mojolicious.org/foo');
+$tx = $t->tx(PUT => 'http://mojolicious.org/foo');
 $tx->res->code(303);
 $tx->res->headers->location('http://example.com/bar');
 $tx->req->content->write_chunk('whatever' => sub { shift->finish });


### PR DESCRIPTION
As detailed in #999, 303 redirects should be handled with a `GET` method. This PR implements that behavior.
