### PR TITLE
use class_to_path to load modules in Mojo::Base

### DIFF
--- a/lib/Mojo/Base.pm
+++ b/lib/Mojo/Base.pm
@@ -76,9 +76,8 @@ sub import {
   }
 
   # Module
-  elsif ((my $file = $flags[0]) && !$flags[0]->can('new')) {
-    $file =~ s!::|'!/!g;
-    require "$file.pm";
+  elsif ($flags[0] && !$flags[0]->can('new')) {
+    require(Mojo::Util::class_to_path($flags[0]));
   }
 
   # "has" and possibly ISA


### PR DESCRIPTION
### Summary
With circular require issues solved, class_to_path can be reused in Mojo::Base for loading modules.

### Motivation
Code reuse

### References

