### PR TITLE
Mojo::Date: negative & fractional epoch

### DIFF
--- a/lib/Mojo/Date.pm
+++ b/lib/Mojo/Date.pm
@@ -54,10 +54,20 @@ sub parse {
 sub to_datetime {
 
   # RFC 3339 (1994-11-06T08:49:37Z)
-  my ($s, $m, $h, $day, $month, $year) = gmtime(my $epoch = shift->epoch);
+  my ($s, $m, $h, $day, $month, $year) = _gmftime(shift->epoch);
   my $str = sprintf '%04d-%02d-%02dT%02d:%02d:%02d', $year + 1900, $month + 1,
     $day, $h, $m, $s;
-  return $str . ($epoch =~ /(\.\d+)$/ ? $1 : '') . 'Z';
+  return $str . ($s =~ /(\.\d+)$/ ? $1 : '') . 'Z';
+}
+
+# gmtime with (possibly) fractional seconds
+sub _gmftime {
+  return gmtime $_[0] unless $_[0] =~ /^((-?)\d+)(\.\d+)$/;
+
+  # decompose $epoch into $t + $f, where 0 ≤ $f < 1
+  my ($t, $f) = $2 ? ($1 - 1, $_[0] - $1 + 1) : ($1, $3);
+  my @t = gmtime $t;
+  return shift(@t) + $f, @t;
 }
 
 sub to_string {

--- a/lib/Mojo/Date.pm
+++ b/lib/Mojo/Date.pm
@@ -22,7 +22,7 @@ sub parse {
   my ($self, $date) = @_;
 
   # epoch (784111777)
-  return $self->epoch($date) if $date =~ /^\d+$|^\d+\.\d+$/;
+  return $self->epoch($date) if $date =~ /^-?\d+$|^-?\d+\.\d+$/;
 
   # RFC 822/1123 (Sun, 06 Nov 1994 08:49:37 GMT)
   # RFC 850/1036 (Sunday, 06-Nov-94 08:49:37 GMT)

--- a/lib/Mojo/Date.pm
+++ b/lib/Mojo/Date.pm
@@ -63,7 +63,7 @@ sub to_datetime {
 sub to_string {
 
   # RFC 7231 (Sun, 06 Nov 1994 08:49:37 GMT)
-  my ($s, $m, $h, $mday, $month, $year, $wday) = gmtime shift->epoch;
+  my ($s, $m, $h, $mday, $month, $year, $wday) = gmtime sprintf('%.0f', shift->epoch);
   return sprintf '%s, %02d %s %04d %02d:%02d:%02d GMT', $DAYS[$wday], $mday,
     $MONTHS[$month], $year + 1900, $h, $m, $s;
 }

--- a/t/mojo/date.t
+++ b/t/mojo/date.t
@@ -38,6 +38,10 @@ is(Mojo::Date->new('1994-11-06t08:49:37.33z')->epoch,
   784111777.33, 'right epoch value');
 is(Mojo::Date->new(784111777.33)->to_datetime,
   '1994-11-06T08:49:37.33Z', 'right format');
+is(Mojo::Date->new(0.33)->to_datetime,
+  '1970-01-01T00:00:00.33Z', 'right format');
+is(Mojo::Date->new('-0.33')->to_datetime,
+  '1969-12-31T23:59:59.67Z', 'right format');
 
 # Special cases
 is(Mojo::Date->new('Sun ,  06-Nov-1994  08:49:37  UTC')->epoch,
@@ -79,6 +83,14 @@ $date = Mojo::Date->new(1305280824);
 is $date->to_string, 'Fri, 13 May 2011 10:00:24 GMT', 'right format';
 $date = Mojo::Date->new('1305280824.23');
 is $date->to_string, 'Fri, 13 May 2011 10:00:24 GMT', 'right format';
+$date = Mojo::Date->new('1305280824.73');
+is $date->to_string, 'Fri, 13 May 2011 10:00:25 GMT', 'right format';
+$date = Mojo::Date->new(-127180500);
+is $date->to_string, 'Tue, 21 Dec 1965 00:05:00 GMT', 'right format';
+$date = Mojo::Date->new('-127180500.23');
+is $date->to_string, 'Tue, 21 Dec 1965 00:05:00 GMT', 'right format';
+$date = Mojo::Date->new('-127180500.60');
+is $date->to_string, 'Tue, 21 Dec 1965 00:04:59 GMT', 'right format';
 
 # Current time roundtrips
 my $before = time;


### PR DESCRIPTION
### Summary
This is a revision of https://github.com/kraih/mojo/pull/1079. 

The test failures pointed in https://github.com/kraih/mojo/pull/1079#issuecomment-291487534 turn out to be a problem with Mojo::Date::to_string() with fractional epoch, and not an effect of accepting negative epoch.

This PR includes fixes to to_string() and to_datetime() in this regard, and brings the change to accept negative epoch again.

### Motivation
Same as https://github.com/kraih/mojo/pull/1079.

Perl documentation (http://perldoc.perl.org/perlport.html#gmtime) mentions that `gmtime` has portability issues because of how floating point numbers are used in the implementation. I think we hit that when [the build](https://travis-ci.org/kraih/mojo/builds/218440119) failed for 5.10.

_Updated (both this description & pull request) after the feedback by @jhthorsen._

The proposed solution is to avoid passing floats to gmtime() – instead
* round the epoch to be used by to_string()
* decompose `$epoch` into `floor($epoch) + $frac` at to_datetime()

The implementation change to to_datetime() gets more complicated as in

```perl
sub to_datetime {

  # RFC 3339 (1994-11-06T08:49:37Z)
  my ($s, $m, $h, $day, $month, $year) = _gmftime(shift->epoch);
  my $str = sprintf '%04d-%02d-%02dT%02d:%02d:%02d', $year + 1900, $month + 1,
    $day, $h, $m, $s;
  return $str . ($s =~ /(\.\d+)$/ ? $1 : '') . 'Z';
}

# gmtime with (possibly) fractional seconds
sub _gmftime {
  return gmtime $_[0] unless $_[0] =~ /^((-?)\d+)(\.\d+)$/;

  # decompose $epoch into $t + $f, where 0 ≤ $f < 1
  my ($t, $f) = $2 ? ($1 - 1, $_[0] - $1 + 1) : ($1, $3);
  my @t = gmtime $t;
  return shift(@t) + $f, @t;
}
```

The code attempts to do as little floating point operations as possible (and only in the case of negative fractional epoch). Among the tests, these illustrate the kind of computation needed to get `to_datetime()` right for this edge case.

```
'0.33'   =>   '1970-01-01T00:00:00.33Z'
'-0.33'  =>  '1969-12-31T23:59:59.67Z'
```
 


