### PR TITLE
fix "split to @_ is deprecated" warning

### DIFF
--- a/lib/Mojo/Home.pm
+++ b/lib/Mojo/Home.pm
@@ -13,7 +13,8 @@ sub detect {
   # Location of the application class (Windows mixes backslash and slash)
   elsif ($class && (my $path = $INC{my $file = class_to_path $class})) {
     $home = Mojo::File->new($path)->to_array;
-    splice @$home, split('/', $file) * -1;
+    my @file_parts = split '/', $file;
+    splice @$home, @file_parts * -1;
     pop @$home if @$home && ($home->[-1] eq 'blib' || $home->[-1] eq 'lib');
   }
 


### PR DESCRIPTION
On Perl 5.10, perl is incorrectly interpreting any split not assigned to
an array as a split intended to replace @_. Since this behavior was
deprecated, Perl is warning about it. This warning is causing tests in
downstream modules (like my Mercury application) which check for
warnings to fail.

I can't find when this deprecation was added (before 5.6), but the
feature was removed from Perl in 5.12, and the warning fixed to only
apply to split called in void context.

The only syntax that prevents this warning is assigning the result of
split to an array. Disabling the category of this warning ("syntax", as
reported in perldiag) does not seem to prevent this warning, but
disabling all warnings does.