### PR TITLE
update document for load_class function

### DIFF
--- a/lib/Mojo/Loader.pm
+++ b/lib/Mojo/Loader.pm
@@ -171,9 +171,9 @@ Search for modules in a namespace non-recursively.
   my $e = load_class 'Foo::Bar';
 
 Load a class and catch exceptions, returns a false value if loading was
-successful, a true value if the class has already been loaded, or a
-L<Mojo::Exception> object if loading failed. Note that classes are checked for a
-C<new> method to see if they are already loaded.
+successful, a true value if the class was not found, or a L<Mojo::Exception>
+object if loading failed. Note that classes are checked for a C<new> method
+to see if they are already loaded.
 
   # Handle exceptions
   if (my $e = load_class 'Foo::Bar') {


### PR DESCRIPTION
### Summary
Update document for Mojo::Loader::load_class function, because the return value is mismatch with the source code

### Motivation
I am reading the Mojo source code to learn such elegant framework, and find this document mismatch with code, would like to update it if my understanding is correct

### References

