### PR TITLE
Added the config mechanism in the generate app command

### DIFF
--- a/lib/Mojolicious/Command/generate/app.pm
+++ b/lib/Mojolicious/Command/generate/app.pm
@@ -25,6 +25,9 @@ EOF
   my $app = class_to_path $class;
   $self->render_to_rel_file('appclass', "$name/lib/$app", $class);
 
+  # Config file
+  $self->render_to_rel_file('config', "$name/$name.conf");
+
   # Controller
   my $controller = "${class}::Controller::Example";
   my $path       = class_to_path $controller;
@@ -136,6 +139,13 @@ sub startup {
   # Documentation browser under "/perldoc"
   $self->plugin('PODRenderer');
 
+  #Config mechanism
+  $self->plugin('Config');
+
+  #Read some config data
+  my $config = $self->app->config;
+  $self->app->secrets( $config->{secrets} );
+
   # Router
   my $r = $self->routes;
 
@@ -202,3 +212,8 @@ and the layout "templates/layouts/default.html.ep",
 <%%= link_to 'here' => '/index.html' %> to move forward to a static page. To
 learn more, you can also browse through the documentation
 <%%= link_to 'here' => '/perldoc' %>.
+
+@@ config
+{
+  secrets => ['changeme1', 'ChangeMe2', 'cHanGemEtoO0'],
+};

--- a/t/mojolicious/commands.t
+++ b/t/mojolicious/commands.t
@@ -250,6 +250,7 @@ $buffer = '';
 like $buffer, qr/my_app/, 'right output';
 ok -e $app->rel_file('my_app/script/my_app'), 'script exists';
 ok -e $app->rel_file('my_app/lib/MyApp.pm'),  'application class exists';
+ok -e $app->rel_file('my_app/my_app.conf'),  'config file exists';
 ok -e $app->rel_file('my_app/lib/MyApp/Controller/Example.pm'),
   'controller exists';
 ok -e $app->rel_file('my_app/t/basic.t'),         'test exists';


### PR DESCRIPTION
### Summary
Generate the config file and enable the config plugin with the `mojo generate app` command in a full blown Mojo app.

### Motivation
I think that the vast majority of web apps end up needing the config mechanism. So, instead of having the developers looking through the docs how to enable the plugin and use it, provide it to them automatically at create time.

### References
There are no open issues (or other pull requests for this).
