### PR TITLE
With "use Mojo::Base -role", "has" is a non-method

### DIFF
--- a/lib/Mojo/Base.pm
+++ b/lib/Mojo/Base.pm
@@ -72,7 +72,6 @@ sub import {
   # Role
   elsif ($flags[0] eq '-role') {
     Carp::croak 'Role::Tiny 2.000001+ is required for roles' unless ROLES;
-    eval "package $caller; use Role::Tiny; 1" or die $@;
   }
 
   # Module
@@ -82,9 +81,16 @@ sub import {
 
   # "has" and possibly ISA
   if ($flags[0]) {
-    no strict 'refs';
-    push @{"${caller}::ISA"}, $flags[0] unless $flags[0] eq '-role';
     Mojo::Util::monkey_patch($caller, 'has', sub { attr($caller, @_) });
+    if ($flags[0] eq '-role') {
+
+      # import of Role::Tiny must come after injecting has
+      eval "package $caller; use Role::Tiny; 1" or die $@;
+    }
+    else {
+      no strict 'refs';
+      push @{"${caller}::ISA"}, $flags[0] unless $flags[0] eq '-role';
+    }
   }
 
   # Mojo modules are strict!

--- a/t/mojo/roles.t
+++ b/t/mojo/roles.t
@@ -97,6 +97,13 @@ is $obj7->name,    'Joel',         'base attribute';
 is $obj7->whisper, 'psst, joel',   'method from first role';
 is $obj7->hello,   'HEY! JOEL!!!', 'method from second role';
 
+# Multiple Mojo::Base roles
+my $obj8 = Mojo::RoleTest->with_roles('+quiet', 'Mojo::RoleTest::Hello')
+  ->new(name => 'Joel');
+is $obj8->name,    'Joel',        'base attribute';
+is $obj8->whisper, 'psst, joel',  'method from first role';
+is $obj8->hello,   'hello mojo!', 'method from second role';
+
 # Classes that are not subclasses of Mojo::Base
 my $stream = Mojo::ByteStream->with_roles('Mojo::RoleTest::Hello')->new;
 is $stream->hello, 'hello mojo!', 'right result';


### PR DESCRIPTION
Proposed solution to https://github.com/kraih/mojo/issues/1170

This pull request delays promoting the caller package into a role to after exporting `has`. That makes `has` to be marked as a non-method and then treated just like `with`, `requires`, `after`, `before` and `around`.
