### PR TITLE
Output formatters to allow list output of length 1

### DIFF
--- a/t/mojolicious/validation_lite_app.t
+++ b/t/mojolicious/validation_lite_app.t
@@ -219,6 +219,21 @@ ok $validation->required(0)->size(1, 1)->is_valid, 'valid';
 is_deeply $validation->output, {0 => 0}, 'right result';
 is $validation->param(0), 0, 'right value';
 
+# Value type coercion
+$validation = $t->app->validation->input({one => ['1'], love => '♥', two => ['zwei', '二'], foo => ['', 'bar']});
+ok $validation->required(one => 'last')->is_valid, 'valid';
+is $validation->output->{one}, '1', 'right result';
+ok $validation->required(two => ('last', 'list', 'first'))->is_valid, 'valid';
+ok !$validation->optional(foo => 'first')->is_valid, 'not valid';
+is_deeply $validation->output, { one => '1', two => 'zwei' }, 'right result';
+is_deeply $validation->optional(love => 'list')->output->{love}, ['♥'], 'right result';
+
+# Required lists
+$validation = $t->app->validation->input({with_gaps => ['first', '', 'third'], empty => []});
+ok $validation->required(with_gaps => 'list')->is_valid, 'valid';
+ok !$validation->required(empty => 'list')->is_valid, 'not valid';
+is_deeply $validation->output, {with_gaps => ['first', 'third']}, 'right result';
+
 # Custom error
 $validation = $t->app->validation->input({foo => 'bar'});
 ok !$validation->required('foo')->has_error, 'no error';


### PR DESCRIPTION
### Summary
As discussed on IRC, this patch provides a mechanism to force a list in Mojolicious::Validator::Validation.pm output.

For me there are a few things that I'd welcome feedback:

 - The if ($output_formatter) seems a little weird here. Ideally I'd prefer there to be a default $output_formatter, but that proves tricky while maintaining complete backwards compatibility
https://github.com/kraih/mojo/compare/master...chy-causer:master#diff-ea8a39c17a3297cc4c5cc85000fae422R94
 - Not sure if ->required(with_gaps =>  'list')->is_valid is valid (if that makes sense.)
https://github.com/kraih/mojo/compare/master...chy-causer:master#diff-af7f52660125846348aa0b9dd5a72bf1R233

### Motivation

I want to have identically named input fields multiple times on a page and rely on the fact that the $validation->output will be an array, even if the number of non-blank elements given is one. If th

This patch provides the inverse functionality, where a scalar is returned even when more than one input is supplied. To me I'd expect this to be default behaviour, more in keeping with the normal usage of $c->param('foo') but I understand the reasoning for this and appreciate backwards compatibility is important so didn't change any existing tests.

### References
I started making sense around here: https://irclog.perlgeek.de/mojo/2017-04-28#i_14501813