### PR TITLE
fix basename on a relative path

### DIFF
--- a/lib/Mojo/File.pm
+++ b/lib/Mojo/File.pm
@@ -21,7 +21,7 @@ use Mojo::Collection;
 
 our @EXPORT_OK = ('path', 'tempdir', 'tempfile');
 
-sub basename { File::Basename::basename ${$_[0]}, @_ }
+sub basename { File::Basename::basename ${shift()}, @_ }
 
 sub child { $_[0]->new(@_) }
 

--- a/t/mojo/file.t
+++ b/t/mojo/file.t
@@ -48,6 +48,7 @@ is path('.')->realpath, realpath('.'), 'same path';
 is path('file.t')->to_abs->basename, basename(rel2abs 'file.t'), 'same path';
 is path('file.t')->to_abs->basename('.t'), basename(rel2abs('file.t'), '.t'),
   'same path';
+is path('file.t')->basename('.t'), basename('file.t', '.t'), 'same path';
 
 # Dirname
 is path('file.t')->to_abs->dirname, scalar dirname(rel2abs 'file.t'),


### PR DESCRIPTION
I'm not sure why it works on absolute paths but I suspect it has something to do with the stringification of the scalar reference. That said, if that works for absolute paths I can't think of why it doesn't work for relative ones. Anyway, this fix seems fairly self-evident and the text works.
