### PR TITLE
Fix unexpected websocket handshake failure degrading into infinite loop

### DIFF
--- a/t/mojo/websocket_proxy.t
+++ b/t/mojo/websocket_proxy.t
@@ -160,7 +160,7 @@ is $result, 'http://example.com/proxy', 'right content';
 $ua->websocket(
   "ws://127.0.0.1:$port/test" => sub {
     my ($ua, $tx) = @_;
-    Mojo::IOLoop->stop and return unless $tx->is_websocket;
+    return Mojo::IOLoop->stop unless $tx->is_websocket;
     $kept_alive = $tx->kept_alive;
     $tx->on(finish => sub { Mojo::IOLoop->stop });
     $tx->on(message => sub { shift->finish; $result = shift });
@@ -183,7 +183,7 @@ $result = undef;
 $ua->websocket(
   "ws://127.0.0.1:$port/test" => sub {
     my ($ua, $tx) = @_;
-    Mojo::IOLoop->stop and return unless $tx->is_websocket;
+    return Mojo::IOLoop->stop unless $tx->is_websocket;
     $tx->on(finish => sub { Mojo::IOLoop->stop });
     $tx->on(message => sub { shift->finish; $result = shift });
     $tx->send('test1');
@@ -201,10 +201,9 @@ my ($success, $leak, $err);
 $ua->websocket(
   "ws://127.0.0.1:$dummy/test" => sub {
     my ($ua, $tx) = @_;
-    Mojo::IOLoop->stop and return unless $tx->is_websocket;
     $success = $tx->success;
-    $leak    = !!Mojo::IOLoop->stream($tx->previous->connection);
     $err     = $tx->error;
+    $leak    = !!Mojo::IOLoop->stream($tx->previous->connection) if $tx->is_websocket;
     Mojo::IOLoop->stop;
   }
 );

--- a/t/mojo/websocket_proxy.t
+++ b/t/mojo/websocket_proxy.t
@@ -160,6 +160,7 @@ is $result, 'http://example.com/proxy', 'right content';
 $ua->websocket(
   "ws://127.0.0.1:$port/test" => sub {
     my ($ua, $tx) = @_;
+    Mojo::IOLoop->stop and return unless $tx->is_websocket;
     $kept_alive = $tx->kept_alive;
     $tx->on(finish => sub { Mojo::IOLoop->stop });
     $tx->on(message => sub { shift->finish; $result = shift });
@@ -182,6 +183,7 @@ $result = undef;
 $ua->websocket(
   "ws://127.0.0.1:$port/test" => sub {
     my ($ua, $tx) = @_;
+    Mojo::IOLoop->stop and return unless $tx->is_websocket;
     $tx->on(finish => sub { Mojo::IOLoop->stop });
     $tx->on(message => sub { shift->finish; $result = shift });
     $tx->send('test1');
@@ -199,6 +201,7 @@ my ($success, $leak, $err);
 $ua->websocket(
   "ws://127.0.0.1:$dummy/test" => sub {
     my ($ua, $tx) = @_;
+    Mojo::IOLoop->stop and return unless $tx->is_websocket;
     $success = $tx->success;
     $leak    = !!Mojo::IOLoop->stream($tx->previous->connection);
     $err     = $tx->error;


### PR DESCRIPTION
### Summary
The test suite (reasonably) presumes that websocket handshaking will succeed during testing. When it does not, the test suite gets (vocally) stuck in Mojo::IOLoop indefinitely. This change handles this edge case correctly, just resulting in failed tests.

The only known instance of this failure is when proxied HTTP connections are intercepted by local network security software and cause the handshaking to fail. This makes the behaviour unlikely to occur and may not be worth the cost to the codebase.

### Motivation
The test suite failing into an infinite loop would appear to be unacceptable behaviour outside of unmitigatable failure such as malfunctioning RAM.

### References
This PR has an [alternative PR](https://github.com/kraih/mojo/pull/1019) which implements the same fix in a different way (minimises line count).