### PR TITLE
Fix ordering problem in unquote.

### DIFF
--- a/lib/Mojo/Util.pm
+++ b/lib/Mojo/Util.pm
@@ -309,8 +309,8 @@ sub unindent {
 sub unquote {
   my $str = shift;
   return $str unless $str =~ s/^"(.*)"$/$1/g;
-  $str =~ s/\\\\/\\/g;
   $str =~ s/\\"/"/g;
+  $str =~ s/\\\\/\\/g;
   return $str;
 }
 

--- a/t/mojo/util.t
+++ b/t/mojo/util.t
@@ -380,6 +380,7 @@ is quote('"foo; 23 "bar"'), '"\"foo; 23 \"bar\""', 'right quoted result';
 # unquote
 is unquote('"foo 23 \"bar"'),     'foo 23 "bar',   'right unquoted result';
 is unquote('"\"foo 23 \"bar\""'), '"foo 23 "bar"', 'right unquoted result';
+is unquote('"\\\""'), '\"', 'right unquoted result';
 
 # trim
 is trim(' la la  la '),             'la la  la',         'right trimmed result';


### PR DESCRIPTION
Hi there,

unquote needs to handle all backslash escaped characters before handling backslash itself otherwise \\\" is handled incorrectly (it returns " instead of \").
