### PR TITLE
Fix doc typo on Mojo::IOLoop::Delay

### DIFF
--- a/lib/Mojo/IOLoop/Delay.pm
+++ b/lib/Mojo/IOLoop/Delay.pm
@@ -150,7 +150,7 @@ that leads to the next closure in the series when executed.
   use Mojo::IOLoop;
 
   # Instead of nested closures we now have a simple chain of steps
-  my $delay = Mojo::IOloop->delay(
+  my $delay = Mojo::IOLoop->delay(
     sub {
       my $delay = shift;
       Mojo::IOLoop->timer(3 => $delay->begin);


### PR DESCRIPTION
### Summary
Fix a typo in Mojo::IOLoop::Delay documentation

### Motivation
Correctness
