### PR TITLE
Allow undef text to indicate No children.

### DIFF
--- a/lib/Mojo/DOM/HTML.pm
+++ b/lib/Mojo/DOM/HTML.pm
@@ -229,7 +229,7 @@ sub _render {
 
   # No children
   return $xml ? "$result />" : $EMPTY{$tag} ? "$result>" : "$result></$tag>"
-    unless $tree->[4];
+    if !$tree->[4] || $tree->[4]->[0] eq 'text' && !defined $tree->[4]->[1];
 
   # Children
   no warnings 'recursion';


### PR DESCRIPTION
### Summary
This is behaviour from CGI.pm
%= t meta => ( name => 'charset', content => 'UTF-8' ) => undef

Previously an end tag was generated.

### Motivation
To produce more accurately the HTML user intends.

### References
https://irclog.perlgeek.de/mojo/2017-04-24#i_14474630
https://pastebin.com/th12hkcS