### PR TITLE
Avoid utf8 warnings for non-utf8 files in Mojo::Exception::inspect

### DIFF
--- a/lib/Mojo/Exception.pm
+++ b/lib/Mojo/Exception.pm
@@ -20,7 +20,15 @@ sub inspect {
   # Search for context in files
   for my $file (@files) {
     next unless -r $file->[0] && open my $handle, '<:utf8', $file->[0];
-    $self->_context($file->[1], [[<$handle>]]);
+    # If there are UTF-8 problems in the source file, don't store any context
+    my @lines = eval {
+      use warnings 'FATAL' => 'utf8';
+      <$handle>;
+    };
+    if ($@) {
+      next;
+    }
+    $self->_context($file->[1], [\@lines]);
     return $self;
   }
 


### PR DESCRIPTION
Instead source files with illegal utf8 chars are ignored as if they
were unreadable. See these two discussions:

https://groups.google.com/d/msg/mojolicious/55jAXEbWzG0/kPY4BEjJBQAJ
https://groups.google.com/d/msg/mojolicious/6c-ZavT2KzQ/vTsJO2E6RQkJ

### Summary
If there were exceptions in source files that happen to have non-UTF-8 characters Mojo::Exception generated UTF-8 related warnings, even when these source files are completely legal perl.

### Motivation
The proposed commit makes no changes whatsoever to correctly UTF-8-encoded files, and does the simplest possible for non-UTF8 files - ignores them completely.

### References
https://groups.google.com/d/msg/mojolicious/55jAXEbWzG0/kPY4BEjJBQAJ
https://groups.google.com/d/msg/mojolicious/6c-ZavT2KzQ/vTsJO2E6RQkJ
