### PR TITLE
add a Mojo::File module

### DIFF
--- a/lib/Mojo.pm
+++ b/lib/Mojo.pm
@@ -78,8 +78,8 @@ L<Mojo> implements the following attributes.
 The home directory of your application, defaults to a L<Mojo::Home> object
 which stringifies to the actual path.
 
-  # Generate portable path relative to home directory
-  my $path = $app->home->rel_file('data/important.txt');
+  # Portably generate path relative to home directory
+  my $path = $app->home->child('data', 'important.txt');
 
 =head2 log
 

--- a/lib/Mojo/Asset/Memory.pm
+++ b/lib/Mojo/Asset/Memory.pm
@@ -2,7 +2,7 @@ package Mojo::Asset::Memory;
 use Mojo::Base 'Mojo::Asset';
 
 use Mojo::Asset::File;
-use Mojo::Util 'spurt';
+use Mojo::File 'path';
 
 has 'auto_upgrade';
 has max_memory_size => sub { $ENV{MOJO_MAX_MEMORY_SIZE} || 262144 };
@@ -41,11 +41,7 @@ sub get_chunk {
   return substr shift->{content} // '', $offset, $max;
 }
 
-sub move_to {
-  my ($self, $to) = @_;
-  spurt $self->{content} // '', $to;
-  return $self;
-}
+sub move_to { path($_[1])->spurt($_[0]{content} // '') and return $_[0] }
 
 sub size { length(shift->{content} // '') }
 

--- a/lib/Mojo/ByteStream.pm
+++ b/lib/Mojo/ByteStream.pm
@@ -12,8 +12,8 @@ our @EXPORT_OK = ('b');
 my @UTILS = (
   qw(b64_decode b64_encode camelize decamelize hmac_sha1_sum html_unescape),
   qw(md5_bytes md5_sum punycode_decode punycode_encode quote sha1_bytes),
-  qw(sha1_sum slurp spurt term_escape trim unindent unquote url_escape),
-  qw(url_unescape xml_escape xor_encode)
+  qw(sha1_sum term_escape trim unindent unquote url_escape url_unescape),
+  qw(xml_escape xor_encode)
 );
 for my $name (@UTILS) {
   my $sub = Mojo::Util->can($name);
@@ -47,9 +47,29 @@ sub secure_compare { Mojo::Util::secure_compare ${shift()}, shift }
 
 sub size { length ${$_[0]} }
 
+# DEPRECATED!
+sub slurp {
+  Mojo::Util::deprecated 'Mojo::ByteStream::slurp is DEPRECATED'
+    . ' in favor of Mojo::File::slurp';
+  require Mojo::File;
+  my $self = shift;
+  $$self = Mojo::File->new($$self)->slurp;
+  return $self;
+}
+
 sub split {
   my ($self, $pattern) = @_;
   return Mojo::Collection->new(map { $self->new($_) } split $pattern, $$self);
+}
+
+# DEPRECATED!
+sub spurt {
+  Mojo::Util::deprecated 'Mojo::ByteStream::spurt is DEPRECATED'
+    . ' in favor of Mojo::File::spurt';
+  require Mojo::File;
+  my $self = shift;
+  Mojo::File->new(shift)->spurt($$self);
+  return $self;
 }
 
 sub tap { shift->Mojo::Base::tap(@_) }
@@ -249,24 +269,6 @@ Generate SHA1 checksum for bytestream with L<Mojo::Util/"sha1_sum">.
   my $size = $stream->size;
 
 Size of bytestream.
-
-=head2 slurp
-
-  $stream = $stream->slurp;
-
-Read all data at once from file into bytestream with L<Mojo::Util/"slurp">.
-
-  # Read file and print lines in random order
-  b('/home/sri/myapp.pl')->slurp->split("\n")->shuffle->join("\n")->say;
-
-=head2 spurt
-
-  $stream = $stream->spurt('/home/sri/myapp.pl');
-
-Write all data from bytestream at once to file with L<Mojo::Util/"spurt">.
-
-  # Remove unnecessary whitespace from file
-  b('/home/sri/foo.txt')->slurp->trim->spurt('/home/sri/bar.txt');
 
 =head2 split
 

--- a/lib/Mojo/File.pm
+++ b/lib/Mojo/File.pm
@@ -1,0 +1,380 @@
+package Mojo::File;
+use Mojo::Base -strict;
+use overload
+  '@{}'    => sub { shift->to_array },
+  bool     => sub {1},
+  '""'     => sub { ${$_[0]} },
+  fallback => 1;
+
+use Carp 'croak';
+use Cwd qw(abs_path getcwd);
+use Exporter 'import';
+use File::Basename ();
+use File::Copy     ();
+use File::Find     ();
+use File::Path     ();
+use File::Spec;
+use File::Temp ();
+use Mojo::Collection;
+use Scalar::Util 'blessed';
+
+our @EXPORT_OK = ('path', 'tempdir');
+
+sub basename { scalar File::Basename::basename ${$_[0]}, @_ }
+
+sub child {
+  my $self = shift;
+  return $self->new($self, @_);
+}
+
+sub dirname { $_[0]->new(scalar File::Basename::dirname ${$_[0]}) }
+
+sub is_abs { File::Spec->file_name_is_absolute(${shift()}) }
+
+sub list {
+  my ($self, $options) = (shift, shift // {});
+
+  return Mojo::Collection->new unless -d $$self;
+  opendir(my $dir, $$self) or croak qq{Can't open directory "$$self": $!};
+  my @files = grep { $_ ne '.' && $_ ne '..' } readdir $dir;
+  @files = grep { !/^\./ } @files unless $options->{hidden};
+  @files = map { File::Spec->catfile($$self, $_) } @files;
+  @files = grep { !-d } @files unless $options->{dir};
+
+  return Mojo::Collection->new(map { $self->new($_) } sort @files);
+}
+
+sub list_tree {
+  my ($self, $options) = (shift, shift // {});
+
+  # This may break in the future, but is worth it for performance
+  local $File::Find::skip_pattern = qr/^\./ unless $options->{hidden};
+
+  my %files;
+  my $want = sub { $files{$File::Find::name}++ };
+  my $post = sub { delete $files{$File::Find::dir} };
+  File::Find::find {wanted => $want, postprocess => $post, no_chdir => 1},
+    $$self
+    if -d $$self;
+
+  return Mojo::Collection->new(map { $self->new($_) } sort keys %files);
+}
+
+sub make_path {
+  my $self = shift;
+  File::Path::make_path $$self, @_
+    or croak qq{Can't make directory "$$self": $!};
+  return $self;
+}
+
+sub move_to {
+  my ($self, $to) = @_;
+  File::Copy::move($$self, $to)
+    or croak qq{Can't move file "$$self" to "$to": $!};
+  return $self;
+}
+
+sub new {
+  my $class = shift;
+  my $self = bless \my $dummy, ref $class || $class;
+
+  unless (@_) { $$self = getcwd }
+
+  elsif (@_ > 1) { $$self = File::Spec->catfile(@_) }
+
+  elsif (blessed $_[0] && $_[0]->isa('File::Temp::Dir')) { $$self = $_[0] }
+
+  else { $$self = shift }
+
+  return $self;
+}
+
+sub path { __PACKAGE__->new(@_) }
+
+sub slurp {
+  my $self = shift;
+
+  open my $file, '<', $$self or croak qq{Can't open file "$$self": $!};
+  my $ret = my $content = '';
+  while ($ret = $file->sysread(my $buffer, 131072, 0)) { $content .= $buffer }
+  croak qq{Can't read from file "$$self": $!} unless defined $ret;
+
+  return $content;
+}
+
+sub spurt {
+  my ($self, $content) = @_;
+  open my $file, '>', $$self or croak qq{Can't open file "$$self": $!};
+  ($file->syswrite($content) // -1) == length $content
+    or croak qq{Can't write to file "$$self": $!};
+  return $self;
+}
+
+sub tap { shift->Mojo::Base::tap(@_) }
+
+sub tempdir { __PACKAGE__->new(File::Temp->newdir(@_)) }
+
+sub to_abs { $_[0]->new(abs_path ${$_[0]}) }
+
+sub to_array { [File::Spec->splitdir(${shift()})] }
+
+sub to_rel { $_[0]->new(File::Spec->abs2rel(${$_[0]}, $_[1])) }
+
+sub to_string {"${$_[0]}"}
+
+1;
+
+=encoding utf8
+
+=head1 NAME
+
+Mojo::File - File system paths
+
+=head1 SYNOPSIS
+
+  use Mojo::File;
+
+  # Portably deal with file system paths
+  my $path = Mojo::File->new('/home/sri/.vimrc');
+  say $path->slurp;
+  say $path->basename;
+  say $path->dirname->child('.bashrc');
+
+  # Use the alternative constructor
+  use Mojo::File 'path';
+  my $path = path('/tmp/foo/bar')->make_path;
+  $path->child('test.txt')->spurt('Hello Mojo!');
+
+=head1 DESCRIPTION
+
+L<Mojo::File> is a scalar-based container for file system paths that provides a
+friendly API for dealing with different operating systems.
+
+  # Access scalar directly to manipulate path
+  my $path = Mojo::File->new('/home/sri/test');
+  $$path .= '.txt';
+
+=head1 FUNCTIONS
+
+L<Mojo::File> implements the following functions, which can be imported
+individually.
+
+=head2 path
+
+  my $path = path;
+  my $path = path('/home/sri/.vimrc');
+  my $path = path('/home', 'sri', '.vimrc');
+  my $path = path(File::Temp->newdir);
+
+Construct a new scalar-based L<Mojo::File> object, defaults to using the current
+working directory.
+
+=head2 tempdir
+
+  my $path = tempdir;
+  my $path = tempdir('tempXXXXX');
+
+Construct a new scalar-based L<Mojo::File> object for a temporary directory with
+L<File::Temp>.
+
+  # Longer version
+  my $path = Mojo::File->new(File::Temp->newdir('tempXXXXX'));
+
+=head1 METHODS
+
+L<Mojo::File> implements the following methods.
+
+=head2 basename
+
+  my $name = $path->basename;
+  my $name = $path->basename('.txt');
+
+Return the last level of the path with L<File::Basename>.
+
+  # ".vimrc" (on UNIX)
+  Mojo::File->new('/home/sri/.vimrc')->basename;
+
+  # "test" (on UNIX)
+  Mojo::File->new('/home/sri/test.txt')->basename('.txt');
+
+=head2 child
+
+  my $child = $path->child('.vimrc');
+
+Return a new L<Mojo::File> object relative to the path.
+
+  # "/home/sri/.vimrc" (on UNIX)
+  Mojo::File->new('/home')->child('sri', '.vimrc');
+
+=head2 dirname
+
+  my $name = $path->dirname;
+
+Return all but the last level of the path with L<File::Basename> as a
+L<Mojo::File> object.
+
+  # "/home/sri" (on UNIX)
+  Mojo::File->new('/home/sri/.vimrc')->dirname;
+
+=head2 is_abs
+
+  my $bool = $path->is_abs;
+
+Check if the path is absolute.
+
+  # True (on UNIX)
+  Mojo::File->new('/home/sri/.vimrc')->is_abs;
+
+  # False (on UNIX)
+  Mojo::File->new('.vimrc')->is_abs;
+
+=head2 list
+
+  my $collection = $path->list;
+  my $collection = $path->list({hidden => 1});
+
+List all files in the directory and return a L<Mojo::Collection> object
+containing the results as L<Mojo::File> objects.
+
+  # List files
+  say for Mojo::File->new('/home/sri/myapp')->list->each;
+
+These options are currently available:
+
+=over 2
+
+=item dir
+
+  dir => 1
+
+Include directories.
+
+=item hidden
+
+  hidden => 1
+
+Include hidden files.
+
+=back
+
+=head2 list_tree
+
+  my $collection = $path->list_tree;
+  my $collection = $path->list_tree({hidden => 1});
+
+List all files recursively in the directory and return a L<Mojo::Collection>
+object containing the results as L<Mojo::File> objects.
+
+  # List all templates
+  say for Mojo::File->new('/home/sri/myapp/templates')->list_tree->each;
+
+These options are currently available:
+
+=over 2
+
+=item hidden
+
+  hidden => 1
+
+Include hidden files and directories.
+
+=back
+
+=head2 make_path
+
+  $path = $path->make_path;
+
+Create the directories if they don't already exist with L<File::Path>.
+
+=head2 move_to
+
+  $path = $path->move_to('/home/sri/.vimrc.backup');
+
+Move the file.
+
+=head2 new
+
+  my $path = Mojo::File->new;
+  my $path = Mojo::File->new('/home/sri/.vimrc');
+  my $path = Mojo::File->new('/home', 'sri', '.vimrc');
+  my $path = Mojo::File->new(File::Temp->newdir);
+
+Construct a new L<Mojo::File> object, defaults to using the current working
+directory.
+
+=head2 slurp
+
+  my $bytes = $path->slurp;
+
+Read all data at once from the file.
+
+=head2 spurt
+
+  $path = $path->spurt($bytes);
+
+Write all data at once to the file.
+
+=head2 tap
+
+  $path = $path->tap(sub {...});
+
+Alias for L<Mojo::Base/"tap">.
+
+=head2 to_abs
+
+  my $absolute = $path->to_abs;
+
+Return the canonical path as a L<Mojo::File> object.
+
+=head2 to_array
+
+  my $parts = $path->to_array;
+
+Split the path on directory separators.
+
+  # "home:sri:.vimrc" (on UNIX)
+  join ':', @{Mojo::File->new('/home/sri/.vimrc')->to_array};
+
+=head2 to_rel
+
+  my $relative = $path->to_rel('/some/base/path');
+
+Return a relative path from the original path to the destination path as a
+L<Mojo::File> object.
+
+  # "sri/.vimrc" (on UNIX)
+  Mojo::File->new('/home/sri/.vimrc')->to_rel('/home');
+
+=head2 to_string
+
+  my $str = $path->to_string;
+
+Stringify the path.
+
+=head1 OPERATORS
+
+L<Mojo::File> overloads the following operators.
+
+=head2 array
+
+  my @parts = @$path;
+
+Alias for L</"to_array">.
+
+=head2 bool
+
+  my $bool = !!$path;
+
+Always true.
+
+=head2 stringify
+
+  my $str = "$path";
+
+Alias for L</"to_string">.
+
+=head1 SEE ALSO
+
+L<Mojolicious>, L<Mojolicious::Guides>, L<http://mojolicious.org>.
+
+=cut

--- a/lib/Mojo/IOLoop/Server.pm
+++ b/lib/Mojo/IOLoop/Server.pm
@@ -2,9 +2,8 @@ package Mojo::IOLoop::Server;
 use Mojo::Base 'Mojo::EventEmitter';
 
 use Carp 'croak';
-use File::Basename 'dirname';
-use File::Spec::Functions 'catfile';
 use IO::Socket::IP;
+use Mojo::File 'path';
 use Mojo::IOLoop;
 use Scalar::Util 'weaken';
 use Socket qw(IPPROTO_TCP TCP_NODELAY);
@@ -18,8 +17,8 @@ use constant TLS_WRITE => TLS ? IO::Socket::SSL::SSL_WANT_WRITE() : 0;
 
 # To regenerate the certificate run this command (18.04.2012)
 # openssl req -new -x509 -keyout server.key -out server.crt -nodes -days 7300
-my $CERT = catfile dirname(__FILE__), 'resources', 'server.crt';
-my $KEY  = catfile dirname(__FILE__), 'resources', 'server.key';
+my $CERT = path(__FILE__)->dirname->child('resources', 'server.crt')->to_string;
+my $KEY  = path(__FILE__)->dirname->child('resources', 'server.key')->to_string;
 
 has reactor => sub { Mojo::IOLoop->singleton->reactor };
 

--- a/lib/Mojo/Loader.pm
+++ b/lib/Mojo/Loader.pm
@@ -2,9 +2,8 @@ package Mojo::Loader;
 use Mojo::Base -strict;
 
 use Exporter 'import';
-use File::Basename 'basename';
-use File::Spec::Functions qw(catdir catfile splitdir);
 use Mojo::Exception;
+use Mojo::File 'path';
 use Mojo::Util qw(b64_decode class_to_path);
 
 our @EXPORT_OK
@@ -21,14 +20,9 @@ sub find_modules {
 
   my %modules;
   for my $directory (@INC) {
-    next unless -d (my $path = catdir $directory, split(/::|'/, $ns));
-
-    # List "*.pm" files in directory
-    opendir(my $dir, $path);
-    for my $file (grep /\.pm$/, readdir $dir) {
-      next if -d catfile splitdir($path), $file;
-      $modules{"${ns}::" . basename $file, '.pm'}++;
-    }
+    next unless -d (my $path = path($directory, split(/::|'/, $ns)));
+    $modules{"${ns}::$_"}++
+      for $path->list->grep(qr/\.pm$/)->map('basename', '.pm')->each;
   }
 
   return sort keys %modules;

--- a/lib/Mojo/Server.pm
+++ b/lib/Mojo/Server.pm
@@ -2,7 +2,7 @@ package Mojo::Server;
 use Mojo::Base 'Mojo::EventEmitter';
 
 use Carp 'croak';
-use Cwd 'abs_path';
+use Mojo::File 'path';
 use Mojo::Loader 'load_class';
 use Mojo::Util 'md5_sum';
 use POSIX ();
@@ -43,7 +43,7 @@ sub load_app {
 
   # Clean environment (reset FindBin defensively)
   {
-    local $0 = $path = abs_path $path;
+    local $0 = $path = path($path)->to_abs->to_string;
     require FindBin;
     FindBin->again;
     local $ENV{MOJO_APP_LOADER} = 1;

--- a/lib/Mojo/Server/Hypnotoad.pm
+++ b/lib/Mojo/Server/Hypnotoad.pm
@@ -4,9 +4,7 @@ use Mojo::Base -base;
 # "Bender: I was God once.
 #  God: Yes, I saw. You were doing well, until everyone died."
 use Config;
-use Cwd 'abs_path';
-use File::Basename 'dirname';
-use File::Spec::Functions 'catfile';
+use Mojo::File 'path';
 use Mojo::Server::Prefork;
 use Mojo::Util 'steady_time';
 use Scalar::Util 'weaken';
@@ -39,7 +37,7 @@ sub run {
 
   # Remember executable and application for later
   $ENV{HYPNOTOAD_EXE} ||= $0;
-  $0 = $ENV{HYPNOTOAD_APP} ||= abs_path $app;
+  $0 = $ENV{HYPNOTOAD_APP} ||= path($app)->to_abs->to_string;
 
   # This is a production server
   $ENV{MOJO_MODE} ||= 'production';
@@ -51,7 +49,7 @@ sub run {
   # Preload application and configure server
   my $prefork = $self->prefork->cleanup(0);
   $prefork->load_app($app)->config->{hypnotoad}{pid_file}
-    //= catfile dirname($ENV{HYPNOTOAD_APP}), 'hypnotoad.pid';
+    //= path($ENV{HYPNOTOAD_APP})->dirname->child('hypnotoad.pid')->to_string;
   $self->configure('hypnotoad');
   weaken $self;
   $prefork->on(wait   => sub { $self->_manage });

--- a/lib/Mojo/Server/Morbo.pm
+++ b/lib/Mojo/Server/Morbo.pm
@@ -4,8 +4,8 @@ use Mojo::Base -base;
 # "Linda: With Haley's Comet out of ice, Earth is experiencing the devastating
 #         effects of sudden, intense global warming.
 #  Morbo: Morbo is pleased but sticky."
+use Mojo::File 'path';
 use Mojo::Server::Daemon;
-use Mojo::Util 'files';
 use POSIX 'WNOHANG';
 
 has daemon => sub { Mojo::Server::Daemon->new };
@@ -15,8 +15,10 @@ sub modified_files {
   my $self = shift;
 
   my $cache = $self->{cache} ||= {};
+  my @check
+    = map { -f $_ && -r _ ? $_ : path($_)->list_tree->each } @{$self->watch};
   my @files;
-  for my $file (map { -f $_ && -r _ ? $_ : files $_ } @{$self->watch}) {
+  for my $file (@check) {
     my ($size, $mtime) = (stat $file)[7, 9];
     next unless defined $size and defined $mtime;
     my $stats = $cache->{$file} ||= [$^T, $size];

--- a/lib/Mojo/Server/Prefork.pm
+++ b/lib/Mojo/Server/Prefork.pm
@@ -2,7 +2,8 @@ package Mojo::Server::Prefork;
 use Mojo::Base 'Mojo::Server::Daemon';
 
 use Config;
-use File::Spec::Functions qw(catfile tmpdir);
+use File::Spec;
+use Mojo::File 'path';
 use Mojo::Util 'steady_time';
 use POSIX 'WNOHANG';
 use Scalar::Util 'weaken';
@@ -11,8 +12,8 @@ has accepts => 10000;
 has cleanup => 1;
 has [qw(graceful_timeout heartbeat_timeout)] => 20;
 has heartbeat_interval => 5;
-has pid_file           => sub { catfile tmpdir, 'prefork.pid' };
-has workers            => 4;
+has pid_file => sub { path(File::Spec->tmpdir, 'prefork.pid')->to_string };
+has workers  => 4;
 
 sub DESTROY { unlink $_[0]->pid_file if $_[0]->cleanup }
 

--- a/lib/Mojo/Template.pm
+++ b/lib/Mojo/Template.pm
@@ -4,7 +4,8 @@ use Mojo::Base -base;
 use Carp 'croak';
 use Mojo::ByteStream;
 use Mojo::Exception;
-use Mojo::Util qw(decode encode monkey_patch slurp);
+use Mojo::File 'path';
+use Mojo::Util qw(decode encode monkey_patch);
 
 use constant DEBUG => $ENV{MOJO_TEMPLATE_DEBUG} || 0;
 
@@ -168,7 +169,7 @@ sub render_file {
   my ($self, $path) = (shift, shift);
 
   $self->name($path) unless defined $self->{name};
-  my $template = slurp $path;
+  my $template = path($path)->slurp;
   my $encoding = $self->encoding;
   croak qq{Template "$path" has invalid encoding}
     if $encoding && !defined($template = decode $encoding, $template);

--- a/lib/Mojo/UserAgent/Transactor.pm
+++ b/lib/Mojo/UserAgent/Transactor.pm
@@ -1,11 +1,11 @@
 package Mojo::UserAgent::Transactor;
 use Mojo::Base -base;
 
-use File::Basename 'basename';
 use Mojo::Asset::File;
 use Mojo::Asset::Memory;
 use Mojo::Content::MultiPart;
 use Mojo::Content::Single;
+use Mojo::File 'path';
 use Mojo::JSON 'encode_json';
 use Mojo::Parameters;
 use Mojo::Transaction::HTTP;
@@ -208,7 +208,7 @@ sub _multipart {
         if (my $file = delete $value->{file}) {
           $file = Mojo::Asset::File->new(path => $file) unless ref $file;
           $part->asset($file);
-          $value->{filename} //= basename $file->path
+          $value->{filename} //= path($file->path)->basename
             if $file->isa('Mojo::Asset::File');
         }
 

--- a/lib/Mojolicious.pm
+++ b/lib/Mojolicious.pm
@@ -31,8 +31,8 @@ has log              => sub {
   my $log  = Mojo::Log->new;
   my $home = $self->home;
   my $mode = $self->mode;
-  $log->path($home->rel_file("log/$mode.log"))
-    if -d $home->rel_file('log') && -w _;
+  $log->path($home->child('log', "$mode.log"))
+    if -d $home->child('log') && -w _;
 
   # Reduced log output outside of development mode
   return $mode eq 'development' ? $log : $log->level('info');
@@ -152,8 +152,8 @@ sub new {
   my $self = shift->SUPER::new(@_);
 
   my $home = $self->home;
-  push @{$self->renderer->paths}, $home->rel_file('templates');
-  push @{$self->static->paths},   $home->rel_file('public');
+  push @{$self->renderer->paths}, $home->child('templates');
+  push @{$self->static->paths},   $home->child('public');
 
   # Default to controller and application namespace
   my $r = $self->routes->namespaces(["@{[ref $self]}::Controller", ref $self]);

--- a/lib/Mojolicious/Command/cpanify.pm
+++ b/lib/Mojolicious/Command/cpanify.pm
@@ -1,7 +1,7 @@
 package Mojolicious::Command::cpanify;
 use Mojo::Base 'Mojolicious::Command';
 
-use File::Basename 'basename';
+use Mojo::File 'path';
 use Mojo::Util 'getopt';
 
 has description => 'Upload distribution to CPAN';
@@ -19,7 +19,7 @@ sub run {
     "https://$user:$password\@pause.perl.org/pause/authenquery" => form => {
       HIDDENNAME                        => $user,
       CAN_MULTIPART                     => 1,
-      pause99_add_uri_upload            => basename($file),
+      pause99_add_uri_upload            => path($file)->basename,
       SUBMIT_pause99_add_uri_httpupload => ' Upload this file from my disk ',
       pause99_add_uri_uri               => '',
       pause99_add_uri_httpupload        => {file => $file},

--- a/lib/Mojolicious/Command/test.pm
+++ b/lib/Mojolicious/Command/test.pm
@@ -1,7 +1,7 @@
 package Mojolicious::Command::test;
 use Mojo::Base 'Mojolicious::Command';
 
-use Mojo::Util qw(files getopt);
+use Mojo::Util 'getopt';
 
 has description => 'Run tests';
 has usage => sub { shift->extract_usage };
@@ -11,10 +11,10 @@ sub run {
 
   getopt \@args, 'v|verbose' => \$ENV{HARNESS_VERBOSE};
 
-  if (!@args && (my $home = $self->app->home)) {
-    die "Can't find test directory.\n" unless -d $home->rel_file('t');
-    /\.t$/ and push @args, $_ for files $home->rel_file('t');
-    say qq{Running tests from "}, $home->rel_file('t') . '".';
+  if (!@args && (my $tests = $self->app->home->child('t'))) {
+    die "Can't find test directory.\n" unless -d $tests;
+    @args = $tests->list_tree->grep(qr/\.t$/)->map('to_string')->each;
+    say qq{Running tests from "$tests".};
   }
 
   $ENV{HARNESS_OPTIONS} //= 'c';

--- a/lib/Mojolicious/Controller.pm
+++ b/lib/Mojolicious/Controller.pm
@@ -402,7 +402,7 @@ a L<Mojolicious> object.
   $c->app->log->debug('Hello Mojo');
 
   # Generate path
-  my $path = $c->app->home->rel_file('templates/foo/bar.html.ep');
+  my $path = $c->app->home->child('templates', 'foo', 'bar.html.ep');
 
 =head2 match
 

--- a/lib/Mojolicious/Guides.pod
+++ b/lib/Mojolicious/Guides.pod
@@ -321,8 +321,6 @@ This is the class hierarchy of the L<Mojolicious> distribution.
 
 =item * L<Mojo::Headers>
 
-=item * L<Mojo::Home>
-
 =item * L<Mojo::IOLoop::Subprocess>
 
 =item * L<Mojo::JSON::Pointer>
@@ -460,6 +458,14 @@ This is the class hierarchy of the L<Mojolicious> distribution.
 =item * L<Mojo::Collection>
 
 =item * L<Mojo::DOM>
+
+=item * L<Mojo::File>
+
+=over 2
+
+=item * L<Mojo::Home>
+
+=back
 
 =item * L<Mojo::JSON>
 

--- a/lib/Mojolicious/Guides/Cookbook.pod
+++ b/lib/Mojolicious/Guides/Cookbook.pod
@@ -1543,8 +1543,8 @@ automatically installed with the modules.
   package MyApp;
   use Mojo::Base 'Mojolicious';
 
-  use File::Basename 'dirname';
-  use File::Spec::Functions 'catdir';
+  use Mojo::File 'path';
+  use Mojo::Home;
 
   # Every CPAN module needs a version
   our $VERSION = '1.0';
@@ -1553,13 +1553,13 @@ automatically installed with the modules.
     my $self = shift;
 
     # Switch to installable home directory
-    $self->home->parse(catdir(dirname(__FILE__), 'MyApp'));
+    $self->home(Mojo::Home->new(path(__FILE__)->dirname->child('MyApp')));
 
     # Switch to installable "public" directory
-    $self->static->paths->[0] = $self->home->rel_file('public');
+    $self->static->paths->[0] = $self->home->child('public');
 
     # Switch to installable "templates" directory
-    $self->renderer->paths->[0] = $self->home->rel_file('templates');
+    $self->renderer->paths->[0] = $self->home->child('templates');
 
     $self->plugin('PODRenderer');
 

--- a/lib/Mojolicious/Guides/Rendering.pod
+++ b/lib/Mojolicious/Guides/Rendering.pod
@@ -1151,16 +1151,15 @@ when C<register> is called.
   package Mojolicious::Plugin::AlertAssets;
   use Mojo::Base 'Mojolicious::Plugin';
 
-  use File::Basename 'dirname';
-  use File::Spec::Functions 'catdir';
+  use Mojo::File 'path';
 
   sub register {
     my ($self, $app) = @_;
 
     # Append "templates" and "public" directories
-    my $base = catdir dirname(__FILE__), 'AlertAssets';
-    push @{$app->renderer->paths}, catdir($base, 'templates');
-    push @{$app->static->paths},   catdir($base, 'public');
+    my $base = path(__FILE__)->dirname->child('AlertAssets');
+    push @{$app->renderer->paths}, $base->child('templates')->to_string;
+    push @{$app->static->paths},   $base->child('public')->to_string;
   }
 
   1;

--- a/lib/Mojolicious/Lite.pm
+++ b/lib/Mojolicious/Lite.pm
@@ -2,7 +2,7 @@ package Mojolicious::Lite;
 use Mojo::Base 'Mojolicious';
 
 # "Bender: Bite my shiny metal ass!"
-use File::Basename qw(basename dirname);
+use Mojo::File 'path';
 use Mojo::UserAgent::Server;
 use Mojo::Util 'monkey_patch';
 
@@ -12,7 +12,8 @@ sub import {
   $ENV{MOJO_EXE} ||= (caller)[1];
 
   # Reuse home directory if possible
-  local $ENV{MOJO_HOME} = dirname $ENV{MOJO_EXE} unless $ENV{MOJO_HOME};
+  local $ENV{MOJO_HOME} = path($ENV{MOJO_EXE})->dirname->to_string
+    unless $ENV{MOJO_HOME};
 
   # Initialize application class
   my $caller = caller;
@@ -20,7 +21,7 @@ sub import {
   push @{"${caller}::ISA"}, 'Mojo';
 
   # Generate moniker based on filename
-  my $moniker = basename $ENV{MOJO_EXE};
+  my $moniker = path($ENV{MOJO_EXE})->basename;
   $moniker =~ s/\.(?:pl|pm|t)$//i;
   my $app = shift->new(moniker => $moniker);
 

--- a/lib/Mojolicious/Plugin/Config.pm
+++ b/lib/Mojolicious/Plugin/Config.pm
@@ -1,10 +1,10 @@
 package Mojolicious::Plugin::Config;
 use Mojo::Base 'Mojolicious::Plugin';
 
-use File::Spec::Functions 'file_name_is_absolute';
-use Mojo::Util qw(decode slurp);
+use Mojo::File 'path';
+use Mojo::Util 'decode';
 
-sub load { $_[0]->parse(decode('UTF-8', slurp $_[1]), @_[1, 2, 3]) }
+sub load { $_[0]->parse(decode('UTF-8', path($_[1])->slurp), @_[1, 2, 3]) }
 
 sub parse {
   my ($self, $content, $file, $conf, $app) = @_;
@@ -30,8 +30,8 @@ sub register {
   my $mode = $file =~ /^(.*)\.([^.]+)$/ ? join('.', $1, $app->mode, $2) : '';
 
   my $home = $app->home;
-  $file = $home->rel_file($file) unless file_name_is_absolute $file;
-  $mode = $home->rel_file($mode) if $mode && !file_name_is_absolute $mode;
+  $file = $home->child($file) unless path($file)->is_abs;
+  $mode = $home->child($mode) if $mode && !path($mode)->is_abs;
   $mode = undef unless $mode && -e $mode;
 
   # Read config file
@@ -68,7 +68,7 @@ Mojolicious::Plugin::Config - Perl-ish configuration plugin
     baz => ['♥'],
 
     # You have full access to the application
-    music_dir => app->home->rel_file('music')
+    music_dir => app->home->child('music')
   };
 
   # Mojolicious

--- a/lib/Mojolicious/Plugin/JSONConfig.pm
+++ b/lib/Mojolicious/Plugin/JSONConfig.pm
@@ -48,7 +48,7 @@ Mojolicious::Plugin::JSONConfig - JSON configuration plugin
     "baz": ["♥"],
 
     %# You have full access to the application
-    "music_dir": "<%= app->home->rel_file('music') %>"
+    "music_dir": "<%= app->home->child('music') %>"
   }
 
   # Mojolicious

--- a/lib/Mojolicious/Plugin/PODRenderer.pm
+++ b/lib/Mojolicious/Plugin/PODRenderer.pm
@@ -4,8 +4,8 @@ use Mojo::Base 'Mojolicious::Plugin';
 use Mojo::Asset::File;
 use Mojo::ByteStream;
 use Mojo::DOM;
+use Mojo::File 'path';
 use Mojo::URL;
-use Mojo::Util 'slurp';
 use Pod::Simple::XHTML;
 use Pod::Simple::Search;
 
@@ -85,7 +85,7 @@ sub _perldoc {
   return $c->redirect_to("https://metacpan.org/pod/$module")
     unless $path && -r $path;
 
-  my $src = slurp $path;
+  my $src = path($path)->slurp;
   $c->respond_to(txt => {data => $src}, html => sub { _html($c, $src) });
 }
 

--- a/lib/Mojolicious/Static.pm
+++ b/lib/Mojolicious/Static.pm
@@ -1,10 +1,10 @@
 package Mojolicious::Static;
 use Mojo::Base -base;
 
-use File::Spec::Functions 'catfile';
 use Mojo::Asset::File;
 use Mojo::Asset::Memory;
 use Mojo::Date;
+use Mojo::File 'path';
 use Mojo::Home;
 use Mojo::Loader 'data_section';
 use Mojo::Util 'md5_sum';
@@ -14,7 +14,7 @@ has paths   => sub { [] };
 
 # Bundled files
 my $PUBLIC = Mojo::Home->new(Mojo::Home->new->mojo_lib_dir)
-  ->rel_file('Mojolicious/resources/public');
+  ->child('Mojolicious', 'resources', 'public');
 
 sub dispatch {
   my ($self, $c) = @_;
@@ -41,15 +41,15 @@ sub file {
 
   # Search all paths
   for my $path (@{$self->paths}) {
-    next unless my $asset = $self->_get_file(catfile $path, split('/', $rel));
-    return $asset;
+    my $asset = $self->_get_file(path($path, split('/', $rel))->to_string);
+    return $asset if $asset;
   }
 
   # Search DATA
   if (my $asset = $self->_get_data_file($rel)) { return $asset }
 
   # Search bundled files
-  return $self->_get_file(catfile($PUBLIC, split('/', $rel)));
+  return $self->_get_file(path($PUBLIC, split('/', $rel))->to_string);
 }
 
 sub is_fresh {

--- a/lib/ojo.pm
+++ b/lib/ojo.pm
@@ -5,6 +5,7 @@ use Benchmark qw(timeit timestr :hireswallclock);
 use Mojo::ByteStream 'b';
 use Mojo::Collection 'c';
 use Mojo::DOM;
+use Mojo::File 'path';
 use Mojo::JSON 'j';
 use Mojo::Util qw(dumper monkey_patch);
 
@@ -28,6 +29,7 @@ sub import {
     b => \&b,
     c => \&c,
     d => sub { _request($ua, 'DELETE', @_) },
+    f => \&path,
     g => sub { _request($ua, 'GET',    @_) },
     h => sub { _request($ua, 'HEAD',   @_) },
     j => \&j,
@@ -121,6 +123,12 @@ Turn list into a L<Mojo::Collection> object.
 
 Perform C<DELETE> request with L<Mojo::UserAgent/"delete"> and return resulting
 L<Mojo::Message::Response> object.
+
+=head2 f
+
+  my $path = f('/home/sri/foo.txt');
+
+Turn string into a L<Mojo::File> object.
 
 =head2 g
 

--- a/t/mojo/asset.t
+++ b/t/mojo/asset.t
@@ -1,11 +1,9 @@
 use Mojo::Base -strict;
 
 use Test::More;
-use File::Basename 'dirname';
-use File::Spec::Functions qw(catdir catfile);
-use File::Temp 'tempdir';
 use Mojo::Asset::File;
 use Mojo::Asset::Memory;
+use Mojo::File qw(path tempdir);
 
 # File asset
 my $file = Mojo::Asset::File->new;
@@ -201,19 +199,18 @@ ok !$asset->is_file, 'stored in memory';
 
 # Temporary directory
 {
-  my $tmpdir = tempdir CLEANUP => 1;
-  local $ENV{MOJO_TMPDIR} = $tmpdir;
+  local $ENV{MOJO_TMPDIR} = my $tmpdir = tempdir;
   $file = Mojo::Asset::File->new;
   is($file->tmpdir, $tmpdir, 'same directory');
   $file->add_chunk('works!');
   is $file->slurp, 'works!', 'right content';
-  is dirname($file->path), $tmpdir, 'same directory';
+  is path($file->path)->dirname, $tmpdir, 'same directory';
 }
 
 # Custom temporary file
 {
-  my $tmpdir = tempdir CLEANUP => 1;
-  my $path = catfile $tmpdir, 'test.file';
+  my $tmpdir = tempdir;
+  my $path   = $tmpdir->child('test.file');
   ok !-e $path, 'file does not exist';
   $file = Mojo::Asset::File->new(path => $path);
   is $file->path, $path, 'right path';

--- a/t/mojo/bytestream.t
+++ b/t/mojo/bytestream.t
@@ -1,9 +1,6 @@
 use Mojo::Base -strict;
 
 use Test::More;
-use File::Basename 'dirname';
-use File::Spec::Functions 'catfile';
-use File::Temp 'tempdir';
 use FindBin;
 use Mojo::ByteStream 'b';
 
@@ -134,19 +131,6 @@ b('te', 'st')->say($handle);
   b(1, 2, 3)->say->quote->say;
 }
 is $buffer, "test\n123\n\"123\"\n", 'right output';
-
-# slurp
-my $file = catfile dirname(__FILE__), 'templates', 'exception.mt';
-$stream = b($file)->slurp;
-is $stream, "test\n% die;\n123\n", 'right content';
-$stream = b($file)->slurp->split("\n")->grep(qr/die/)->join;
-is $stream, '% die;', 'right content';
-
-# spurt
-my $dir = tempdir CLEANUP => 1;
-$file = catfile $dir, 'test.txt';
-is b("just\nworks!")->spurt($file)->quote, qq{"just\nworks!"}, 'right result';
-is b($file)->slurp, "just\nworks!", 'successful roundtrip';
 
 # term_escape
 is b("\t\b\r\n\f")->term_escape, "\\x09\\x08\\x0d\n\\x0c", 'right result';

--- a/t/mojo/daemon.t
+++ b/t/mojo/daemon.t
@@ -3,10 +3,9 @@ use Mojo::Base -strict;
 BEGIN { $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll' }
 
 use Test::More;
-use Cwd 'abs_path';
-use File::Spec::Functions 'catdir';
 use FindBin;
 use Mojo;
+use Mojo::File 'path';
 use Mojo::IOLoop;
 use Mojo::Log;
 use Mojo::Server::Daemon;
@@ -65,8 +64,8 @@ is $tx->res->body, 'Hello TestApp!', 'right content';
 
 # Optional home detection
 my @path = qw(th is mojo dir wil l never-ever exist);
-my $app = Mojo->new(home => Mojo::Home->new(catdir @path));
-is $app->home, catdir(@path), 'right home directory';
+my $app = Mojo->new(home => Mojo::Home->new(@path));
+is $app->home, path(@path), 'right home directory';
 
 # Config
 is $app->config('foo'), undef, 'no value';
@@ -83,7 +82,7 @@ is_deeply $app->config, {foo => 'bar', baz => 'yada', test => 23},
 my $daemon = Mojo::Server::Daemon->new;
 my $path   = "$FindBin::Bin/lib/../lib/myapp.pl";
 is ref $daemon->load_app($path), 'Mojolicious::Lite', 'right reference';
-is $daemon->app->config('script'), abs_path($path), 'right script name';
+is $daemon->app->config('script'), path($path)->to_abs, 'right script name';
 is ref $daemon->build_app('TestApp'), 'TestApp', 'right reference';
 is ref $daemon->app, 'TestApp', 'right reference';
 

--- a/t/mojo/file.t
+++ b/t/mojo/file.t
@@ -1,0 +1,133 @@
+use Mojo::Base -strict;
+
+use Test::More;
+use Cwd qw(abs_path getcwd);
+use File::Basename qw(basename dirname);
+use File::Spec::Functions qw(abs2rel catfile splitdir);
+use File::Temp;
+use Mojo::File qw(path tempdir);
+
+# Constructor
+is(Mojo::File->new, getcwd(), 'same path');
+is path(), getcwd(), 'same path';
+is path()->to_string, getcwd(), 'same path';
+is path('/foo/bar'), '/foo/bar', 'same path';
+is path('foo', 'bar', 'baz'), catfile('foo', 'bar', 'baz'), 'same path';
+
+# Tap into method chain
+is path('/home')->tap(sub { $$_ .= '/sri' })->to_string, '/home/sri',
+  'same path';
+
+# Children
+is path('foo', 'bar')->child('baz', 'yada'),
+  catfile(catfile('foo', 'bar'), 'baz', 'yada'), 'same path';
+
+# Array
+is_deeply path('foo', 'bar')->to_array, [splitdir catfile('foo', 'bar')],
+  'same structure';
+is_deeply [@{path('foo', 'bar')}], [splitdir catfile('foo', 'bar')],
+  'same structure';
+
+# Absolute
+is path('file.t')->to_abs, abs_path('file.t'), 'same path';
+
+# Relative
+is path('test.txt')->to_abs->to_rel(getcwd),
+  abs2rel(abs_path('test.txt'), getcwd), 'same path';
+
+# Basename
+is path('file.t')->to_abs->basename, basename(abs_path 'file.t'), 'same path';
+is path('file.t')->to_abs->basename('.t'), basename(abs_path('file.t'), '.t'),
+  'same path';
+
+# Dirname
+is path('file.t')->to_abs->dirname, dirname(abs_path 'file.t'), 'same path';
+
+# Checks
+ok path(__FILE__)->to_abs->is_abs, 'path is absolute';
+ok !path('file.t')->is_abs, 'path is not absolute';
+
+# Temporary directory
+my $dir  = tempdir;
+my $path = "$dir";
+ok -d $path, 'directory exists';
+undef $dir;
+ok !-d $path, 'directory does not exist anymore';
+$dir = tempdir 'mytestXXXXX';
+ok -d $dir, 'directory exists';
+like $dir->basename, qr/mytest.{5}$/, 'right format';
+
+# Temporary diectory (separate object)
+$dir  = Mojo::File->new(File::Temp->newdir);
+$path = "$dir";
+ok -d $path, 'directory exists';
+undef $dir;
+ok !-d $path, 'directory does not exist anymore';
+
+# Make path
+$dir = tempdir;
+my $subdir = $dir->child('foo', 'bar');
+ok !-d $subdir, 'directory does not exist anymore';
+$subdir->make_path;
+ok -d $subdir, 'directory exists';
+
+# Move to
+$dir = tempdir;
+my $destination = $dir->child('dest.txt');
+my $source      = $dir->child('src.txt')->spurt('works!');
+ok -f $source,       'file exists';
+ok !-f $destination, 'file does not exists';
+ok !-f $source->move_to($destination), 'file no longer exists';
+ok -f $destination, 'file exists';
+is $destination->slurp, 'works!', 'right content';
+
+# List
+is_deeply path('does_not_exist')->list->to_array, [], 'no files';
+is_deeply path(__FILE__)->list->to_array,         [], 'no files';
+my $lib = path(__FILE__)->dirname->child('lib', 'Mojo');
+my @files = map { path($lib)->child(split '/') }
+  ('DeprecationTest.pm', 'LoaderException.pm', 'LoaderException2.pm');
+is_deeply path($lib)->list->map('to_string')->to_array, \@files, 'right files';
+unshift @files, $lib->child('.hidden.txt')->to_string;
+is_deeply path($lib)->list({hidden => 1})->map('to_string')->to_array, \@files,
+  'right files';
+@files = map { path($lib)->child(split '/') } (
+  'BaseTest',           'DeprecationTest.pm',
+  'LoaderException.pm', 'LoaderException2.pm',
+  'LoaderTest'
+);
+is_deeply path($lib)->list({dir => 1})->map('to_string')->to_array, \@files,
+  'right files';
+my @hidden = map { path($lib)->child(split '/') } '.hidden.txt', '.test';
+is_deeply path($lib)->list({dir => 1, hidden => 1})->map('to_string')->to_array,
+  [@hidden, @files], 'right files';
+
+# List tree
+is_deeply path('does_not_exist')->list_tree->to_array, [], 'no files';
+is_deeply path(__FILE__)->list_tree->to_array,         [], 'no files';
+@files = map { path($lib)->child(split '/') } (
+  'BaseTest/Base1.pm',  'BaseTest/Base2.pm',
+  'BaseTest/Base3.pm',  'DeprecationTest.pm',
+  'LoaderException.pm', 'LoaderException2.pm',
+  'LoaderTest/A.pm',    'LoaderTest/B.pm',
+  'LoaderTest/C.pm'
+);
+is_deeply path($lib)->list_tree->map('to_string')->to_array, \@files,
+  'right files';
+@hidden = map { path($lib)->child(split '/') } '.hidden.txt',
+  '.test/hidden.txt';
+is_deeply path($lib)->list_tree({hidden => 1})->map('to_string')->to_array,
+  [@hidden, @files], 'right files';
+
+# I/O
+$dir = tempdir;
+my $file = $dir->child('test.txt')->spurt('just works!');
+is $file->slurp, 'just works!', 'right content';
+{
+  no warnings 'redefine';
+  local *IO::Handle::syswrite = sub { $! = 0; 5 };
+  eval { $file->spurt("just\nworks!") };
+  like $@, qr/Can't write to file ".*/, 'right error';
+}
+
+done_testing();

--- a/t/mojo/log.t
+++ b/t/mojo/log.t
@@ -1,20 +1,19 @@
 use Mojo::Base -strict;
 
 use Test::More;
-use File::Spec::Functions 'catfile';
-use File::Temp 'tempdir';
+use Mojo::File qw(path tempdir);
 use Mojo::Log;
-use Mojo::Util qw(decode slurp);
+use Mojo::Util 'decode';
 
 # Logging to file
-my $dir = tempdir CLEANUP => 1;
-my $path = catfile $dir, 'test.log';
-my $log = Mojo::Log->new(level => 'error', path => $path);
+my $dir  = tempdir;
+my $path = $dir->child('test.log');
+my $log  = Mojo::Log->new(level => 'error', path => $path);
 $log->error('Just works');
 $log->fatal('I ♥ Mojolicious');
 $log->debug('Does not work');
 undef $log;
-my $content = decode 'UTF-8', slurp($path);
+my $content = decode 'UTF-8', path($path)->slurp;
 like $content,   qr/\[.*\] \[error\] Just works/,        'right error message';
 like $content,   qr/\[.*\] \[fatal\] I ♥ Mojolicious/, 'right fatal message';
 unlike $content, qr/\[.*\] \[debug\] Does not work/,     'no debug message';

--- a/t/mojo/prefork.t
+++ b/t/mojo/prefork.t
@@ -7,12 +7,10 @@ use Test::More;
 plan skip_all => 'set TEST_PREFORK to enable this test (developer only!)'
   unless $ENV{TEST_PREFORK};
 
-use File::Basename 'dirname';
-use File::Spec::Functions 'catfile';
+use Mojo::File 'path';
 use Mojo::IOLoop::Server;
 use Mojo::Server::Prefork;
 use Mojo::UserAgent;
-use Mojo::Util 'slurp';
 
 # Manage and clean up PID file
 my $prefork = Mojo::Server::Prefork->new;
@@ -20,18 +18,18 @@ my $file    = $prefork->pid_file;
 ok !$prefork->check_pid, 'no process id';
 $prefork->ensure_pid_file(-23);
 ok -e $file, 'file exists';
-is slurp($file), "-23\n", 'right process id';
+is path($file)->slurp, "-23\n", 'right process id';
 ok !$prefork->check_pid, 'no process id';
 ok !-e $file, 'file has been cleaned up';
 $prefork->ensure_pid_file($$);
 ok -e $file, 'file exists';
-is slurp($file), "$$\n", 'right process id';
+is path($file)->slurp, "$$\n", 'right process id';
 is $prefork->check_pid, $$, 'right process id';
 undef $prefork;
 ok !-e $file, 'file has been cleaned up';
 
 # Bad PID file
-my $bad = catfile dirname(__FILE__), 'does_not_exist', 'test.pid';
+my $bad = path(__FILE__)->dirname->child('does_not_exist', 'test.pid');
 $prefork = Mojo::Server::Prefork->new(pid_file => $bad);
 $prefork->app->log->level('fatal');
 my $log = '';

--- a/t/mojo/request.t
+++ b/t/mojo/request.t
@@ -1,12 +1,11 @@
 use Mojo::Base -strict;
 
 use Test::More;
-use File::Spec::Functions 'catfile';
-use File::Temp 'tempdir';
 use IO::Compress::Gzip 'gzip';
 use Mojo::Content::Single;
 use Mojo::Content::MultiPart;
 use Mojo::Cookie::Request;
+use Mojo::File 'tempdir';
 use Mojo::Message::Request;
 use Mojo::URL;
 use Mojo::Util 'encode';
@@ -760,7 +759,8 @@ is $req->body_params->to_hash->{text2}, '', 'right value';
 is $req->upload('upload')->filename, 'hello.pl', 'right filename';
 ok !$req->upload('upload')->asset->is_file, 'stored in memory';
 is $req->upload('upload')->asset->size, 69, 'right size';
-my $file = catfile(tempdir(CLEANUP => 1), ("MOJO_TMP." . time . ".txt"));
+my $tempdir = tempdir;
+my $file    = $tempdir->child('MOJO_TMP.' . time . '.txt');
 is $req->upload('upload')->move_to($file)->filename, 'hello.pl',
   'right filename';
 ok unlink($file), 'unlinked file';

--- a/t/mojo/template.t
+++ b/t/mojo/template.t
@@ -1,8 +1,7 @@
 use Mojo::Base -strict;
 
 use Test::More;
-use File::Basename 'dirname';
-use File::Spec::Functions 'catfile';
+use Mojo::File 'path';
 use Mojo::Template;
 
 package MyTemplateExporter;
@@ -651,21 +650,21 @@ EOF
 isa_ok $output, 'Mojo::Exception', 'right exception';
 like $output->message, qr/ohoh/, 'right message';
 ok $output->verbose, 'verbose exception';
-is $output->lines_before->[0][0], 15,  'right number';
+is $output->lines_before->[0][0], 14,  'right number';
 is $output->lines_before->[0][1], '}', 'right line';
-is $output->lines_before->[1][0], 16,  'right number';
+is $output->lines_before->[1][0], 15,  'right number';
 is $output->lines_before->[1][1], '',  'right line';
-is $output->lines_before->[2][0], 17,  'right number';
+is $output->lines_before->[2][0], 16,  'right number';
 is $output->lines_before->[2][1], 'package MyTemplateException;', 'right line';
-is $output->lines_before->[3][0], 18,                        'right number';
+is $output->lines_before->[3][0], 17,                        'right number';
 is $output->lines_before->[3][1], 'use Mojo::Base -strict;', 'right line';
-is $output->lines_before->[4][0], 19,                        'right number';
+is $output->lines_before->[4][0], 18,                        'right number';
 is $output->lines_before->[4][1], '',                        'right line';
-is $output->line->[0], 20, 'right number';
+is $output->line->[0], 19, 'right number';
 is $output->line->[1], "sub exception { die 'ohoh' }", 'right line';
-is $output->lines_after->[0][0], 21,              'right number';
+is $output->lines_after->[0][0], 20,              'right number';
 is $output->lines_after->[0][1], '',              'right line';
-is $output->lines_after->[1][0], 22,              'right number';
+is $output->lines_after->[1][0], 21,              'right number';
 is $output->lines_after->[1][1], 'package main;', 'right line';
 like "$output", qr/ohoh/, 'right result';
 
@@ -1106,13 +1105,13 @@ EOF
 
 # File
 $mt = Mojo::Template->new;
-my $file = catfile dirname(__FILE__), 'templates', 'test.mt';
+my $file = path(__FILE__)->dirname->child('templates', 'test.mt');
 $output = $mt->render_file($file, 3);
 like $output, qr/23\nHello World!/, 'file';
 
 # Exception in file
 $mt     = Mojo::Template->new;
-$file   = catfile dirname(__FILE__), 'templates', 'exception.mt';
+$file   = path(__FILE__)->dirname->child('templates', 'exception.mt');
 $output = $mt->render_file($file);
 isa_ok $output, 'Mojo::Exception', 'right exception';
 like $output->message, qr/exception\.mt line 2/, 'message contains filename';
@@ -1142,7 +1141,7 @@ like "$output", qr/foo\.mt from DATA section line 2/, 'right result';
 
 # Exception with UTF-8 context
 $mt     = Mojo::Template->new;
-$file   = catfile dirname(__FILE__), 'templates', 'utf8_exception.mt';
+$file   = path(__FILE__)->dirname->child('templates', 'utf8_exception.mt');
 $output = $mt->render_file($file);
 isa_ok $output, 'Mojo::Exception', 'right exception';
 ok $output->verbose, 'verbose exception';
@@ -1163,7 +1162,7 @@ is $output->lines_after->[0], undef, 'no lines after';
 
 # Different encodings
 $mt = Mojo::Template->new(encoding => 'shift_jis');
-$file = catfile dirname(__FILE__), 'templates', 'utf8_exception.mt';
+$file = path(__FILE__)->dirname->child('templates', 'utf8_exception.mt');
 ok !eval { $mt->render_file($file) }, 'file not rendered';
 like $@, qr/invalid encoding/, 'right error';
 

--- a/t/mojo/util.t
+++ b/t/mojo/util.t
@@ -4,19 +4,16 @@ use FindBin;
 use lib "$FindBin::Bin/lib";
 
 use Test::More;
-use File::Basename 'dirname';
-use File::Spec::Functions qw(catdir catfile splitdir);
-use File::Temp 'tempdir';
 use Mojo::ByteStream 'b';
 use Mojo::DeprecationTest;
 
 use Mojo::Util
   qw(b64_decode b64_encode camelize class_to_file class_to_path decamelize),
-  qw(decode dumper encode files getopt hmac_sha1_sum html_unescape md5_bytes),
-  qw(md5_sum monkey_patch punycode_decode punycode_encode quote secure_compare),
-  qw(secure_compare sha1_bytes sha1_sum slurp split_cookie_header),
-  qw(split_header spurt steady_time tablify term_escape trim unindent unquote),
-  qw(url_escape url_unescape xml_escape xor_encode);
+  qw(decode dumper encode getopt hmac_sha1_sum html_unescape md5_bytes md5_sum),
+  qw(monkey_patch punycode_decode punycode_encode quote secure_compare),
+  qw(sha1_bytes sha1_sum split_cookie_header split_header steady_time tablify),
+  qw(term_escape trim unindent unquote url_escape url_unescape xml_escape),
+  qw(xor_encode);
 
 # camelize
 is camelize('foo_bar_baz'), 'FooBarBaz', 'right camelized result';
@@ -411,40 +408,6 @@ is xor_encode("\x10\x1d\x14\x14\x17\x58\x0f\x17\x0a\x14\x1c", 'x'),
   'hello world', 'right result';
 is xor_encode('hello', '123456789'), "\x59\x57\x5f\x58\x5a", 'right result';
 is xor_encode("\x59\x57\x5f\x58\x5a", '123456789'), 'hello', 'right result';
-
-# slurp
-is slurp(catfile(dirname(__FILE__), 'templates', 'exception.mt')),
-  "test\n% die;\n123\n", 'right content';
-
-# spurt
-my $dir = tempdir CLEANUP => 1;
-my $file = catfile $dir, 'test.txt';
-spurt "just\nworks!", $file;
-is slurp($file), "just\nworks!", 'successful roundtrip';
-
-# spurt (incomplete write)
-{
-  no warnings 'redefine';
-  local *IO::Handle::syswrite = sub { $! = 0; 5 };
-  eval { spurt "just\nworks!", $file };
-  like $@, qr/Can't write to file ".*/, 'right error';
-}
-
-# files
-is_deeply [files 'does_not_exist'], [], 'no files';
-is_deeply [files __FILE__],         [], 'no files';
-my $lib = catdir dirname(__FILE__), 'lib', 'Mojo';
-my @files = map { catfile $lib, split '/' } (
-  'BaseTest/Base1.pm',  'BaseTest/Base2.pm',
-  'BaseTest/Base3.pm',  'DeprecationTest.pm',
-  'LoaderException.pm', 'LoaderException2.pm',
-  'LoaderTest/A.pm',    'LoaderTest/B.pm',
-  'LoaderTest/C.pm'
-);
-is_deeply [map { catfile splitdir $_ } files $lib], \@files, 'right files';
-my @hidden = map { catfile $lib, split '/' } '.hidden.txt', '.test/hidden.txt';
-is_deeply [map { catfile splitdir $_ } files $lib, {hidden => 1}],
-  [@hidden, @files], 'right files';
 
 # steady_time
 like steady_time, qr/^[\d.]+$/, 'high resolution time';

--- a/t/mojo/websocket.t
+++ b/t/mojo/websocket.t
@@ -20,7 +20,7 @@ use Mojolicious::Lite;
 app->log->level('fatal');
 
 # Avoid exception template
-app->renderer->paths->[0] = app->home->rel_file('public');
+app->renderer->paths->[0] = app->home->child('public');
 
 get '/link' => sub {
   my $c = shift;

--- a/t/mojolicious/app.t
+++ b/t/mojolicious/app.t
@@ -11,9 +11,9 @@ use Test::More;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 
-use File::Spec::Functions 'catfile';
 use Mojo::Asset::File;
 use Mojo::Date;
+use Mojo::File 'path';
 use Mojo::IOLoop;
 use Mojolicious;
 use Mojolicious::Controller;
@@ -390,7 +390,7 @@ like $log, qr/Controller "MojoliciousTest::Another" does not exist/,
 $t->app->log->unsubscribe(message => $cb);
 
 # Check Last-Modified header for static files
-my $path = catfile($FindBin::Bin, 'public_dev', 'hello.txt');
+my $path = path($FindBin::Bin, 'public_dev', 'hello.txt');
 my $size = Mojo::Asset::File->new(path => $path)->size;
 my $mtime
   = Mojo::Date->new(Mojo::Asset::File->new(path => $path)->mtime)->to_string;

--- a/t/mojolicious/command.t
+++ b/t/mojolicious/command.t
@@ -3,9 +3,7 @@ use Mojo::Base -strict;
 BEGIN { $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll' }
 
 use Test::More;
-use Cwd 'getcwd';
-use File::Spec::Functions 'catdir';
-use File::Temp 'tempdir';
+use Mojo::File qw(path tempdir);
 use Mojolicious::Command;
 
 # Application
@@ -14,8 +12,8 @@ isa_ok $command->app, 'Mojo',        'right application';
 isa_ok $command->app, 'Mojolicious', 'right application';
 
 # Creating directories
-my $cwd = getcwd;
-my $dir = tempdir CLEANUP => 1;
+my $cwd = path;
+my $dir = tempdir;
 chdir $dir;
 my $buffer = '';
 {
@@ -24,7 +22,7 @@ my $buffer = '';
   $command->create_rel_dir('foo/bar');
 }
 like $buffer, qr/[mkdir]/, 'right output';
-ok -d catdir(qw(foo bar)), 'directory exists';
+ok -d path('foo', 'bar'), 'directory exists';
 $buffer = '';
 {
   open my $handle, '>', \$buffer;
@@ -35,6 +33,7 @@ like $buffer, qr/\[exist\]/, 'right output';
 chdir $cwd;
 
 # Generating files
+is $command->rel_file('foo/bar.txt')->basename, 'bar.txt', 'right result';
 my $template = "@@ foo_bar\njust <%= 'works' %>!\n";
 open my $data, '<', \$template;
 no strict 'refs';

--- a/t/mojolicious/commands.t
+++ b/t/mojolicious/commands.t
@@ -10,8 +10,7 @@ use Test::More;
 use FindBin;
 use lib "$FindBin::Bin/lib";
 
-use Cwd 'getcwd';
-use File::Temp 'tempdir';
+use Mojo::File qw(path tempdir);
 
 package Mojolicious::Command::my_fake_test_command;
 
@@ -239,8 +238,8 @@ require Mojolicious::Command::generate::app;
 $app = Mojolicious::Command::generate::app->new;
 ok $app->description, 'has a description';
 like $app->usage, qr/app/, 'has usage information';
-my $cwd = getcwd;
-my $dir = tempdir CLEANUP => 1;
+my $cwd = path;
+my $dir = tempdir;
 chdir $dir;
 $buffer = '';
 {

--- a/t/mojolicious/exception_lite_app.t
+++ b/t/mojolicious/exception_lite_app.t
@@ -10,7 +10,7 @@ use Mojolicious::Lite;
 use Test::Mojo;
 
 # No real templates
-app->renderer->paths->[0] = app->home->rel_file('does_not_exist');
+app->renderer->paths->[0] = app->home->child('does_not_exist');
 
 # Logger
 app->log->handle(undef);

--- a/t/mojolicious/json_config_lite_app.t
+++ b/t/mojolicious/json_config_lite_app.t
@@ -6,9 +6,7 @@ BEGIN {
 }
 
 use Test::More;
-use Cwd 'abs_path';
-use File::Basename 'dirname';
-use File::Spec::Functions 'catfile';
+use Mojo::File 'path';
 use Mojolicious::Lite;
 use Test::Mojo;
 
@@ -23,7 +21,8 @@ like $@, qr/Malformed JSON/, 'right error';
 # Load plugins
 my $config
   = plugin j_s_o_n_config => {default => {foo => 'baz', hello => 'there'}};
-my $path = abs_path catfile(dirname(__FILE__), 'json_config_lite_app_abs.json');
+my $path
+  = path(__FILE__)->to_abs->dirname->child('json_config_lite_app_abs.json');
 plugin JSONConfig => {file => $path};
 is $config->{foo},          'bar',            'right value';
 is $config->{hello},        'there',          'right value';

--- a/t/mojolicious/layouted_lite_app.t
+++ b/t/mojolicious/layouted_lite_app.t
@@ -13,7 +13,7 @@ use Test::Mojo;
 # Plugin with a template
 plugin 'PluginWithTemplate';
 
-app->renderer->paths->[0] = app->home->rel_file('does_not_exist');
+app->renderer->paths->[0] = app->home->child('does_not_exist');
 
 # Reverse filter
 hook after_render => sub {

--- a/t/mojolicious/lib/MojoliciousTest.pm
+++ b/t/mojolicious/lib/MojoliciousTest.pm
@@ -13,7 +13,7 @@ sub startup {
     unshift @{$self->renderer->classes}, 'MojoliciousTest::Foo';
 
     # Static root for development
-    unshift @{$self->static->paths}, $self->home->rel_file('public_dev');
+    unshift @{$self->static->paths}, $self->home->child('public_dev');
 
     # Development namespace
     unshift @{$self->routes->namespaces}, 'MojoliciousTest3';

--- a/t/mojolicious/multipath_lite_app.t
+++ b/t/mojolicious/multipath_lite_app.t
@@ -7,8 +7,8 @@ use Mojolicious::Lite;
 use Test::Mojo;
 
 # More paths with higher precedence
-unshift @{app->renderer->paths}, app->home->rel_file('templates2');
-unshift @{app->static->paths},   app->home->rel_file('public2');
+unshift @{app->renderer->paths}, app->home->child('templates2');
+unshift @{app->static->paths},   app->home->child('public2');
 
 get '/twenty_three' => '23';
 

--- a/t/mojolicious/ojo.t
+++ b/t/mojolicious/ojo.t
@@ -8,6 +8,7 @@ BEGIN {
 
 use Test::More;
 use ojo;
+use File::Basename 'basename';
 
 # Application
 a('/' => sub { $_->render(data => $_->req->method . $_->req->body) })
@@ -43,6 +44,9 @@ is b('<foo>')->url_escape, '%3Cfoo%3E', 'right result';
 
 # Collection
 is c(1, 2, 3)->join('-'), '1-2-3', 'right result';
+
+# File
+is f(__FILE__)->basename, basename(__FILE__), 'right result';
 
 # Dumper
 is r([1, 2]), "[\n  1,\n  2\n]\n", 'right result';

--- a/t/pod_coverage.t
+++ b/t/pod_coverage.t
@@ -8,4 +8,6 @@ plan skip_all => 'Test::Pod::Coverage 1.04+ required for this test!'
   unless eval 'use Test::Pod::Coverage 1.04; 1';
 
 # DEPRECATED!
-all_pod_coverage_ok({also_private => [qw(list_files rel_dir is_status_class)]});
+my @deprecated
+  = qw(files is_status_class lib_dir parse parts rel_dir slurp spurt);
+all_pod_coverage_ok({also_private => \@deprecated});


### PR DESCRIPTION
### Summary
This patch adds a `Mojo::File` module to encapsulate most of the code we use to interact with file systems on different operating systems. Its scope is currently limited to things we need and use in Mojolicious itself.

While i was a bit sceptical at first about the value it will add to the project. After seeing the improvements it brought to tests and documentation, i think it has the potential to make a lot of code look quite a bit cleaner.

There is a small performance cost, due to a lot of `Mojo::File` objects getting instantiated and method call overhead. But all tests so far suggest that this is negligible.

### Motivation
There's a lot of `File::*` modules we use in Mojolicious (`File::Basename`, `File::Spec`, `File::Find`, `File::Copy`, `File::Path`...). Their use is very decentralized at the moment, even though we've already written our own little extensions, like `files()`, `slurp()` and `spurt()`, which we had to put into `Mojo::Util`. So i think it might make sense to re-evaluate this approach.

### References
https://groups.google.com/d/msg/mojolicious/8ld7jmH-qbg/wO2OCkCsEQAJ
