### PR TITLE
fix SSL_ca_file reference to undef

### DIFF
--- a/lib/Mojo/IOLoop/TLS.pm
+++ b/lib/Mojo/IOLoop/TLS.pm
@@ -9,6 +9,9 @@ use Scalar::Util 'weaken';
 use constant TLS => $ENV{MOJO_NO_TLS}
   ? 0
   : eval 'use IO::Socket::SSL 1.94 (); 1';
+use constant DEFAULT => eval { IO::Socket::SSL->VERSION('1.965') }
+  ? ''
+  : \undef;
 use constant READ  => TLS ? IO::Socket::SSL::SSL_WANT_READ()  : 0;
 use constant WRITE => TLS ? IO::Socket::SSL::SSL_WANT_WRITE() : 0;
 
@@ -51,7 +54,7 @@ sub _expand {
   weaken $self;
   my $tls = {
     SSL_ca_file => $args->{tls_ca}
-      && -T $args->{tls_ca} ? $args->{tls_ca} : \undef,
+      && -T $args->{tls_ca} ? $args->{tls_ca} : DEFAULT,
     SSL_error_trap         => sub { $self->_cleanup->emit(error => $_[1]) },
     SSL_honor_cipher_order => 1,
     SSL_startHandshake     => 0


### PR DESCRIPTION
### Summary
since IO::Socket::SSL >= 1.965 `\undef` means no CA, that is specificed as `''` in older versions

### Motivation
Otherwise we observe errors like:
> Mojo::Reactor::Poll: I/O watcher failed: SSL_ca_file SCALAR(0x2490188) does not exist at /usr/lib/perl5/vendor_perl/5.18.2/IO/Socket/SSL.pm line 1616.

### References
https://progress.opensuse.org/issues/23934#change-62720
