### PR TITLE
:has selector for Mojo::DOM

### DIFF
--- a/lib/Mojo/DOM/CSS.pm
+++ b/lib/Mojo/DOM/CSS.pm
@@ -19,7 +19,7 @@ my $ATTR_RE   = qr/
 
 sub matches {
   my $tree = shift->tree;
-  return $tree->[0] ne 'tag' ? undef : _match(_compile(shift), $tree, $tree);
+  return $tree->[0] ne 'tag' ? undef : _match(_compile(shift), $tree, undef);
 }
 
 sub select     { _select(0, shift->tree, _compile(@_)) }
@@ -28,9 +28,11 @@ sub select_one { _select(1, shift->tree, _compile(@_)) }
 sub _ancestor {
   my ($selectors, $current, $tree, $one, $pos) = @_;
 
+  return undef if defined($tree) && $current eq $tree;
   while ($current = $current->[3]) {
-    return undef if $current->[0] eq 'root' || $current eq $tree;
+    return undef if $current->[0] eq 'root';
     return 1 if _combinator($selectors, $current, $tree, $pos);
+    return undef if defined($tree) && $current eq $tree;
     last if $one;
   }
 
@@ -56,7 +58,7 @@ sub _combinator {
   # Selector
   return undef unless my $c = $selectors->[$pos];
   if (ref $c) {
-    return undef unless _selector($c, $current);
+    return undef unless _selector($c, $current, $tree);
     return 1 unless $c = $selectors->[++$pos];
   }
 
@@ -71,6 +73,22 @@ sub _combinator {
 
   # " " (ancestor)
   return _ancestor($selectors, $current, $tree, 0, ++$pos);
+}
+
+sub _relativize {
+  my $group = $_[0];
+
+  for my $selectors (@$group) {
+    shift @$selectors if ($selectors->[0] && !defined($selectors->[0]->[0]));
+    if ($selectors->[0] && ref $selectors->[0]) {
+      unshift @$selectors, ' ';
+    } elsif (defined($selectors->[0])) {
+    } else {
+      unshift @$selectors, ' ', [];
+    }
+  }
+
+  return $group;
 }
 
 sub _compile {
@@ -102,8 +120,9 @@ sub _compile {
     elsif ($css =~ /\G:([\w\-]+)(?:\(((?:\([^)]+\)|[^)])+)\))?/gcs) {
       my ($name, $args) = (lc $1, $2);
 
-      # ":matches" and ":not" (contains more selectors)
+      # ":matches", ":not", and ":has" (contains more selectors)
       $args = _compile($args) if $name eq 'matches' || $name eq 'not';
+      $args = _relativize(_compile($args)) if $name eq 'has';
 
       # ":nth-*" (with An+B notation)
       $args = _equation($args) if $name =~ /^nth-/;
@@ -157,7 +176,7 @@ sub _match {
 sub _name {qr/(?:^|:)\Q@{[_unescape(shift)]}\E$/}
 
 sub _pc {
-  my ($class, $args, $current) = @_;
+  my ($class, $args, $current, $scope) = @_;
 
   # ":checked"
   return exists $current->[2]{checked} || exists $current->[2]{selected}
@@ -174,6 +193,12 @@ sub _pc {
 
   # ":root"
   return $current->[3] && $current->[3][0] eq 'root' if $class eq 'root';
+
+  # ":has"
+  return !!_has(1, $current, $args) if $class eq 'has';
+
+  # ":scope"
+  return $current->[0] eq 'root' || ($current eq $scope) if $class eq 'scope';
 
   # ":nth-child", ":nth-last-child", ":nth-of-type" or ":nth-last-of-type"
   if (ref $args) {
@@ -214,8 +239,25 @@ sub _select {
   return $one ? undef : \@results;
 }
 
+sub _has {
+  my ($one, $tree, $group) = @_;
+
+  my $gnew = [];
+  for my $selector (@$group) {
+    my @snew = @$selector;
+    unshift @snew, [['equals',$tree]];
+    push @$gnew, \@snew;
+  }
+  $group = $gnew;
+  if($tree->[0] ne 'root') {
+    $tree = $tree->[3];
+  }
+
+  return _select($one, $tree, $group);
+}
+
 sub _selector {
-  my ($selector, $current) = @_;
+  my ($selector, $current, $scope) = @_;
 
   for my $s (@$selector) {
     my $type = $s->[0];
@@ -227,7 +269,9 @@ sub _selector {
     elsif ($type eq 'attr') { return undef unless _attr(@$s[1, 2], $current) }
 
     # Pseudo-class
-    elsif ($type eq 'pc') { return undef unless _pc(@$s[1, 2], $current) }
+    elsif ($type eq 'pc') { return undef unless _pc(@$s[1, 2], $current, $scope) }
+
+    elsif ($type eq 'equals') { return undef unless $current == $s->[1] }
   }
 
   return 1;
@@ -514,6 +558,18 @@ An C<E> element that matches compound selector C<s1> and/or compound selector
 C<s2>. Note that this selector is EXPERIMENTAL and might change without warning!
 
   my $headers = $css->select(':matches(section, article, aside, nav) h1');
+
+This selector is part of
+L<Selectors Level 4|http://dev.w3.org/csswg/selectors-4>, which is still a work
+in progress.
+
+=head2 E:has(s1,s2)
+
+An C<E> element that has a child that matches selector C<s1> or selector
+C<s2>. Note that support for compound selectors is EXPERIMENTAL and might
+change without warning!
+
+  my $paras = $css->select('p:has(h1,h2,h3)');
 
 This selector is part of
 L<Selectors Level 4|http://dev.w3.org/csswg/selectors-4>, which is still a work

--- a/t/mojo/dom.t
+++ b/t/mojo/dom.t
@@ -927,6 +927,39 @@ is $dom->at(':empty[type^="ch"]')->attr->{name}, 'groovy',  'right name';
 is $dom->at('p')->attr->{id},                    'content', 'right attribute';
 is $dom->at('p:empty')->attr->{id}, 'no_content', 'right attribute';
 
+is $dom->find(':has(input)')->[0]->tag, 'form', 'right tag';
+
+$dom = Mojo::DOM->new(<<EOF);
+<ul>
+    <li>A</li>
+    <li>B</li>
+    <li>C</li>
+    <li>D</li>
+    <li>E</li>
+    <li>F</li>
+    <li>G</li>
+    <li>H</li>
+    <a><b></b></a>
+    <a><b><c></c></b></a>
+    <a><c></c></a>
+    <a><c><d></d></c></a>
+    <a><c></c></a>
+</ul>
+EOF
+
+is $dom->find('li:has(+li)')->[-1], '<li>G</li>', 'right content';
+is $dom->find('a:has(b,c)')->[0], '<a><b></b></a>', 'right content';
+is $dom->find('a:has(b,c)')->[-1], '<a><c></c></a>', 'right content';
+is $dom->find('a:has(>b)')->[0], '<a><b></b></a>', 'right content';
+is $dom->find('a:has(>b)')->[1], '<a><b><c></c></b></a>', 'right content';
+is $dom->find('a:has(>c)')->[0], '<a><c></c></a>', 'right content';
+is $dom->find('a:has(d)')->[0], '<a><c><d></d></c></a>', 'right content';
+is $dom->find('a:has(>d)')->[0], undef, 'right content';
+is $dom->find('d:has(c)')->[0], undef, 'right content';
+is $dom->find('c:has(c)')->[0], undef, 'right content';
+is $dom->find('d:has(*)')->[0], undef, 'right content';
+is $dom->find('c:has(*)')->[0], '<c><d></d></c>', 'right content';
+
 # More pseudo-classes
 $dom = Mojo::DOM->new(<<EOF);
 <ul>
@@ -1264,6 +1297,35 @@ is $dom->at('#♥ + #☃ ~ *:nth-last-child(1)')->text, 'G', 'right text';
 is $dom->at('#♥ ~ #☃ ~ *:nth-last-child(1)')->text, 'G', 'right text';
 is $dom->at('#♥ + *:nth-last-child(2)')->text,        'F', 'right text';
 is $dom->at('#♥ ~ *:nth-last-child(2)')->text,        'F', 'right text';
+
+# Scoped selectors
+$dom = Mojo::DOM::->new(<<EOF);
+<div>
+  <p>One</p>
+  <p>Two</p>
+  <p><a href="#">Link</a></p>
+</div>
+<div>
+  <p>Three</p>
+  <p>Four</p>
+</div>
+EOF
+is $dom->at('div')->at(':scope p')->text, 'One', 'right text';
+is $dom->at('div')->at(':scope > p')->text, 'One', 'right text';
+is $dom->at('div')->at('> p')->text, 'One', 'right text';
+is $dom->at('div')->at(':scope a')->text, 'Link', 'right text';
+ok !$dom->at('div')->at(':scope > a'), 'not a child';
+is $dom->at('div')->at(':scope > p > a')->text, 'Link','right text';
+is $dom->find('div')->last->at(':scope p')->text, 'Three', 'right text';
+is $dom->find('div')->last->at(':scope > p')->text, 'Three', 'right text';
+is $dom->find('div')->last->at('> p')->text, 'Three', 'right text';
+TODO: {
+  local $TODO = 'sibling :scope selectors are a work in progress';
+  #is $dom->at('p')->at(':scope + p')->text, 'Two', 'right text';
+  ok $dom->at('p')->at(':scope + p'), 'right text';
+}
+
+
 
 # Adding nodes
 $dom = Mojo::DOM->new(<<EOF);


### PR DESCRIPTION
### Summary
Add ".." and "..." selectors to Mojo/DOM/CSS.

This is more of an idea than a full PR at this point.

TL;DR:

```
mojo get http://www.tagesschau.de "a h4.headline .. a .dachzeile .. a"
```
harvests those A elements from tagesschau.de which contain h4 class=headline and class=dachzeile elements. The ".." backs up a level, like "cd .." does.

### Motivation
Some web sites fail to allow web harvesting because they mark embedded elements rather than containers: instead of

```
<p class="article">
<h4 class="headline">Blah</h4>
blah blah blah
```

they use something like

```
<div>
<h4 class="headline">Blah</h4>
blah blah blah
```

It would be nice to be able to harvest the containing <div> by writing
```
mojo get http://blah.com "h4.headline .. div"
```

So I hacked something up to allow that. It also allows "a ... b" to match any "b" ancestor of "a", but that's just an idea and a potential performance problem.

### Potential issues
- Drop compatibility with CSS.
- User-defined "CSS" selectors can take much longer to process.
- Not as powerful as XPath/XQuery