### PR TITLE
Accept SameSite cookie attribute.

### DIFF
--- a/lib/Mojolicious/Sessions.pm
+++ b/lib/Mojolicious/Sessions.pm
@@ -4,7 +4,7 @@ use Mojo::Base -base;
 use Mojo::JSON;
 use Mojo::Util qw(b64_decode b64_encode);
 
-has [qw(cookie_domain secure)];
+has [qw(cookie_domain secure samesite)];
 has cookie_name        => 'mojolicious';
 has cookie_path        => '/';
 has default_expiration => 3600;
@@ -55,6 +55,7 @@ sub store {
     expires  => $session->{expires},
     httponly => 1,
     path     => $self->cookie_path,
+    samesite => $self->samesite,
     secure   => $self->secure
   };
   $c->signed_cookie($self->cookie_name, $value, $options);
@@ -139,6 +140,15 @@ A callback used to deserialize sessions, defaults to L<Mojo::JSON/"j">.
     my $bytes = shift;
     return {};
   });
+
+=head2 samesite
+
+  my $same_site = $sessions->same_site;
+  $sessions = $sessions->same_site('Lax');
+
+Sets the "SameSite" cookie attribute as defined in
+L<https://tools.ietf.org/html/draft-ietf-httpbis-cookie-same-site-00>.
+Acceptable values are C<lax> and C<strict>.
 
 =head2 secure
 

--- a/t/mojo/cookie.t
+++ b/t/mojo/cookie.t
@@ -143,6 +143,14 @@ $cookie->value('ba r');
 $cookie->path('/test');
 is $cookie->to_string, 'foo="ba r"; path=/test', 'right format';
 
+# Response cookie with SameSite attribute as string
+$cookie = Mojo::Cookie::Response->new;
+$cookie->name('foo');
+$cookie->value('ba r');
+$cookie->path('/test');
+$cookie->samesite('lax');
+is $cookie->to_string, 'foo="ba r"; path=/test; SameSite=Lax', 'SameSite attribute';
+
 # Response cookie without value as string
 $cookie = Mojo::Cookie::Response->new;
 $cookie->name('foo');
@@ -196,28 +204,30 @@ is $cookies->[2], undef, 'no more cookies';
 $cookies
   = Mojo::Cookie::Response->parse(
       'foo="ba r"; Domain=example.com; Path=/test; Max-Age=60;'
-    . ' Expires=Thu, 07 Aug 2008 07:07:59 GMT; Secure;');
-is $cookies->[0]->name,    'foo',         'right name';
-is $cookies->[0]->value,   'ba r',        'right value';
-is $cookies->[0]->domain,  'example.com', 'right domain';
-is $cookies->[0]->path,    '/test',       'right path';
-is $cookies->[0]->max_age, 60,            'right max age value';
-is $cookies->[0]->expires, 1218092879,    'right expires value';
-is $cookies->[0]->secure,  1,             'right secure flag';
+    . ' Expires=Thu, 07 Aug 2008 07:07:59 GMT; Secure; SameSite=Strict');
+is $cookies->[0]->name,     'foo',         'right name';
+is $cookies->[0]->value,    'ba r',        'right value';
+is $cookies->[0]->domain,   'example.com', 'right domain';
+is $cookies->[0]->path,     '/test',       'right path';
+is $cookies->[0]->max_age,  60,            'right max age value';
+is $cookies->[0]->expires,  1218092879,    'right expires value';
+is $cookies->[0]->secure,   1,             'right secure flag';
+is $cookies->[0]->samesite, 'strict',      'right samesite attribute';
 is $cookies->[1], undef, 'no more cookies';
 
 # Parse response cookie with invalid flag (RFC 6265)
 $cookies
   = Mojo::Cookie::Response->parse(
       'foo="ba r"; Domain=.example.com; Path=/test; Max-Age=60;'
-    . ' Expires=Thu, 07 Aug 2008 07:07:59 GMT; InSecure;');
-is $cookies->[0]->name,    'foo',         'right name';
-is $cookies->[0]->value,   'ba r',        'right value';
-is $cookies->[0]->domain,  'example.com', 'right domain';
-is $cookies->[0]->path,    '/test',       'right path';
-is $cookies->[0]->max_age, 60,            'right max age value';
-is $cookies->[0]->expires, 1218092879,    'right expires value';
-is $cookies->[0]->secure,  undef,         'no secure flag';
+    . ' Expires=Thu, 07 Aug 2008 07:07:59 GMT; InSecure; SameSite=Whatever');
+is $cookies->[0]->name,     'foo',         'right name';
+is $cookies->[0]->value,    'ba r',        'right value';
+is $cookies->[0]->domain,   'example.com', 'right domain';
+is $cookies->[0]->path,     '/test',       'right path';
+is $cookies->[0]->max_age,  60,            'right max age value';
+is $cookies->[0]->expires,  1218092879,    'right expires value';
+is $cookies->[0]->secure,   undef,         'no secure flag';
+is $cookies->[0]->samesite, undef,         'no invalid samesite value';
 is $cookies->[1], undef, 'no more cookies';
 
 # Parse quoted response cookie (RFC 6265)


### PR DESCRIPTION
Also allow it to be set for the session cookie.

https://tools.ietf.org/html/draft-ietf-httpbis-cookie-same-site-00

Only supported in some of the important browsers as of now (cf. http://caniuse.com/#feat=same-site-cookie-attribute). I believe it eventually will be supported by all, but I have no hard evidence on that.
If you consider it a premature addition maybe keep the pull request around in a branch?