### PR TITLE
document that around_action can be called more than once

### DIFF
--- a/lib/Mojolicious.pm
+++ b/lib/Mojolicious.pm
@@ -332,9 +332,10 @@ action dispatching is the last hook in the chain, yours will run before it.
 
 This is a very powerful hook and should not be used lightly, it allows you for
 example to pass additional arguments to actions or handle return values
-differently. (Passed a callback leading to the next hook, the current
-controller object, the action callback and a flag indicating if this action is
-an endpoint)
+differently. Note that this hook can be run more than once for the current
+request, for example when using nested routes. (Passed a callback leading
+to the next hook, the current controller object, the action callback and a
+flag indicating if this action is an endpoint)
 
 =head2 before_render
 


### PR DESCRIPTION
### Summary
Document that around_action can be called more than once for the current request.

### Motivation
Because this is perhaps surprising.

### References
https://irclog.perlgeek.de/mojo/2017-02-16#i_14111623