### PR TITLE
Add support for pluggable reloader backends in Morbo. 

### DIFF
--- a/lib/Mojo/Server/Morbo/Backend.pm
+++ b/lib/Mojo/Server/Morbo/Backend.pm
@@ -1,0 +1,77 @@
+package Mojo::Server::Morbo::Backend;
+use Mojo::Base -base;
+
+use Carp 'croak';
+
+has watch => sub { [qw(lib templates)] };
+has watch_timeout => sub { $ENV{MORBO_BACKEND_TIMEOUT} || 1 };
+
+sub modified_files {
+  croak 'Method "modified_files" not implemented by subclass';
+}
+
+1;
+
+=encoding utf8
+
+=head1 NAME
+
+Mojo::Server::Morbo::Backend - Morbo backend base class
+
+=head1 SYNOPSIS
+
+  package Mojo::Server::Morbo::Backend::Inotify:
+  use Mojo::Base 'Mojo::Server::Morbo::Backend';
+
+  sub modified_files {...}
+
+=head1 DESCRIPTION
+
+L<Mojo::Server::Morbo::Backend> is an abstract base class for the morbo
+auto-reloader backend. The default included with Mojo is
+L<Mojo::Server::Morbo::Backend::Poll>.
+
+=head1 ATTRIBUTES
+
+L<Mojo::Server::Morbo::Backend> implements the following attributes.
+
+=head2 watch
+
+  my $watch = $backend->watch;
+  $backend  = $backend->watch(['/home/sri/my_app']);
+
+Files and directories to watch for changes, defaults to the application script
+as well as the C<lib> and C<templates> directories in the current working
+directory.
+
+=head2 watch_timeout
+
+  my $watch_timeout = $backend->watch_timeout;
+  $backend          = $backend->watch_timeout(10);
+
+Backends should not block longer than this many seconds to wait for events. Defaults
+to 1 or the MORBO_BACKEND_TIMEOUT environment variable.
+
+=head1 METHODS
+
+L<Mojo::Server::Morbo::Backend> inherits all methods from L<Mojo::Base> and
+implements the following new ones.
+
+=head2 modified_files
+
+  my $files = $backend->modified_files;
+
+Check if files from L</"watch"> have been modified since the last check and
+return an array reference with the results.
+
+  # All files that have been modified
+  say for @{$backend->modified_files};
+
+Meant to be implemented in a subclass. Make sure your implementation uses
+the L</"watch_timeout"> attribute to return for signal handling.
+
+=head1 SEE ALSO
+
+L<Mojolicious>, L<Mojolicious::Guides>, L<http://mojolicious.org>.
+
+=cut

--- a/lib/Mojo/Server/Morbo/Backend/Poll.pm
+++ b/lib/Mojo/Server/Morbo/Backend/Poll.pm
@@ -1,0 +1,58 @@
+package Mojo::Server::Morbo::Backend::Poll;
+use Mojo::Base 'Mojo::Server::Morbo::Backend';
+
+use Mojo::File 'path';
+
+sub modified_files {
+  my $self = shift;
+
+  sleep $self->watch_timeout;
+  my $cache = $self->{cache} ||= {};
+  my @files;
+  for my $file (map { -f $_ && -r _ ? $_ : _list($_) } @{$self->watch}) {
+    my ($size, $mtime) = (stat $file)[7, 9];
+    next unless defined $size and defined $mtime;
+    my $stats = $cache->{$file} ||= [$^T, $size];
+    next if $mtime <= $stats->[0] && $size == $stats->[1];
+    @$stats = ($mtime, $size);
+    push @files, $file;
+  }
+
+  return \@files;
+}
+
+sub _list { path(shift)->list_tree->map('to_string')->each }
+
+1;
+
+=encoding utf8
+
+=head1 NAME
+
+Mojo::Server::Morbo::Backend::Poll - Morbo default backend class
+
+=head1 SYNOPSIS
+
+  my $backend = Mojo::Server::Morbo::Backend::Poll->new;
+  if ($backend->modified_files) {...}
+
+=head1 DESCRIPTION
+
+L<Mojo::Server::Morbo::Backend:Poll> is the default reloader backend for
+L<Mojo::Server::Morbo>.
+
+=head1 METHODS
+
+L<Mojo::Server::Morbo::Backend::Poll> inherits all methods from
+L<Mojo::Server::Morbo::Backend>.
+
+=head2 modified_files
+
+Checks the mtime timestamp for all the watched files and returns
+an array reference with any modified files.
+
+=head1 SEE ALSO
+
+L<Mojolicious>, L<Mojolicious::Guides>, L<http://mojolicious.org>.
+
+=cut

--- a/script/morbo
+++ b/script/morbo
@@ -5,16 +5,17 @@ use Mojo::Server::Morbo;
 use Mojo::Util qw(extract_usage getopt);
 
 getopt
-  'h|help'     => \my $help,
-  'l|listen=s' => \my @listen,
-  'm|mode=s'   => \$ENV{MOJO_MODE},
-  'v|verbose'  => \$ENV{MORBO_VERBOSE},
-  'w|watch=s'  => \my @watch;
+  'b|backend=s' => \$ENV{MOJO_MORBO_BACKEND},
+  'h|help'      => \my $help,
+  'l|listen=s'  => \my @listen,
+  'm|mode=s'    => \$ENV{MOJO_MODE},
+  'v|verbose'   => \$ENV{MORBO_VERBOSE},
+  'w|watch=s'   => \my @watch;
 
 die extract_usage if $help || !(my $app = shift);
 my $morbo = Mojo::Server::Morbo->new;
 $morbo->daemon->listen(\@listen) if @listen;
-$morbo->watch(\@watch) if @watch;
+$morbo->backend->watch(\@watch)  if @watch;
 $morbo->run($app);
 
 =encoding utf8
@@ -34,6 +35,9 @@ morbo - Morbo HTTP and WebSocket development server
     morbo -w /usr/local/lib -w public -w myapp.conf ./myapp.pl
 
   Options:
+    -b, --backend <name>           Morbo backend to use for the reloader
+                                   defaults to 'Poll'
+                                   (Mojo::Server::Morbo::Backend::Poll)
     -h, --help                     Show this message
     -l, --listen <location>        One or more locations you want to listen on,
                                    defaults to the value of MOJO_LISTEN or

--- a/t/mojo/file.t
+++ b/t/mojo/file.t
@@ -169,7 +169,8 @@ is_deeply path($lib)->list({hidden => 1})->map('to_string')->to_array, \@files,
 @files = map { path($lib)->child(split '/') } (
   'BaseTest',           'DeprecationTest.pm',
   'LoaderException.pm', 'LoaderException2.pm',
-  'LoaderTest',         'TestConnectProxy.pm'
+  'LoaderTest',         'Server',
+  'TestConnectProxy.pm'
 );
 is_deeply path($lib)->list({dir => 1})->map('to_string')->to_array, \@files,
   'right files';
@@ -185,7 +186,8 @@ is_deeply path(__FILE__)->list_tree->to_array,         [], 'no files';
   'BaseTest/Base3.pm',  'DeprecationTest.pm',
   'LoaderException.pm', 'LoaderException2.pm',
   'LoaderTest/A.pm',    'LoaderTest/B.pm',
-  'LoaderTest/C.pm',    'TestConnectProxy.pm'
+  'LoaderTest/C.pm',    'Server/Morbo/Backend/TestBackend.pm',
+  'TestConnectProxy.pm'
 );
 is_deeply path($lib)->list_tree->map('to_string')->to_array, \@files,
   'right files';
@@ -194,13 +196,15 @@ is_deeply path($lib)->list_tree->map('to_string')->to_array, \@files,
 is_deeply path($lib)->list_tree({hidden => 1})->map('to_string')->to_array,
   [@hidden, @files], 'right files';
 my @all = map { path($lib)->child(split '/') } (
-  '.hidden.txt',        '.test',
-  '.test/hidden.txt',   'BaseTest',
-  'BaseTest/Base1.pm',  'BaseTest/Base2.pm',
-  'BaseTest/Base3.pm',  'DeprecationTest.pm',
-  'LoaderException.pm', 'LoaderException2.pm',
-  'LoaderTest',         'LoaderTest/A.pm',
-  'LoaderTest/B.pm',    'LoaderTest/C.pm',
+  '.hidden.txt',          '.test',
+  '.test/hidden.txt',     'BaseTest',
+  'BaseTest/Base1.pm',    'BaseTest/Base2.pm',
+  'BaseTest/Base3.pm',    'DeprecationTest.pm',
+  'LoaderException.pm',   'LoaderException2.pm',
+  'LoaderTest',           'LoaderTest/A.pm',
+  'LoaderTest/B.pm',      'LoaderTest/C.pm',
+  'Server',               'Server/Morbo',
+  'Server/Morbo/Backend', 'Server/Morbo/Backend/TestBackend.pm',
   'TestConnectProxy.pm'
 );
 is_deeply path($lib)->list_tree({dir => 1, hidden => 1})->map('to_string')

--- a/t/mojo/lib/Mojo/Server/Morbo/Backend/TestBackend.pm
+++ b/t/mojo/lib/Mojo/Server/Morbo/Backend/TestBackend.pm
@@ -1,0 +1,6 @@
+package Mojo::Server::Morbo::Backend::TestBackend;
+use Mojo::Base 'Mojo::Server::Morbo::Backend';
+
+sub modified_files { return ['always_changed'] }
+
+1

--- a/t/pod_coverage.t
+++ b/t/pod_coverage.t
@@ -9,5 +9,5 @@ plan skip_all => 'Test::Pod::Coverage 1.04+ required for this test!'
 
 # DEPRECATED!
 my @deprecated
-  = qw(files is_status_class lib_dir parse parts rel_dir slurp spurt);
+  = qw(files is_status_class lib_dir parse parts rel_dir slurp spurt watch);
 all_pod_coverage_ok({also_private => \@deprecated});


### PR DESCRIPTION
### Summary
Reloader class can be set on the command line or as an ENV. Move current implementation to default backend ::Poll.

### Motivation
This change makes it possible to write OS specific file watchers for morbo that is more performant than the default poll implementation. To confirm that the implementation works, I've made a simple Inotify watcher here: https://gist.github.com/anonymous/60d22a13a103796a22662782b2dcb436

### References
This pull request is a proposal to resolve #1071