### PR TITLE
Fix warnings with Encode >= 2.87

### DIFF
--- a/lib/Mojo/Util.pm
+++ b/lib/Mojo/Util.pm
@@ -127,7 +127,7 @@ sub dumper {
   Data::Dumper->new([@_])->Indent(1)->Sortkeys(1)->Terse(1)->Useqq(1)->Dump;
 }
 
-sub encode { _encoding($_[0])->encode("$_[1]") }
+sub encode { _encoding($_[0])->encode("$_[1]", 0) }
 
 sub extract_usage {
   my $file = @_ ? "$_[0]" : (caller)[1];

--- a/t/mojo/util.t
+++ b/t/mojo/util.t
@@ -191,6 +191,17 @@ is decode('does_not_exist', ''), undef, 'decoding with invalid encoding worked';
 eval { encode('does_not_exist', '') };
 like $@, qr/Unknown encoding 'does_not_exist'/, 'right error';
 
+# encode (using external encoding)
+{
+  my @warnings;
+  local $SIG{__WARN__} = sub {
+    push @warnings, @_;
+  };
+  encode('MIME-Header', "foo\x{df}\x{0100}bar\x{263a}");
+
+  is scalar(@warnings), 0, 'no warnings';
+}
+
 # url_escape
 is url_escape('business;23'), 'business%3B23', 'right URL escaped result';
 


### PR DESCRIPTION
### Summary

With `Encode` 2.87 or higher `Mojo::Util::encode('MIME-Header', $string)`
issues a warning for every character in `$string`.

### Motivation

Keeping my errorlog sparse. ;-)

### References
.
