### PR TITLE
Fix example meta charset to use name and content attribute names

### DIFF
--- a/lib/Mojolicious/Plugin/TagHelpers.pm
+++ b/lib/Mojolicious/Plugin/TagHelpers.pm
@@ -691,7 +691,7 @@ key/value pairs to generate attributes from.
 Very useful for reuse in more specific tag helpers.
 
   my $output = $c->tag('meta');
-  my $output = $c->tag('meta', charset => 'UTF-8');
+  my $output = $c->tag('meta', name => 'charset', content => 'UTF-8');
   my $output = $c->tag(div => '<p>This will be escaped</p>');
   my $output = $c->tag(div => sub { '<p>This will not be escaped</p>' });
 


### PR DESCRIPTION
### Summary
The current example creates an attribute named charset when in HTML the attribute name should be content and charset belongs in another attribute named name.

### Motivation
To be correct and give proper expectation that there is no special handling of the meta tag in this instance.

### References
https://irclog.perlgeek.de/mojo/2017-04-23#i_14474559