### PR TITLE
Permit Mojo::Util::tablify to work on non-rectangular arrays.

### DIFF
--- a/lib/Mojo/Util.pm
+++ b/lib/Mojo/Util.pm
@@ -282,8 +282,8 @@ sub tablify {
     }
   }
 
-  my @formats = (map({"\%-${_}s"} @spec[0 .. $#spec - 1]),'%s');
-  return join '', map { sprintf join(' ', @formats[0..scalar @$_ - 1]) . "\n", @$_ } @$rows;
+  my @formats = map({"\%-${_}s"} @spec[0 .. $#spec - 1]), '%s';
+  return join '', map { sprintf join('  ', @formats[0 .. scalar @$_ - 1]) . "\n", @$_ } @$rows;
 }
 
 sub term_escape {

--- a/lib/Mojo/Util.pm
+++ b/lib/Mojo/Util.pm
@@ -284,7 +284,7 @@ sub tablify {
 
   my @formats = (map({"\%-${_}s"} @spec[0 .. $#spec - 1]), '%s');
   return join '',
-    map { sprintf join('  ', @formats[0 .. scalar @$_ - 1]) . "\n", @$_ }
+    map { sprintf join('  ', @formats[0 .. $#$_]) . "\n", @$_ }
     @$rows;
 }
 

--- a/lib/Mojo/Util.pm
+++ b/lib/Mojo/Util.pm
@@ -282,7 +282,7 @@ sub tablify {
     }
   }
 
-  my @formats = map({"\%-${_}s"} @spec[0 .. $#spec - 1]), '%s';
+  my @formats = (map({"\%-${_}s"} @spec[0 .. $#spec - 1]), '%s');
   return join '', map { sprintf join('  ', @formats[0 .. scalar @$_ - 1]) . "\n", @$_ } @$rows;
 }
 

--- a/lib/Mojo/Util.pm
+++ b/lib/Mojo/Util.pm
@@ -282,8 +282,8 @@ sub tablify {
     }
   }
 
-  my $format = join '  ', map({"\%-${_}s"} @spec[0 .. $#spec - 1]), '%s';
-  return join '', map { sprintf "$format\n", @$_ } @$rows;
+  my @formats = (map({"\%-${_}s"} @spec[0 .. $#spec - 1]),'%s');
+  return join '', map { sprintf join(' ', @formats[0..scalar @$_ - 1]) . "\n", @$_ } @$rows;
 }
 
 sub term_escape {

--- a/lib/Mojo/Util.pm
+++ b/lib/Mojo/Util.pm
@@ -283,7 +283,9 @@ sub tablify {
   }
 
   my @formats = (map({"\%-${_}s"} @spec[0 .. $#spec - 1]), '%s');
-  return join '', map { sprintf join('  ', @formats[0 .. scalar @$_ - 1]) . "\n", @$_ } @$rows;
+  return join '',
+    map { sprintf join('  ', @formats[0 .. scalar @$_ - 1]) . "\n", @$_ }
+    @$rows;
 }
 
 sub term_escape {

--- a/t/mojo/util.t
+++ b/t/mojo/util.t
@@ -487,6 +487,9 @@ is tablify([[undef, 'yada'], ['yada', undef]]), "      yada\nyada  \n",
 is tablify([['foo', 'bar', 'baz'], ['yada', 'yada', 'yada']]),
   "foo   bar   baz\nyada  yada  yada\n", 'right result';
 is tablify([['a', '', 0], [0, '', 'b']]), "a    0\n0    b\n", 'right result';
+is tablify([[1, 2], [3]]),     "1  2\n3\n",      'right result';
+is tablify([[1], [2, 3]]),     "1\n2  3\n",      'right result';
+is tablify([[1], [], [2, 3]]),     "1\n\n2  3\n",      'right result';
 
 # deprecated
 {


### PR DESCRIPTION
### Summary
Should a non-rectangular array (one in which not all rows have equal numbers of columns) be passed to Mojo::Util::tablify, the resulting columns or entirely empty rows will be skipped rather than producing errors from missing sprintf() arguments.

### Motivation
Users who write simple classes based on Mojolicious::Command should be able to produce arrays for table output, perhaps from a variety of functions or a JSON structure, without having to ensure that each row has an equal number of columns.

### References
https://irclog.perlgeek.de/mojo/2017-09-14#i_15164351
