### PR TITLE
Optimise frame parsing by removing substr calls

### DIFF
--- a/lib/Mojo/WebSocket.pm
+++ b/lib/Mojo/WebSocket.pm
@@ -101,7 +101,7 @@ sub parse_frame {
 
   # Head
   return undef unless length $$buffer >= 2;
-  my ($first, $second) = unpack 'C*', substr($$buffer, 0, 2);
+  my ($first, $second) = unpack 'C2', $$buffer;
 
   # FIN
   my $fin = ($first & 0b10000000) == 0b10000000 ? 1 : 0;
@@ -123,7 +123,7 @@ sub parse_frame {
   elsif ($len == 126) {
     return undef unless length $$buffer > 4;
     $hlen = 4;
-    $len = unpack 'n', substr($$buffer, 2, 2);
+    $len = unpack 'x2n', $$buffer;
     warn "-- Extended 16-bit payload ($len)\n" if DEBUG;
   }
 
@@ -131,8 +131,7 @@ sub parse_frame {
   elsif ($len == 127) {
     return undef unless length $$buffer > 10;
     $hlen = 10;
-    my $ext = substr $$buffer, 2, 8;
-    $len = MODERN ? unpack('Q>', $ext) : unpack('N', substr($ext, 4, 4));
+    $len = MODERN ? unpack('x2Q>', $$buffer) : unpack('x2x4N', $$buffer);
     warn "-- Extended 64-bit payload ($len)\n" if DEBUG;
   }
 


### PR DESCRIPTION
### Summary
These changes slightly improve the speed of parsing Websocket frames by removing the substr() calls and skipping bytes as needed instead. Considering only the unpack/substr calls, these changes give ~20% speed improvement in benchmarks.

The "Extended payload (64-bit with 32-bit fallback)" unpack format is slightly more verbose than required in the 32-bit fallback ("x2x4" vs "x6") but I believe this expanded form makes its behaviour easier to follow and did not appear to be detrimental to performance.

### Motivation
Optimisation.

### References
No references. Optimisation potential was noticed while studying the code.
