### PR TITLE
Fixup handling of multiple radio buttons checked

### DIFF
--- a/lib/Mojolicious/Plugin/TagHelpers.pm
+++ b/lib/Mojolicious/Plugin/TagHelpers.pm
@@ -80,7 +80,8 @@ sub _input {
     if ($type eq 'checkbox' || $type eq 'radio') {
       my $value = $attrs{value} // 'on';
       delete $attrs{checked};
-      $attrs{checked} = undef if grep { $_ eq $value } @values;
+      $attrs{checked} = undef if $type ne 'checkbox' ?
+        $values[-1] eq $value : grep { $_ eq $value } @values;
     }
 
     # Others

--- a/t/mojolicious/tag_helper_lite_app.t
+++ b/t/mojolicious/tag_helper_lite_app.t
@@ -28,6 +28,8 @@ post '/text';
 
 get '/multibox';
 
+get '/multibutton';
+
 get 'form/:test' => 'form';
 
 put 'selection';
@@ -280,6 +282,86 @@ $t->get_ok('/multibox?foo=two&foo=one&foo=on')->status_is(200)
   <input checked name="foo" type="checkbox" value="one">
   <input checked name="foo" type="checkbox" value="two">
   <input name="foo" type="checkbox" value="three">
+  <input type="submit" value="Ok">
+</form>
+EOF
+
+# Checkboxes with second multiple values
+$t->get_ok('/multibox?foo=two&foo=one')->status_is(200)
+  ->content_is(<<EOF);
+<form action="/multibox">
+  <input name="foo" type="checkbox">
+  <input checked name="foo" type="checkbox" value="one">
+  <input checked name="foo" type="checkbox" value="two">
+  <input name="foo" type="checkbox" value="three">
+  <input type="submit" value="Ok">
+</form>
+EOF
+
+# Radiobuttons
+$t->get_ok('/multibutton')->status_is(200)->content_is(<<EOF);
+<form action="/multibutton">
+  <input name="foo" type="radio">
+  <input name="foo" type="radio" value="one">
+  <input name="foo" type="radio" value="two">
+  <input checked name="foo" type="radio" value="three">
+  <input type="submit" value="Ok">
+</form>
+EOF
+
+# Radiobuttons with one value
+$t->get_ok('/multibutton?foo=two')->status_is(200)->content_is(<<EOF);
+<form action="/multibutton">
+  <input name="foo" type="radio">
+  <input name="foo" type="radio" value="one">
+  <input checked name="foo" type="radio" value="two">
+  <input name="foo" type="radio" value="three">
+  <input type="submit" value="Ok">
+</form>
+EOF
+
+# Radiobuttons with one right and one wrong value
+$t->get_ok('/multibutton?foo=one&foo=four')->status_is(200)->content_is(<<EOF);
+<form action="/multibutton">
+  <input name="foo" type="radio">
+  <input checked name="foo" type="radio" value="one">
+  <input name="foo" type="radio" value="two">
+  <input name="foo" type="radio" value="three">
+  <input type="submit" value="Ok">
+</form>
+EOF
+
+# Radiobuttons with wrong value
+$t->get_ok('/multibutton?foo=bar')->status_is(200)->content_is(<<EOF);
+<form action="/multibutton">
+  <input name="foo" type="radio">
+  <input name="foo" type="radio" value="one">
+  <input name="foo" type="radio" value="two">
+  <input name="foo" type="radio" value="three">
+  <input type="submit" value="Ok">
+</form>
+EOF
+
+# Radiobuttons with multiple values
+$t->get_ok('/multibutton?foo=two&foo=one&foo=on')->status_is(200)
+  ->content_is(<<EOF);
+<form action="/multibutton">
+  <input checked name="foo" type="radio">
+  <input name="foo" type="radio" value="one">
+  <input name="foo" type="radio" value="two">
+  <input name="foo" type="radio" value="three">
+  <input type="submit" value="Ok">
+</form>
+EOF
+
+# Radiobuttons with second multiple values
+$t->get_ok('/multibutton?foo=two&foo=one')->status_is(200)
+  ->content_is(<<EOF);
+<form action="/multibutton">
+  <input name="foo" type="radio">
+  <input checked name="foo" type="radio" value="one">
+  <input name="foo" type="radio" value="two">
+  <input name="foo" type="radio" value="three">
   <input type="submit" value="Ok">
 </form>
 EOF
@@ -628,6 +710,15 @@ __DATA__
   %= check_box foo => 'one'
   %= check_box foo => 'two'
   %= check_box foo => 'three', checked => undef
+  %= submit_button
+%= end
+
+@@ multibutton.html.ep
+%= form_for multibutton => begin
+  %= radio_button 'foo'
+  %= radio_button foo => 'one'
+  %= radio_button foo => 'two'
+  %= radio_button foo => 'three', checked => undef
   %= submit_button
 %= end
 


### PR DESCRIPTION
### Summary
Avoid setting checked attribute on multiple radio of the same name.

### Motivation
This is obviously incorrect handling on radio buttons.

### References
https://irclog.perlgeek.de/mojo/2017-04-24#i_14478333
https://irclog.perlgeek.de/mojo/2017-04-23#i_14473347