### PR TITLE
fix for multiple Location: headers in response

### DIFF
--- a/lib/Mojo/UserAgent/Transactor.pm
+++ b/lib/Mojo/UserAgent/Transactor.pm
@@ -76,7 +76,7 @@ sub redirect {
   return undef if uc $req->method eq 'CONNECT';
 
   # Fix location without authority and/or scheme
-  return undef unless my $location = $res->headers->location;
+  return undef unless my $location = $res->headers->to_hash(1)->{Location}->[0];
   $location = Mojo::URL->new($location);
   $location = $location->base($req->url)->to_abs unless $location->is_abs;
   my $proto = $location->protocol;


### PR DESCRIPTION
### Summary
Fix/workaround for servers that return multiple Location headers.

### Motivation
Make Mojo::UA work with servers that return multiple Location headers.

### References
When a server returns multiple Location headers (which it shouldn't, but some do), Mojo::UserAgent redirects to a URL that is made of the multiple URLs in the headers concatenated. Example:

MOJO_USERAGENT_DEBUG=1 perl -MMojo::UserAgent -e 'Mojo::UserAgent->new->max_redirects(2)->get("http://www.lvz.de/Leipzig/Polizeiticker/Polizeiticker-Leipzig/Amokdrohungen-gegen-vier-Leipziger-Schulen-Polizei-sichert-Gebaeude")'

This fix simply uses the first URL for the redirect.