### PR TITLE
Encode static files from data sections to UTF-8

### DIFF
--- a/lib/Mojolicious/Static.pm
+++ b/lib/Mojolicious/Static.pm
@@ -6,8 +6,8 @@ use Mojo::Asset::Memory;
 use Mojo::Date;
 use Mojo::File 'path';
 use Mojo::Home;
-use Mojo::Loader 'data_section';
-use Mojo::Util 'md5_sum';
+use Mojo::Loader qw(data_section file_is_binary);
+use Mojo::Util qw(encode md5_sum);
 
 # Bundled files
 my $PUBLIC = Mojo::Home->new(Mojo::Home->new->mojo_lib_dir)
@@ -137,9 +137,10 @@ sub _get_data_file {
   $self->warmup unless $self->{index};
 
   # Find file
-  return undef
-    unless defined(my $data = data_section($self->{index}{$rel}, $rel));
-  return Mojo::Asset::Memory->new->add_chunk($data);
+  my @args = ($self->{index}{$rel}, $rel);
+  return undef unless defined(my $data = data_section(@args));
+  return Mojo::Asset::Memory->new->add_chunk(
+    file_is_binary(@args) ? $data : encode 'UTF-8', $data);
 }
 
 sub _get_file {

--- a/t/mojolicious/static_lite_app.t
+++ b/t/mojolicious/static_lite_app.t
@@ -216,6 +216,10 @@ $t->get_ok('/static.txt' => {Range => 'bytes=45-50'})->status_is(416)
   ->header_is(Server          => 'Mojolicious (Perl)')
   ->header_is('Accept-Ranges' => 'bytes')->content_is('');
 
+# UTF-8 encoded inline file
+$t->get_ok('/static_utf8.txt')->status_is(200)
+  ->header_is(Server => 'Mojolicious (Perl)')->content_is("I ♥ Unicode\n");
+
 done_testing();
 
 __DATA__
@@ -224,3 +228,6 @@ Unreachable file.
 
 @@ static.txt (base64)
 dGVzdCAxMjMKbGFsYWxh
+
+@@ static_utf8.txt
+I ♥ Unicode


### PR DESCRIPTION
### Summary
Data sections in files with `use utf8` active will be decoded to characters when retrieved. It is expected that `use utf8` will be active in Mojolicious source code. Thus static files retrieved from these data sections need to be encoded back to UTF-8 to be served correctly.

### Motivation

### References
https://irclog.perlgeek.de/mojo/2017-12-22#i_15612756
