### PR TITLE
Provide a more practical example regex

### DIFF
--- a/lib/Mojolicious/Guides/Rendering.pod
+++ b/lib/Mojolicious/Guides/Rendering.pod
@@ -819,8 +819,10 @@ logic with methods like L<Mojolicious::Validator::Validation/"is_valid">.
     my $validation = $c->validation;
     return $c->render unless $validation->has_data;
 
-    # Validate parameters ("pass_again" depends on "pass")
-    $validation->required('user')->size(1, 20)->like(qr/^[e-t]+$/);
+    # Validate parameters ("user" size is within 1 - 20
+    # and content looks somewhat like a valid unix username)
+    $validation->required('user')->size(1, 20)
+      ->like(qr/^[a-z_][a-z0-9_-]*\$?$/);
     $validation->required('pass_again')->equal_to('pass')
       if $validation->optional('pass')->size(7, 500)->is_valid;
 


### PR DESCRIPTION
### Summary
Currently user is restricted to letters e through t and that's a good example, but would almost never exist in the real world.  Thus provided is a regex that might be used to filter usernames.

### Motivation
I think it's less arbitrary and thus not confusing in an off the wall sort of way.

### References
No reply to my inquiry on IRC about this.
https://irclog.perlgeek.de/mojo/2017-04-23#i_14470938