### PR TITLE
Prevent http response from code being overwritten by stash(status => 'text...') 

### DIFF
--- a/lib/Mojo/Message/Response.pm
+++ b/lib/Mojo/Message/Response.pm
@@ -137,8 +137,8 @@ sub _start_line {
   my $self = shift;
 
   return $self if defined $self->{start_buffer};
-  my $code = $self->code    || 404;
-  my $msg  = $self->message || $self->default_message;
+  my $code = int($self->code) || 404;
+  my $msg  = $self->message   || $self->default_message;
   $self->{start_buffer} = "HTTP/@{[$self->version]} $code $msg\x0d\x0a";
 
   return $self;


### PR DESCRIPTION
### Summary
Any user using stash('status') unaware that it's a restricted variable can potentially allow unsanitized data to replace the http response code.

#### PoC
```perl
use Mojolicious::Lite;
get '/hello/#status' =>  'groovy';
app->start;

__DATA__
@@ groovy.html.ep
Your name is <%= $status %>.

# Exploit:
# http://127.0.0.1:3000/hello/200%20OK%0d%0aContent-Length:%20150%0d%0aX-XSS-Protection:%200%0d%0a%0d%0a<html><body onload="eval(window.location.replace(String.fromCharCode(104,116,116,112,58,47,47,119,119,119,46,115,97,110,103,101,114,46,100,107,47)))">
```

### Motivation
I recently had a complaint from a client that certain pages of their application was displaying unrendered html when opened in safari. It appeared that the issue was limited to pages with the route '/list/:status' and some manual requests returned the following:

```
* Connected to localhost (127.0.0.1) port 3000 (#0)
> GET /list/SALE HTTP/1.1
> User-Agent: curl/7.38.0
> Host: localhost:3000
> Accept: */*
> 
* HTTP 1.0, assume close after body
< HTTP/1.1 SALE
< Content-Type: text/html;charset=UTF-8
< Date: Mon, 24 Oct 2016 07:31:26 GMT
< Server: Mojolicious (Perl)
< Content-Length: 4
```

Rereading the documentation can i see that 'status' is a reserved word but the lack of runtime warnings is somewhat problematic...

### References
```
From: Sebastian Riedel <kraihx@gmail.com>
Date: Mon, 24 Oct 2016 14:47:44 +0200
Subject: Re: Mojolicious Vulnerability (stash status)

> This may affect some people so thought I would send via email as a
> precaution.

Thank you, this is very hard to exploit, so you're welcome to discuss
the problem and your patch in public.
```