### PR TITLE
text method in Mojo::Dom works now also on nodes of type text, raw and cdata

### DIFF
--- a/lib/Mojo/DOM.pm
+++ b/lib/Mojo/DOM.pm
@@ -150,7 +150,14 @@ sub tag {
 
 sub tap { shift->Mojo::Base::tap(@_) }
 
-sub text { _text([_nodes(shift->tree)], 0) }
+sub text {
+  my $tree = shift->tree;
+  my $type = $tree->[0];
+  if ($type eq 'text' || $type eq 'cdata' || $type eq 'raw') {
+    return $tree->[1];
+  }
+  _text([_nodes($tree)], 0);
+}
 
 sub to_string { shift->_delegate('render') }
 
@@ -860,13 +867,17 @@ Alias for L<Mojo::Base/"tap">.
 
   my $text = $dom->text;
 
-Extract text content from this element only (not including child elements).
+Extract text content from this element only (not including child elements),
+or from nodes of type text, raw or cdata.
 
   # "bar"
   $dom->parse("<div>foo<p>bar</p>baz</div>")->at('p')->text;
 
   # "foo\nbaz\n"
   $dom->parse("<div>foo\n<p>bar</p>baz\n</div>")->at('div')->text;
+
+  # "&"
+  $dom->parse("<p>&amp;</p>")->at('p')->child_nodes->[0]->text;
 
 =head2 to_string
 

--- a/t/mojo/dom.t
+++ b/t/mojo/dom.t
@@ -293,7 +293,7 @@ ok !$dom->child_nodes->first->matches('*'), 'no match';
 is_deeply $dom->child_nodes->first->attr, {}, 'no attributes';
 is $dom->child_nodes->first->namespace, undef, 'no namespace';
 is $dom->child_nodes->first->tag,       undef, 'no tag';
-is $dom->child_nodes->first->text,      '',    'no text';
+is $dom->child_nodes->first->text,      'foo',    'text';
 is $dom->child_nodes->first->all_text,  '',    'no text';
 
 # Class and ID
@@ -2519,5 +2519,25 @@ my $huge = ('<a>' x 100) . 'works' . ('</a>' x 100);
 $dom = Mojo::DOM->new($huge);
 is $dom->all_text, 'works', 'right text';
 is "$dom", $huge, 'right result';
+
+# text
+$dom = Mojo::DOM->new(<<EOF);
+<title>&amp;</title>
+<p>&amp;</p>
+<b><!-- &amp; --><b>
+<a><![CDATA[&amp;]]></a>
+EOF
+is $dom->at('title')->child_nodes->[0]->type, 'raw', 'right type';
+is $dom->at('title')->child_nodes->[0]->text, '&', 'right text';
+is $dom->at('title')->text,                   '&', 'right text';
+is $dom->at('p')->child_nodes->[0]->type,     'text', 'right type';
+is $dom->at('p')->child_nodes->[0]->text,     '&', 'right text';
+is $dom->at('p')->text,                       '&', 'right text';
+is $dom->at('a')->child_nodes->[0]->type,     'cdata', 'right type';
+is $dom->at('a')->child_nodes->[0]->text,     '&amp;', 'right text';
+is $dom->at('a')->text,                       '&amp;', 'right text';
+is $dom->at('b')->child_nodes->[0]->type,     'comment', 'right type';
+is $dom->at('b')->child_nodes->[0]->text,     '', 'no text';
+is $dom->at('b')->text,                       '', 'no text';
 
 done_testing();


### PR DESCRIPTION

### Summary
Allows to process the text of nodes directly.

### Motivation
In traversing a parsed tree the text nodes also need processing as text.

### References
#1022 
