### PR TITLE
JSON encode utf8 flagged scalars as strings

### DIFF
--- a/lib/Mojo/JSON.pm
+++ b/lib/Mojo/JSON.pm
@@ -251,7 +251,8 @@ sub _encode_value {
   # Number
   no warnings 'numeric';
   return $value
-    if length((my $dummy = '') & $value)
+    if !utf8::is_utf8($value)
+    && length((my $dummy = '') & $value)
     && 0 + $value eq $value
     && $value * 0 == 0;
 


### PR DESCRIPTION
Values that start as numbers won't get the utf8 flag enabled implicitly
through other operations, so it is a good signal that we should encode
as a string.  Additionally, this avoids planned future perl warnings
about performing bitwise operations on strings containing wide
characters.

Discussion regarding deprecation warning:
https://www.nntp.perl.org/group/perl.perl5.porters/2017/12/msg248248.html