### PR TITLE
Pass arguments for filters

### DIFF
--- a/lib/Mojolicious/Validator/Validation.pm
+++ b/lib/Mojolicious/Validator/Validation.pm
@@ -70,9 +70,10 @@ sub optional {
 
   my @input = ref $input eq 'ARRAY' ? @$input : ($input);
   my $filters_cb =  $self->validator->filters;
-  for my $cb ( @filters) {
-    $cb =  $filters_cb->{$cb};
-    @input = map { $self->$cb($name, $_) } @input;
+  for my $cb (@filters) {
+    ($cb, my @args) =  ref $cb ? @$cb : $cb;
+    $cb = $filters_cb->{$cb};
+    @input = map { $self->$cb($name, $_, @args) } @input;
   }
   $self->output->{$name} = ref $input eq 'ARRAY' ? \@input : $input[0]
     if @input && !grep { !length } @input;

--- a/lib/Mojolicious/Validator/Validation.pm
+++ b/lib/Mojolicious/Validator/Validation.pm
@@ -69,7 +69,9 @@ sub optional {
   return $self->topic($name) unless defined(my $input = $self->input->{$name});
 
   my @input = ref $input eq 'ARRAY' ? @$input : ($input);
-  for my $cb (map { $self->validator->filters->{$_} } @filters) {
+  my $filters_cb =  $self->validator->filters;
+  for my $cb ( @filters) {
+    $cb =  $filters_cb->{$cb};
     @input = map { $self->$cb($name, $_) } @input;
   }
   $self->output->{$name} = ref $input eq 'ARRAY' ? \@input : $input[0]


### PR DESCRIPTION
### Summary
Sometimes we are required to check incoming IDs not only for format `->like( qr/\d+/ )`, but also for existence in DB.
Having this patch we can provide model name for filter.

### Motivation
These changes allow to pass arguments for filters

### References
no reference

**UPD**
I did not link [blog post](http://blogs.perl.org/users/eugen_konkov/2017/08/how-to-pass-arguments-for-mojolicious-filter.html) because description did not ask about that:

>### References
>LIST RELEVANT ISSUES, PULL REQUESTS AND IRC/MAILING-LIST DISCUSSIONS HERE

Thank you @simbabque 