### PR TITLE
move default log behavior to overloaded attribute

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,7 +1,9 @@
 
-7.11  2016-11-25
+7.11  2016-11-28
   - Improved one_tick method in Mojo::IOLoop to protect from recursion, similar
     to the start method.
+  - Improved Mojolicious log attribute making it easier to override default
+    settings. (jberger)
 
 7.10  2016-11-01
   - Added getopt function to Mojo::Util.

--- a/t/mojolicious/app.t
+++ b/t/mojolicious/app.t
@@ -449,9 +449,14 @@ $t->get_ok('/just/some/template')->status_is(200)
   ->header_is(Server => 'Mojolicious (Perl)')
   ->content_is("Development template with high precedence.\n");
 
-# Check develpment mode log level
+# Check default development mode log level
 my $app = Mojolicious->new;
 is $app->log->level, 'debug', 'right log level';
+
+# Check non-development mode log level
+$app = Mojolicious->new;
+$app->mode('test');
+is $app->log->level, 'info', 'right log level';
 
 # Make sure we can override attributes with constructor arguments
 $app = MojoliciousTest->new(mode => 'test');


### PR DESCRIPTION
### Summary
Move the log initialization from the `new` constructor to the attribute default.

### Motivation
The current behavior is a good "sane default" but is difficult to override when desired. By encapsulating the default logic into an overloadable attribute definition a subclass application can easily change the default initialization. This also has the added benefits of making documentation of these default initialization behaviors easier and makes setting the mode attribute in the startup method more useful.

### References
IRC discussion starts here: https://irclog.perlgeek.de/mojo/2016-11-28#i_13642669

