### PR TITLE
Correct typo in POD (lintian)

### DIFF
--- a/lib/Mojo/Transaction.pm
+++ b/lib/Mojo/Transaction.pm
@@ -260,7 +260,7 @@ proxy.
   my $res = $tx->result;
 
 Returns the L<Mojo::Message::Response> object from L</"res"> or dies if a
-connection error has occured.
+connection error has occurred.
 
   # Fine grained response handling (dies on connection errors)
   my $res = $tx->result;


### PR DESCRIPTION
A typo detected whilst packaging 7.13 for Debian