### PR TITLE
prevent warnings whenever morbo checks broken symlinks

### DIFF
--- a/lib/Mojo/Server/Morbo.pm
+++ b/lib/Mojo/Server/Morbo.pm
@@ -18,6 +18,7 @@ sub modified_files {
   my @files;
   for my $file (map { -f $_ && -r _ ? $_ : files $_ } @{$self->watch}) {
     my ($size, $mtime) = (stat $file)[7, 9];
+    next unless defined $size and defined $mtime;
     my $stats = $cache->{$file} ||= [$^T, $size];
     next if $mtime <= $stats->[0] && $size == $stats->[1];
     @$stats = ($mtime, $size);

--- a/t/mojo/morbo.t
+++ b/t/mojo/morbo.t
@@ -122,6 +122,20 @@ is_deeply $morbo->modified_files, \@new, 'two files have changed';
 spurt 'whatever', catfile($subdir, '.hidden.txt');
 is_deeply $morbo->modified_files, [], 'directory has not changed again';
 
+# Broken symlink
+SKIP: {
+  skip 'Symlink support required!', 4 unless eval { symlink '', ''; 1 };
+  my $missing = catfile $subdir, 'missing.txt';
+  my $broken = catfile $subdir, 'broken.txt';
+  symlink $missing, $broken;
+  ok -l $broken, 'symlink created';
+  ok !-f $broken, 'symlink target does not exist';
+  my $warned;
+  local $SIG{__WARN__} = sub { $warned++ };
+  is_deeply $morbo->modified_files, [], 'directory has not changed';
+  ok !$warned, 'no warnings';
+}
+
 # Stop
 kill 'INT', $pid;
 sleep 1 while _port($port);


### PR DESCRIPTION
### Summary
Currently, if broken symlinks exist in the directories watched by morbo, `stat` will return undefined values for that file causing unnecessary caching and warnings. Anything which does not return defined values can simply be skipped by morbo.

### Motivation
Reduce computation and avoid warnings if watched directories have broken symlinks.

### References
https://irclog.perlgeek.de/mojo/2016-12-27#i_13808575
