### PR TITLE
allow tablify to format non-rectangular arrays

### DIFF
--- a/lib/Mojo/Util.pm
+++ b/lib/Mojo/Util.pm
@@ -290,8 +290,8 @@ sub tablify {
     }
   }
 
-  my $format = join '  ', map({"\%-${_}s"} @spec[0 .. $#spec - 1]), '%s';
-  return join '', map { sprintf "$format\n", @$_ } @$rows;
+  my @fs = (map({"\%-${_}s"} @spec[0 .. $#spec - 1]), '%s');
+  return join '', map { sprintf join('  ', @fs[0 .. $#$_]) . "\n", @$_ } @$rows;
 }
 
 sub term_escape {

--- a/t/mojo/util.t
+++ b/t/mojo/util.t
@@ -487,6 +487,9 @@ is tablify([[undef, 'yada'], ['yada', undef]]), "      yada\nyada  \n",
 is tablify([['foo', 'bar', 'baz'], ['yada', 'yada', 'yada']]),
   "foo   bar   baz\nyada  yada  yada\n", 'right result';
 is tablify([['a', '', 0], [0, '', 'b']]), "a    0\n0    b\n", 'right result';
+is tablify([[1, 2], [3   ]        ]), "1  2\n3\n",   'right result';
+is tablify([[1   ], [2, 3]        ]), "1\n2  3\n",   'right result';
+is tablify([[1   ], [    ], [2, 3]]), "1\n\n2  3\n", 'right result';
 
 # deprecated
 {


### PR DESCRIPTION
### Summary
This change allows tablify to work on non-rectangular arrays without generating errors. For example, when outputting parsed CSV files with trailing empty cells omitted/removed by trimmed whitespace.

### Motivation
Removes the need for looping over and modifying the input array reference several times to prepare it for tablify by the user.

### References
This implements the line-count-even implementation suggested by sri and tests provided by lindleyw in https://github.com/kraih/mojo/pull/1132.