### PR TITLE
Fixed broken documentation url

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,4 +99,4 @@ __DATA__
 
 ## Want to know more?
 
-  Take a look at our excellent [documentation](http://mojolicious.org/perldoc>)!
+  Take a look at our excellent [documentation](http://mojolicious.org/perldoc)!


### PR DESCRIPTION
### Summary
Fix url that contained a trailing '>' character which causes the mojolicious.org site to return a 404 not found error.

### Motivation
Simple fix to prevent a 404 not found error.