### PR TITLE
use block eval instead of string eval to load optional modules

### DIFF
--- a/lib/Mojo/IOLoop/Client.pm
+++ b/lib/Mojo/IOLoop/Client.pm
@@ -12,13 +12,13 @@ use Socket qw(IPPROTO_TCP SOCK_STREAM TCP_NODELAY);
 # Non-blocking name resolution requires Net::DNS::Native
 use constant NNR => $ENV{MOJO_NO_NNR}
   ? 0
-  : eval 'use Net::DNS::Native 0.15 (); 1';
+  : eval { require Net::DNS::Native; Net::DNS::Native->VERSION('0.15'); 1 };
 my $NDN = NNR ? Net::DNS::Native->new(pool => 5, extra_thread => 1) : undef;
 
 # SOCKS support requires IO::Socket::Socks
 use constant SOCKS => $ENV{MOJO_NO_SOCKS}
   ? 0
-  : eval 'use IO::Socket::Socks 0.64 (); 1';
+  : eval { require IO::Socket::Socks; IO::Socket::Socks->VERSION('0.64'); 1 };
 use constant READ  => SOCKS ? IO::Socket::Socks::SOCKS_WANT_READ()  : 0;
 use constant WRITE => SOCKS ? IO::Socket::Socks::SOCKS_WANT_WRITE() : 0;
 

--- a/lib/Mojo/IOLoop/TLS.pm
+++ b/lib/Mojo/IOLoop/TLS.pm
@@ -8,7 +8,7 @@ use Scalar::Util 'weaken';
 # TLS support requires IO::Socket::SSL
 use constant TLS => $ENV{MOJO_NO_TLS}
   ? 0
-  : eval 'use IO::Socket::SSL 1.94 (); 1';
+  : eval { require IO::Socket::SSL; IO::Socket::SSL->VERSION('1.94'); 1 };
 use constant DEFAULT => eval { IO::Socket::SSL->VERSION('1.965') }
   ? \undef
   : '';

--- a/t/mojo/reactor_ev.t
+++ b/t/mojo/reactor_ev.t
@@ -4,7 +4,8 @@ use Test::More;
 
 plan skip_all => 'set TEST_EV to enable this test (developer only!)'
   unless $ENV{TEST_EV};
-plan skip_all => 'EV 4.0+ required for this test!' unless eval 'use EV 4.0; 1';
+plan skip_all => 'EV 4.0+ required for this test!'
+  unless eval { require EV; EV->VERSION('4.0'); 1 };
 
 use IO::Socket::INET;
 


### PR DESCRIPTION
### Summary
String eval is unnecessary for this type of check. We can consistently use block eval here.

### Motivation
Consistency and avoidance of string eval where it's not needed.

### References

