### PR TITLE
Use MetaCPAN v1 API

### DIFF
--- a/lib/Mojolicious/Command/get.pm
+++ b/lib/Mojolicious/Command/get.pm
@@ -151,7 +151,7 @@ Mojolicious::Command::get - Get command
     mojo get mojolicious.org a attr href
     mojo get mojolicious.org '*' attr id
     mojo get mojolicious.org 'h1, h2, h3' 3 text
-    mojo get https://api.metacpan.org/v0/author/SRI /name
+    mojo get https://fastapi.metacpan.org/v1/author/SRI /name
     mojo get -H 'Host: example.com' http+unix://%2Ftmp%2Fmyapp.sock/index.html
 
   Options:

--- a/lib/Mojolicious/Command/version.pm
+++ b/lib/Mojolicious/Command/version.pm
@@ -33,7 +33,7 @@ EOF
   # Check latest version on CPAN
   my $latest = eval {
     $self->app->ua->max_redirects(10)->tap(sub { $_->proxy->detect })
-      ->get('api.metacpan.org/v0/release/Mojolicious')->result->json->{version};
+      ->get('fastapi.metacpan.org/v1/release/Mojolicious')->result->json->{version};
   } or return;
 
   my $msg = 'This version is up to date, have fun!';

--- a/lib/Mojolicious/Guides/Cookbook.pod
+++ b/lib/Mojolicious/Guides/Cookbook.pod
@@ -505,7 +505,7 @@ latency backend web services.
   # Search MetaCPAN for "mojolicious"
   get '/' => sub {
     my $c = shift;
-    $c->ua->get('api.metacpan.org/v0/module/_search?q=mojolicious' => sub {
+    $c->ua->get('fastapi.metacpan.org/v1/module/_search?q=mojolicious' => sub {
       my ($ua, $tx) = @_;
       $c->render('metacpan', hits => $tx->result->json->{hits}{hits});
     });
@@ -549,7 +549,7 @@ style.
       # Concurrent requests
       sub {
         my $delay = shift;
-        my $url   = Mojo::URL->new('api.metacpan.org/v0/module/_search');
+        my $url   = Mojo::URL->new('fastapi.metacpan.org/v1/module/_search');
         $url->query({sort => 'date:desc'});
         $c->ua->get($url->clone->query({q => 'mojo'})   => $delay->begin);
         $c->ua->get($url->clone->query({q => 'minion'}) => $delay->begin);
@@ -977,7 +977,7 @@ Who actually controls the event loop backend is not important.
   # Search MetaCPAN for "mojolicious"
   my $cv = AE::cv;
   my $ua = Mojo::UserAgent->new;
-  $ua->get('api.metacpan.org/v0/module/_search?q=mojolicious' => sub {
+  $ua->get('fastapi.metacpan.org/v1/module/_search?q=mojolicious' => sub {
     my ($ua, $tx) = @_;
     $cv->send($tx->result->json('/hits/hits/0/_source/release'));
   });
@@ -1080,7 +1080,7 @@ L<Mojo::Message/"json">.
   my $ua = Mojo::UserAgent->new;
 
   # Search MetaCPAN for "mojolicious" and list latest releases
-  my $url = Mojo::URL->new('http://api.metacpan.org/v0/release/_search');
+  my $url = Mojo::URL->new('http://fastapi.metacpan.org/v1/release/_search');
   $url->query({q => 'mojolicious', sort => 'date:desc'});
   for my $hit (@{$ua->get($url)->result->json->{hits}{hits}}) {
     say "$hit->{_source}{name} ($hit->{_source}{author})";
@@ -1475,7 +1475,7 @@ You can follow redirects and view the headers for all messages.
 
 Extract just the information you really need from JSON data structures.
 
-  $ mojo get https://api.metacpan.org/v0/author/SRI /name
+  $ mojo get https://fastapi.metacpan.org/v1/author/SRI /name
 
 This can be an invaluable tool for testing your applications.
 


### PR DESCRIPTION
### Summary
Currently "mojo version" silently fails to capture the latest Mojo version from CPAN, because

http://api.metacpan.org/v0/release/Mojolicious

says "MetaCPAN v0 API has been has been shut down! See the MetaCPAN v1 API should be used instead."

The solution is switch to http://fastapi.metacpan.org/v1/release/Mojolicious

