### PR TITLE
Mojo::Base::with_roles patch

### DIFF
--- a/lib/Mojolicious/Command/version.pm
+++ b/lib/Mojolicious/Command/version.pm
@@ -16,6 +16,7 @@ sub run {
     = Mojo::IOLoop::Client->can_socks ? $IO::Socket::Socks::VERSION : 'n/a';
   my $tls = Mojo::IOLoop::TLS->can_tls    ? $IO::Socket::SSL::VERSION  : 'n/a';
   my $nnr = Mojo::IOLoop::Client->can_nnr ? $Net::DNS::Native::VERSION : 'n/a';
+  my $roles = Mojo::Base->can_roles ? $Role::Tiny::VERSION : 'n/a';
 
   print <<EOF;
 CORE
@@ -27,6 +28,7 @@ OPTIONAL
   IO::Socket::Socks 0.64+ ($socks)
   IO::Socket::SSL 1.94+   ($tls)
   Net::DNS::Native 0.15+  ($nnr)
+  Role::Tiny 2.000001+    ($roles)
 
 EOF
 

--- a/t/mojo/roles.t
+++ b/t/mojo/roles.t
@@ -1,0 +1,59 @@
+use Mojo::Base -strict;
+
+use Test::More;
+
+BEGIN {
+  plan skip_all => 'Role::Tiny 2.000001+ required for this test!'
+    unless Mojo::Base->can_roles;
+}
+
+package Mojo::RoleTest::LOUD;
+use Role::Tiny;
+
+sub yell {'HEY!'}
+
+requires 'name';
+
+sub hello {
+  my ($self) = @_;
+  return $self->yell . ' ' . uc($self->name) . '!!!';
+}
+
+package Mojo::RoleTest::quiet;
+use Role::Tiny;
+
+requires 'name';
+
+sub whisper {
+  my ($self) = @_;
+  return 'psst, ' . lc($self->name);
+}
+
+package Mojo::RoleTest::Base;
+use Mojo::Base -base;
+
+has name => 'bob';
+
+sub hello {
+  my ($self) = shift;
+  return 'hello ' . $self->name;
+}
+
+package main;
+
+my $obj = Mojo::RoleTest::Base->new(name => 'Ted');
+is($obj->name,  'Ted',       'attr works');
+is($obj->hello, 'hello Ted', 'class method');
+
+my $obj2 = Mojo::RoleTest::Base->with_roles('Mojo::RoleTest::LOUD')->new;
+is($obj2->hello, 'HEY! BOB!!!', 'method from role overrides base method');
+is($obj2->yell,  'HEY!',        'new method from role');
+
+my $obj3 = Mojo::RoleTest::Base->with_roles('Mojo::RoleTest::quiet',
+  'Mojo::RoleTest::LOUD')->new(name => 'Joel');
+is($obj3->name,    'Joel',         'attr from base class');
+is($obj3->whisper, 'psst, joel',   'method from role1');
+is($obj3->hello,   'HEY! JOEL!!!', 'method override from role2');
+
+done_testing();
+


### PR DESCRIPTION
### Summary
Add with_roles method to Mojo::Base, per the specs described here:
https://irclog.perlgeek.de/mojo/2017-08-08#i_14984146

### Motivation
Allow multiple developers to extend key Mojolicious classes (Test::Mojo, Mojo::UserAgent, etc)
using Role::Tiny (optional dependency)

### References
https://irclog.perlgeek.de/mojo/2017-08-08#i_14984146

