### PR TITLE
Testing Mojo::DOM with Test::Mojo

### DIFF
--- a/lib/Test/Mojo.pm
+++ b/lib/Test/Mojo.pm
@@ -16,6 +16,7 @@ use Mojo::UserAgent;
 use Mojo::Util qw(decode encode);
 use Test::More ();
 
+has dom => sub { shift->tx->res->dom };
 has [qw(message success tx)];
 has ua => sub { Mojo::UserAgent->new->ioloop(Mojo::IOLoop->singleton) };
 
@@ -85,7 +86,7 @@ sub delete_ok { shift->_build_ok(DELETE => @_) }
 
 sub element_count_is {
   my ($self, $selector, $count, $desc) = @_;
-  my $size = $self->tx->res->dom->find($selector)->size;
+  my $size = $self->dom->find($selector)->size;
   return $self->_test('is', $size, $count,
     _desc($desc, qq{element count for selector "$selector"}));
 }
@@ -93,13 +94,13 @@ sub element_count_is {
 sub element_exists {
   my ($self, $selector, $desc) = @_;
   $desc = _desc($desc, qq{element for selector "$selector" exists});
-  return $self->_test('ok', $self->tx->res->dom->at($selector), $desc);
+  return $self->_test('ok', $self->dom->at($selector), $desc);
 }
 
 sub element_exists_not {
   my ($self, $selector, $desc) = @_;
   $desc = _desc($desc, qq{no element for selector "$selector"});
-  return $self->_test('ok', !$self->tx->res->dom->at($selector), $desc);
+  return $self->_test('ok', !$self->dom->at($selector), $desc);
 }
 
 sub finish_ok {
@@ -371,6 +372,7 @@ sub _request_ok {
     my $desc = _desc("WebSocket handshake with $url");
     return $self->_test('ok', $self->tx->is_websocket, $desc);
   }
+  delete $self->{dom};
 
   # Perform request
   $self->tx($self->ua->start($tx));
@@ -387,7 +389,7 @@ sub _test {
 }
 
 sub _text {
-  return '' unless my $e = shift->tx->res->dom->at(shift);
+  return '' unless my $e = shift->dom->at(shift);
   return $e->text;
 }
 
@@ -449,6 +451,13 @@ C<HARNESS_IS_VERBOSE> environment variable.
 =head1 ATTRIBUTES
 
 L<Test::Mojo> implements the following attributes.
+
+=head2 dom
+
+  my $dom = $t->dom;
+  $t      = $t->dom(Mojo::DOM->new);
+
+Current L<Mojo::DOM> object. Defaults to DOM from the current transaction.
 
 =head2 message
 

--- a/t/mojo/test.t
+++ b/t/mojo/test.t
@@ -1,0 +1,21 @@
+
+use Mojo::Base -strict;
+
+BEGIN {
+  $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll';
+}
+use Mojolicious::Lite;
+
+get('/' => sub { shift->render(text => '<b>wrong</b>') });
+
+use Test::More;
+use Test::Mojo;
+
+my $t = Test::Mojo->new();
+isa_ok($t, 'Test::Mojo', 'right class');
+can_ok($t, qw/tx ua dom/);
+$t->dom(Mojo::DOM->new('<b>right</b>'));
+$t->text_is('b', 'right', 'dom can be set');
+$t->get_ok('/')->text_is('b', 'wrong', 'dom reset on request');
+
+done_testing;


### PR DESCRIPTION
### Summary
Expose dom as an attribute on Test::Mojo to allow testing Mojo::DOM objects without involving a user agent. Revised version of #1045 with new tests instead of changing t/mojo/dom.t

```
my $t=Test::Mojo->new();
$t->dom(Mojo::DOM->new('<foo>bar</foo>'));
$t->is_text('foo','bar');
```

### Motivation
This makes it easy to use Test::Mojo to test the contents of HTML/XML strings.
