### PR TITLE
fix bug with detect home dir

### DIFF
--- a/lib/Mojo/Home.pm
+++ b/lib/Mojo/Home.pm
@@ -13,7 +13,7 @@ sub detect {
   # Location of the application class (Windows mixes backslash and slash)
   elsif ($class && (my $path = $INC{my $file = class_to_path $class})) {
     $path =~ s!\\!/!g;
-    $path =~ s!(?:/b?lib)?/\Q$file\E$!!;
+    $path =~ s!(?:(?:\A|/)b?lib)?/\Q$file\E$!!;
     $detected = Mojo::File->new($path)->to_abs;
   }
 

--- a/t/mojo/home.t
+++ b/t/mojo/home.t
@@ -40,6 +40,20 @@ use Mojo::Home;
   is_deeply $home->to_array, $fake->to_array, 'right path detected';
 }
 
+# Specific class detection (with relative "lib")
+{
+  local $INC{'My/Class.pm'} = path('lib', 'My', 'Class.pm')->to_string;
+  my $home = Mojo::Home->new->detect('My::Class');
+  is_deeply $home->to_array, path->to_array, 'right path detected';
+}
+
+# Specific class detection (with relative "blib")
+{
+  local $INC{'My/Class.pm'} = path('blib', 'My', 'Class.pm')->to_string;
+  my $home = Mojo::Home->new->detect('My::Class');
+  is_deeply $home->to_array, path->to_array, 'right path detected';
+}
+
 # Current working directory
 my $home = Mojo::Home->new->detect;
 is_deeply $home->to_array, path->to_abs->to_array, 'right path detected';


### PR DESCRIPTION
### Summary
Upgrade to `Mojolicious` 7.15+ breaks mojolicious apps, which was created by `mojo generate app` before 6.40. In new versions (https://github.com/kraih/mojo/commit/f662f968b590c79f205ea12094285c080391e858) startup script use `FindBin` which add absolute path in `@INC`, old versions use `use lib 'lib'` which add relative path to app in `@INC`.

So, for old apps `Mojo::Home` detect home dir with extra `lib` suffix.

Steps to reproduce bug:

```
and@google:~/tmp/x$ pwd
/home/and/tmp/x
and@google:~/tmp/x$ mojo version
CORE
  Perl        (v5.22.2, linux)
  Mojolicious (7.15, Doughnut)

OPTIONAL
  EV 4.0+                 (4.22)
  IO::Socket::Socks 0.64+ (n/a)
  IO::Socket::SSL 1.94+   (2.043)
  Net::DNS::Native 0.15+  (n/a)

You might want to update your Mojolicious to 7.16!
and@google:~/tmp/x$ mojo generate app
  [exist] /home/and/tmp/x/my_app/script/my_app
  [chmod] /home/and/tmp/x/my_app/script/my_app 744
  [exist] /home/and/tmp/x/my_app/lib/MyApp.pm
  [exist] /home/and/tmp/x/my_app/lib/MyApp/Controller/Example.pm
  [exist] /home/and/tmp/x/my_app/t/basic.t
  [exist] /home/and/tmp/x/my_app/public/index.html
  [exist] /home/and/tmp/x/my_app/templates/layouts/default.html.ep
  [exist] /home/and/tmp/x/my_app/templates/example/welcome.html.ep
and@google:~/tmp/x$ ls
my_app
and@google:~/tmp/x$ cd my_app/
and@google:~/tmp/x/my_app$ ./script/my_app eval 'say app->home'
/home/and/tmp/x/my_app
```

Then change `script/my_app` to use `use lib 'lib';` instead of `use FindBin; BEGIN ...` and get broken app. The saddest thing is that the tests that are started via `prove` run correctly.

```
and@google:~/tmp/x/my_app$ cat ./script/my_app 
#!/usr/bin/env perl

use strict;
use warnings;

use lib 'lib';
use Mojolicious::Commands;

# Start command line interface for application
Mojolicious::Commands->start_app('MyApp');
and@google:~/tmp/x/my_app$ ./script/my_app eval 'say app->home'
/home/and/tmp/x/my_app/lib
```