### PR TITLE
Mojo::Date: negative & fractional epoch (again)

### DIFF
--- a/lib/Mojo/Date.pm
+++ b/lib/Mojo/Date.pm
@@ -22,7 +22,7 @@ sub parse {
   my ($self, $date) = @_;
 
   # epoch (784111777)
-  return $self->epoch($date) if $date =~ /^\d+$|^\d+\.\d+$/;
+  return $self->epoch($date) if $date =~ /^-?\d+$|^-?\d+\.\d+$/;
 
   # RFC 822/1123 (Sun, 06 Nov 1994 08:49:37 GMT)
   # RFC 850/1036 (Sunday, 06-Nov-94 08:49:37 GMT)

--- a/lib/Mojo/Date.pm
+++ b/lib/Mojo/Date.pm
@@ -63,7 +63,8 @@ sub to_datetime {
 sub to_string {
 
   # RFC 7231 (Sun, 06 Nov 1994 08:49:37 GMT)
-  my ($s, $m, $h, $mday, $month, $year, $wday) = gmtime shift->epoch;
+  my ($s, $m, $h, $mday, $month, $year, $wday)
+    = gmtime sprintf("%.0f", shift->epoch);
   return sprintf '%s, %02d %s %04d %02d:%02d:%02d GMT', $DAYS[$wday], $mday,
     $MONTHS[$month], $year + 1900, $h, $m, $s;
 }

--- a/lib/Mojo/Date.pm
+++ b/lib/Mojo/Date.pm
@@ -48,8 +48,8 @@ sub parse {
   else { return $self->epoch(undef) }
 
   my $epoch = eval { timegm $s, $m, $h, $day, $month, $year };
-  return $self->epoch(
-    (defined $epoch && ($epoch += $offset) >= 0) ? $epoch : undef);
+  $epoch += $offset if defined $epoch;
+  return $self->epoch($epoch);
 }
 
 sub to_datetime {

--- a/t/mojo/date.t
+++ b/t/mojo/date.t
@@ -108,7 +108,7 @@ is(Mojo::Date->new('Thu, 01 Jan 1970 00:00:00 GMT')->epoch,
 
 # No epoch value
 $date = Mojo::Date->new;
-ok $date->parse('Mon, 01 Jan 1900 00:00:00'), 'right format';
+ok $date->parse('Mon, 29 Feb 1900 00:00:00'), 'right format';
 is $date->epoch, undef, 'no epoch value';
 
 done_testing();

--- a/t/mojo/date.t
+++ b/t/mojo/date.t
@@ -38,6 +38,10 @@ is(Mojo::Date->new('1994-11-06t08:49:37.33z')->epoch,
   784111777.33, 'right epoch value');
 is(Mojo::Date->new(784111777.33)->to_datetime,
   '1994-11-06T08:49:37.33Z', 'right format');
+is(Mojo::Date->new(0.33)->to_datetime,
+  '1970-01-01T00:00:00.33Z', 'right format');
+is(Mojo::Date->new('-0.33')->to_datetime,
+  '1969-12-31T23:59:59.67Z', 'right format');
 
 # Special cases
 is(Mojo::Date->new('Sun ,  06-Nov-1994  08:49:37  UTC')->epoch,
@@ -79,6 +83,14 @@ $date = Mojo::Date->new(1305280824);
 is $date->to_string, 'Fri, 13 May 2011 10:00:24 GMT', 'right format';
 $date = Mojo::Date->new('1305280824.23');
 is $date->to_string, 'Fri, 13 May 2011 10:00:24 GMT', 'right format';
+$date = Mojo::Date->new('1305280824.73');
+is $date->to_string, 'Fri, 13 May 2011 10:00:25 GMT', 'right format';
+$date = Mojo::Date->new(-127180500);
+is $date->to_string, 'Tue, 21 Dec 1965 00:05:00 GMT', 'right format';
+$date = Mojo::Date->new('-127180500.23');
+is $date->to_string, 'Tue, 21 Dec 1965 00:05:00 GMT', 'right format';
+$date = Mojo::Date->new('-127180500.60');
+is $date->to_string, 'Tue, 21 Dec 1965 00:04:59 GMT', 'right format';
 
 # Current time roundtrips
 my $before = time;


### PR DESCRIPTION
### Summary

This is a revision of https://github.com/kraih/mojo/pull/1080

The intention is to enable Mojo::Date to work with dates before Jan 1, 1970 (which require negative epoch values) and to make to_datetime() and to_string() to be consistent when given negative and/or fractional values.

### Motivation

To avoid these issues:

```
pirl @> use Mojo::Date                                                                                                  
()
pirl @> Mojo::Date->new(-1)                                                                                             
bless({ epoch => undef }, "Mojo::Date")
pirl @> Mojo::Date->new(-1)->to_datetime                                                                                
Use of uninitialized value $epoch in gmtime at /Users/ferreira/.perlbrew/libs/perl-5.22.2@dzil/lib/perl5/Mojo/Date.pm line 57.
Use of uninitialized value $epoch in pattern match (m//) at /Users/ferreira/.perlbrew/libs/perl-5.22.2@dzil/lib/perl5/Mojo/Date.pm line 60.
"1970-01-01T00:00:00Z"
pirl @> Mojo::Date->new(-1)->to_string                                                                                  
Use of uninitialized value in gmtime at /Users/ferreira/.perlbrew/libs/perl-5.22.2@dzil/lib/perl5/Mojo/Date.pm line 66.
"Thu, 01 Jan 1970 00:00:00 GMT"
```
Instead:

```
pirl @> Mojo::Date->new(-1)
bless({ epoch => -1 }, "Mojo::Date")
pirl @> Mojo::Date->new(-1)->to_datetime
"1969-12-31T23:59:59Z"
pirl @> Mojo::Date->new(-1)->to_string
"Wed, 31 Dec 1969 23:59:59 GMT"
```

The use case that made me hit these bugs was representing birth dates as `Mango::BSON::Time` objects, which in turn relies on `Mojo::Date` for stringification. It will be nice to see those working:

```
pirl @> Mojo::Date->new('1960-08-20T20:45:00-00:46')                                                                    
bless({ epoch => undef }, "Mojo::Date")
pirl @> Mojo::Date->new(-295499700)                                                                                     
bless({ epoch => undef }, "Mojo::Date")
```

Instead:

```
pirl @> Mojo::Date->new('1960-08-20T20:45:00-00:46') 
bless({ epoch => -295499700 }, "Mojo::Date")
pirl @> Mojo::Date->new(-295499700)
bless({ epoch => -295499700 }, "Mojo::Date")
```

In the last two PRs I proposed, the case of negative and fractional epoch was seen to be specially troublesome. Illustrated below

```
pirl @> Mojo::Date->new->epoch(-0.3)->to_string                                                                         
"Wed, 31 Dec 1969 23:59:59 GMT"
pirl @> Mojo::Date->new->epoch(-0.7)->to_string                                                                         
"Wed, 31 Dec 1969 23:59:59 GMT"
pirl @> Mojo::Date->new->epoch(-0.3)->to_datetime                                                                       
"1969-12-31T23:59:59.3Z"
pirl @> Mojo::Date->new->epoch(-0.7)->to_datetime                                                                       
"1969-12-31T23:59:59.7Z"
```

Instead:

```
pirl @> Mojo::Date->new->epoch(-0.3)->to_string
"Thu, 01 Jan 1970 00:00:00 GMT"    # closer to 0, so back to Jan 1, 1970
pirl @> Mojo::Date->new->epoch(-0.7)->to_string 
"Wed, 31 Dec 1969 23:59:59 GMT"   # closer to 1
pirl @> Mojo::Date->new->epoch(-0.3)->to_datetime   
"1969-12-31T23:59:59.7Z"
pirl @> Mojo::Date->new->epoch(-0.7)->to_datetime 
"1969-12-31T23:59:59.3Z"
```

### References
https://github.com/kraih/mojo/pull/1080

https://github.com/kraih/mojo/pull/1079
