### PR TITLE
Add regression test for controller loader bug

### DIFF
--- a/t/mojolicious/app-loader.t
+++ b/t/mojolicious/app-loader.t
@@ -1,0 +1,27 @@
+use Mojo::Base -strict;
+
+use Test::More;
+
+use FindBin;
+use lib "$FindBin::Bin/lib";
+
+use Mojolicious;
+use Test::Mojo;
+
+my $t = Test::Mojo->new('MojoliciousLoaderTest');
+
+
+# Application is already available
+$t->get_ok('/bar')->status_is(200)
+  ->header_is(Server => 'Mojolicious (Perl)')
+  ->content_like(qr/Hello Mojo from the other template \/bar!/);
+
+$t->get_ok('/foo')->status_is(200)
+  ->header_is(Server => 'Mojolicious (Perl)')
+  ->content_like(qr/Hello Mojo from the template \/foo!/);
+
+$t->get_ok('/bar')->status_is(200)
+  ->header_is(Server => 'Mojolicious (Perl)')
+  ->content_like(qr/Hello Mojo from the other template \/bar!/);
+
+done_testing();

--- a/t/mojolicious/lib/MojoliciousLoaderTest.pm
+++ b/t/mojolicious/lib/MojoliciousLoaderTest.pm
@@ -1,0 +1,15 @@
+package MojoliciousLoaderTest;
+use Mojo::Base 'Mojolicious';
+
+sub startup {
+  my $self = shift;
+
+  # Template and static file class with lower precedence for production
+  $self->renderer->paths([$self->home->child('templates-loadertest')]);
+
+  my $r = $self->routes;
+  $r->get('/foo')->to(controller => 'Foo', action => 'index');
+  $r->get('/bar')->to(controller => 'Foo::Bar', action => 'index');
+}
+
+1;

--- a/t/mojolicious/lib/MojoliciousLoaderTest/Foo/Bar.pm
+++ b/t/mojolicious/lib/MojoliciousLoaderTest/Foo/Bar.pm
@@ -1,0 +1,7 @@
+package MojoliciousLoaderTest::Foo::Bar;
+
+use Mojo::Base 'Mojolicious::Controller';
+
+sub index {}
+
+1;

--- a/t/mojolicious/templates-loadertest/exception.html.epl
+++ b/t/mojolicious/templates-loadertest/exception.html.epl
@@ -1,0 +1,7 @@
+% my $self = shift;
+% if ($self->app->mode eq 'development') {
+%= $self->stash('exception')->message
+% }
+% else {
+Not development mode error!
+% }

--- a/t/mojolicious/templates-loadertest/foo/bar/index.html.epl
+++ b/t/mojolicious/templates-loadertest/foo/bar/index.html.epl
@@ -1,0 +1,2 @@
+% my $c = shift;
+Hello Mojo from the other template <%= $c->url_for %>!

--- a/t/mojolicious/templates-loadertest/foo/index.html.epl
+++ b/t/mojolicious/templates-loadertest/foo/index.html.epl
@@ -1,0 +1,2 @@
+% my $c = shift;
+Hello Mojo from the template <%= $c->url_for %>!


### PR DESCRIPTION
### Summary
`Mojo::Loader` fails loading controller classes under certain circumstances.

### Motivation
This is actually a bug report that provides a failing regression test. I have no idea how to fix without breaking at the other end.

### Setup
The long story:
1. A Mojolicious app (example code below) with two controller namespaces (`Foo` and `Foo::Bar`) where the seconds lies down in the hierarchy of the first.
2. `Foo` does not have a controller class, but only a template.
3. Start app and run queries in the following order
3.1 First request to `foo-bar#index` works
3.2 First request to `foo#index` works
3.3 Second request to `foo-bar#index` crashes
```Can't locate object method "new" via package "TestApp::Controller::Foo::Bar" (perhaps you forgot to load "TestApp::Controller::Foo::Bar"?) ...```

### Perception
This error was introduced with commit bfc5449 that should fix issue #944.
It is caused by to enthusiastic unloading of `Mojo::Util::_teardown` and `Symbol::delete_package` respectively.

### The code
App
```perl
package TestApp;
use Mojo::Base 'Mojolicious';

sub startup {
  my $r = shift->routes;
  $r->get('/')->to(controller => 'Foo', action => 'index');
  $r->get('/foo')->to(controller => 'Foo::Bar', action => 'index');
}

1;
```
Foo::Bar controller
```perl
package TestApp::Controller::Foo::Bar;

use Mojo::Base 'Mojolicious::Controller';

sub index { shift->render }

1;
```
Foo template
```perl
% my $c = shift;
Hello Mojo from the template <%= $c->url_for %>!
```
Foo-Bar template
```perl
: my $c = shift;
Hello Mojo from the other template <%= $c->url_for %>!
```