### PR TITLE
Add Minion version to Mojolicious::Command::version

### DIFF
--- a/lib/Mojolicious/Command/version.pm
+++ b/lib/Mojolicious/Command/version.pm
@@ -12,6 +12,7 @@ sub run {
   my $self = shift;
 
   my $ev = eval 'use Mojo::Reactor::EV; 1' ? $EV::VERSION : 'n/a';
+  my $minion = eval 'use Minion; 1' ? $Minion::VERSION : 'n/a';
   my $socks
     = Mojo::IOLoop::Client->can_socks ? $IO::Socket::Socks::VERSION : 'n/a';
   my $tls = Mojo::IOLoop::TLS->can_tls    ? $IO::Socket::SSL::VERSION  : 'n/a';
@@ -21,6 +22,7 @@ sub run {
 CORE
   Perl        ($^V, $^O)
   Mojolicious ($Mojolicious::VERSION, $Mojolicious::CODENAME)
+  Minion      ($minion)
 
 OPTIONAL
   EV 4.0+                 ($ev)

--- a/t/mojolicious/commands.t
+++ b/t/mojolicious/commands.t
@@ -383,6 +383,8 @@ $buffer = '';
   $version->run;
 }
 like $buffer, qr/Perl/, 'right output';
+like $buffer, qr/Mojolicious/, 'right mojolicious output';
+like $buffer, qr/Minion/, 'right minion output';
 like $buffer, qr/You might want to update your Mojolicious to 1000!/,
   'right output';
 


### PR DESCRIPTION
### Summary
Add Minion version to Mojolicious::Command::version

### Motivation
It is helpful when using Minion with Mojolicious.  Otherwise it displays "n/a" like other optional modules.

### References
None.
