### PR TITLE
Add 'special' attribute to Mojolicious::Static

### DIFF
--- a/t/mojolicious/production_app.t
+++ b/t/mojolicious/production_app.t
@@ -33,6 +33,9 @@ is $t->app, $t->app->commands->app, 'applications are equal';
 is $t->app->static->file('hello.txt')->slurp,
   "Hello Mojo from a static file!\n", 'right content';
 is $t->app->static->file('does_not_exist.html'), undef, 'no file';
+isnt $t->app->static->file('mojo/jquery/jquery.js'), undef, 'find built-in jQuery';
+delete $t->app->static->special->{'mojo/jquery/jquery.js'};
+is $t->app->static->file('mojo/jquery/jquery.js'), undef, 'suppress built-in jQuery';
 is $t->app->moniker, 'mojolicious_test', 'right moniker';
 
 # Default namespaces


### PR DESCRIPTION
…to permit examining, overriding, or disabling any or all bundled files. May resolve #1094

### Summary
Enumerate bundled, static files so application can examine or modify their resolution at runtime. For example, a Mojolicious::Lite app could:

    delete app->static->special->{'favicon.ico'};

and then proceed to serve `favicon.ico` from a route.  

    app->static->special->{'mojo/jquery/jquery.js'} =
      app->home->child('resources', 'jquery.js');

would override the built-in jQuery for error pages with one in the app's `resources` directory.

Note: It might also be desirable to permit values which are Mojo::Asset objects, rather than filenames.

### References
[issue #1094 ](https://github.com/kraih/mojo/issues/1094)