### PR TITLE
Export "with" at "use Mojo::Base -base"

### DIFF
--- a/lib/Mojo/Base.pm
+++ b/lib/Mojo/Base.pm
@@ -81,11 +81,14 @@ sub import {
     require "$file.pm";
   }
 
-  # "has" and possibly ISA
+  # Exports and possibly ISA
   if ($flags[0]) {
     no strict 'refs';
     push @{"${caller}::ISA"}, $flags[0] unless $flags[0] eq '-role';
-    Mojo::Util::monkey_patch($caller, 'has', sub { attr($caller, @_) });
+    my %subs = (has => sub { attr($caller, @_) });
+    $subs{with} = sub { Role::Tiny->apply_roles_to_package($caller, @_) }
+      unless !ROLES || $flags[0] eq '-role';
+    Mojo::Util::monkey_patch($caller, %subs);
   }
 
   # Mojo modules are strict!
@@ -184,6 +187,7 @@ L<Role::Tiny> (2.000001+).
   use IO::Handle ();
   push @ISA, 'Mojo::Base';
   sub has { Mojo::Base::attr(__PACKAGE__, @_) }
+  sub with { Role::Tiny->apply_roles_to_package(__PACKAGE__, @_) }
 
   # use Mojo::Base 'SomeBaseClass';
   use strict;
@@ -194,6 +198,7 @@ L<Role::Tiny> (2.000001+).
   require SomeBaseClass;
   push @ISA, 'SomeBaseClass';
   sub has { Mojo::Base::attr(__PACKAGE__, @_) }
+  sub with { Role::Tiny->apply_roles_to_package(__PACKAGE__, @_) }
 
   # use Mojo::Base -role;
   use strict;

--- a/t/mojo/roles.t
+++ b/t/mojo/roles.t
@@ -46,6 +46,10 @@ use Mojo::Base -role;
 
 sub hello {'hello mojo!'}
 
+package Mojo::RoleTest::WithHello;
+use Mojo::Base -base;
+with 'Mojo::RoleTest::Hello';
+
 package main;
 
 use Mojo::ByteStream;
@@ -67,6 +71,10 @@ is $obj2->yell,  'HEY!',        'another role method';
 my $obj4 = Mojo::RoleTest->with_roles('+LOUD')->new;
 is $obj4->hello, 'HEY! BOB!!!', 'role method';
 is $obj4->yell,  'HEY!',        'another role method';
+
+# Single role (using with)
+my $obj8 = Mojo::RoleTest::WithHello->new;
+is $obj8->hello, 'hello mojo!', 'role method';
 
 # Multiple roles
 my $obj3 = Mojo::RoleTest->with_roles('Mojo::RoleTest::Role::quiet',


### PR DESCRIPTION
### Summary
Now that Mojo::Base has support for roles with
```
use Mojo::Base -role;
```
it would be nice to have "with" exported to the caller package – alongside "has" – when doing `use Mojo::Base -base` . For example:
```
package Foo;
use Mojo::Base -role;
after foo => sub { say "Bye." }

package FooFoo;
use Mojo::Base -base;
with 'Foo';         # comes from Mojo::Base just like "has"
sub foo { say "Foo" }

package main;
FooFoo->new->foo;
# Foo
# Bye.
```

### Motivation
In the same spirit that `use Mojo::Base -role` allows to create roles without mentioning `Role::Tiny`, this change allows to consume roles (statically) without mentioning `Role::Tiny`.

So instead of
```
package Foo;
use Mojo::Base -base;
use Role::Tiny::With;
with 'SomeRole';
```
one can write
```
package Foo;
use Mojo::Base -base;
with 'SomeRole';
```

### References
None