### PR TITLE
The config mechanism in the app generated with generate app command

### DIFF
--- a/lib/Mojolicious/Command/generate/app.pm
+++ b/lib/Mojolicious/Command/generate/app.pm
@@ -25,6 +25,9 @@ EOF
   my $app = class_to_path $class;
   $self->render_to_rel_file('appclass', "$name/lib/$app", $class);
 
+  # Config file
+  $self->render_to_rel_file('config', "$name/$name.conf");
+
   # Controller
   my $controller = "${class}::Controller::Example";
   my $path       = class_to_path $controller;
@@ -136,6 +139,12 @@ sub startup {
   # Documentation browser under "/perldoc"
   $self->plugin('PODRenderer');
 
+  # Config mechanism
+  $self->plugin('Config');
+
+  # $config holds the hashref returned by the config file
+  my $config = $self->app->config;
+
   # Router
   my $r = $self->routes;
 
@@ -202,3 +211,12 @@ and the layout "templates/layouts/default.html.ep",
 <%%= link_to 'here' => '/index.html' %> to move forward to a static page. To
 learn more, you can also browse through the documentation
 <%%= link_to 'here' => '/perldoc' %>.
+
+@@ config
+{
+  db => {
+      dsn => "...",
+      username => "...",
+      password => "...",
+    },
+};

--- a/t/mojolicious/commands.t
+++ b/t/mojolicious/commands.t
@@ -252,6 +252,7 @@ ok -e $app->rel_file('my_app/script/my_app'), 'script exists';
 ok -e $app->rel_file('my_app/lib/MyApp.pm'),  'application class exists';
 ok -e $app->rel_file('my_app/lib/MyApp/Controller/Example.pm'),
   'controller exists';
+ok -e $app->rel_file('my_app/my_app.conf'),  'config file exists';
 ok -e $app->rel_file('my_app/t/basic.t'),         'test exists';
 ok -e $app->rel_file('my_app/public/index.html'), 'static file exists';
 ok -e $app->rel_file('my_app/templates/layouts/default.html.ep'),


### PR DESCRIPTION
### Summary
Generate the config file and enable the config plugin with the `mojo generate app` command in the full blown Mojo app.

### Motivation
I think that the vast majority of web apps end up needing the config mechanism. So, instead of having the developers looking throughout the docs how to enable the plugin, how to name the config file, how to access the config variables within the app, provide it to them automatically at create time.

### References
This is my second PR for this small improvement,[ the first ](https://github.com/kraih/mojo/pull/1062) being rejected because the sample regarding how to use the config file disabled the warning for the default secrets.