### PR TITLE
Initialize $r to avoid "Use of uninitialized value" error

### DIFF
--- a/lib/Mojolicious/Command/get.pm
+++ b/lib/Mojolicious/Command/get.pm
@@ -16,7 +16,7 @@ sub run {
   my ($self, @args) = @_;
 
   # Data from STDIN
-  vec(my $r, fileno(STDIN), 1) = 1;
+  vec(my $r = '', fileno(STDIN), 1) = 1;
   my $in = !-t STDIN && select($r, undef, undef, 0) ? join '', <STDIN> : undef;
 
   my $ua = Mojo::UserAgent->new(ioloop => Mojo::IOLoop->singleton);

--- a/t/mojolicious/commands.t
+++ b/t/mojolicious/commands.t
@@ -7,6 +7,10 @@ BEGIN {
 
 use Test::More;
 
+my $test_no_warnings = eval {
+    require Test::NoWarnings;
+};
+
 use FindBin;
 use lib "$FindBin::Bin/lib";
 
@@ -387,5 +391,10 @@ $buffer = '';
 like $buffer, qr/Perl/, 'right output';
 like $buffer, qr/You might want to update your Mojolicious to 1000!/,
   'right output';
+
+SKIP: {
+    skip('Test::NoWarnings required!', 1) unless $test_no_warnings;
+    Test::NoWarnings::had_no_warnings();
+}
 
 done_testing();


### PR DESCRIPTION
### Summary
When running the get command the errors appear
```
Use of uninitialized value $r in vec at /usr/share/perl5/vendor_perl/Mojolicious/Command/get.pm line 19.
Use of uninitialized value $r in scalar assignment at /usr/share/perl5/vendor_perl/Mojolicious/Command/get.pm line 19.
```
### Motivation
To avoid noise when testing mojo from the cli.
 