### PR TITLE
Mojo::Date: epoch can be a negative number

### DIFF
--- a/lib/Mojo/Date.pm
+++ b/lib/Mojo/Date.pm
@@ -22,7 +22,7 @@ sub parse {
   my ($self, $date) = @_;
 
   # epoch (784111777)
-  return $self->epoch($date) if $date =~ /^\d+$|^\d+\.\d+$/;
+  return $self->epoch($date) if $date =~ /^-?\d+$|^-?\d+\.\d+$/;
 
   # RFC 822/1123 (Sun, 06 Nov 1994 08:49:37 GMT)
   # RFC 850/1036 (Sunday, 06-Nov-94 08:49:37 GMT)

--- a/t/mojo/date.t
+++ b/t/mojo/date.t
@@ -77,6 +77,8 @@ $date = Mojo::Date->new(784111777);
 is "$date", 'Sun, 06 Nov 1994 08:49:37 GMT', 'right format';
 $date = Mojo::Date->new(1305280824);
 is $date->to_string, 'Fri, 13 May 2011 10:00:24 GMT', 'right format';
+$date = Mojo::Date->new(-127180800);
+is $date->to_string, 'Tue, 21 Dec 1965 00:00:00 GMT', 'right format';
 
 # Current time roundtrips
 my $before = time;


### PR DESCRIPTION
### Summary
Fixes Mojo::Date when used with negative numbers as epoch

### Motivation
I found the issue when representing birth dates with Mango::Time objects - a date before the epoch like 1965-12-21 would emit uninit warnings and end up represented as Jan 1, 1970. This comes from https://github.com/oliwer/mango/blob/master/lib/Mango/BSON/Time.pm#L12 which in turn points to Mojo::Date code https://github.com/kraih/mojo/blob/master/lib/Mojo/Date.pm#L25 

For example, running the test included in this PR with the code in master gives the output

```
$ prove -I lib t/mojo/date.t
t/mojo/date.t .. 1/? Use of uninitialized value in gmtime at /Users/ferreira/ws/mojo/lib/Mojo/Date.pm line 66.

#   Failed test 'right format'
#   at t/mojo/date.t line 81.
#          got: 'Thu, 01 Jan 1970 00:00:00 GMT'
#     expected: 'Tue, 21 Dec 1965 00:00:00 GMT'
# Looks like you failed 1 test of 40.
t/mojo/date.t .. Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/40 subtests 

Test Summary Report
-------------------
t/mojo/date.t (Wstat: 256 Tests: 40 Failed: 1)
  Failed test:  33
  Non-zero exit status: 1
Files=1, Tests=40,  0 wallclock secs ( 0.02 usr  0.01 sys +  0.02 cusr  0.00 csys =  0.05 CPU)
Result: FAIL
```


### References
None