### PR TITLE
Proposed fix for #1054

### DIFF
--- a/lib/Mojo/IOLoop/Subprocess.pm
+++ b/lib/Mojo/IOLoop/Subprocess.pm
@@ -34,12 +34,14 @@ sub run {
   }
 
   # Parent
+  my $me     = $$;
   my $stream = Mojo::IOLoop::Stream->new($reader)->timeout(0);
   $self->ioloop->stream($stream);
   my $buffer = '';
   $stream->on(read => sub { $buffer .= pop });
   $stream->on(
     close => sub {
+      return unless $$ == $me;
       waitpid $pid, 0;
       my $results = eval { $self->deserialize->($buffer) } || [];
       $self->$parent(shift(@$results) // $@, @$results);

--- a/t/mojo/subprocess.t
+++ b/t/mojo/subprocess.t
@@ -145,4 +145,17 @@ $subprocess->run(
 Mojo::IOLoop->start;
 like $fail, qr/Whatever/, 'right error';
 
+# Stream inherited by previous subprocesses, #1054
+my $me = $$;
+for (0 .. 2) {
+  my $subprocess = Mojo::IOLoop::Subprocess->new;
+  $subprocess->run(
+    sub { 1 + 1 },
+    sub {
+      my ($subprocess, $err) = @_;
+      is $me, $$, 'correct parent';
+    }
+  );
+}
+
 done_testing();


### PR DESCRIPTION
Exit early when the subprocess parent callback is in the wrong process

Closes #1054, see also:
  * http://irclog.perlgeek.de/mojo/2016-08-26#i_13096567
      - http://irclog.perlgeek.de/mojo/2014-07-23#i_9067566
      - https://gist.github.com/oe​tiker/bbd3e468b0d25815738c
  * http://irclog.perlgeek.de/mojo/2016-08-27#i_13101743

Note that I have adapted the example from the bug report as a test. I'd like to see that tested on a few platforms before merging.