### PR TITLE
ojo_signatures.t: Suppress proxies

### DIFF
--- a/t/mojolicious/ojo_signatures.t
+++ b/t/mojolicious/ojo_signatures.t
@@ -1,6 +1,9 @@
 use Mojo::Base -strict;
 
-BEGIN { $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll' }
+BEGIN {
+  $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll';
+  $ENV{MOJO_PROXY}   =  0;
+}
 
 use Test::More;
 


### PR DESCRIPTION
Without this, I get a test failure because it’s trying to ask a proxy
for localhost, which of course comes back with the wrong content.
