### PR TITLE
Mojo::Promise->all to take non-Promise objects

### DIFF
--- a/t/mojo/promise.t
+++ b/t/mojo/promise.t
@@ -145,6 +145,23 @@ $promise->resolve('first');
 Mojo::IOLoop->one_tick;
 is_deeply \@results, ['second'], 'promises resolved';
 
+# Race with a non-Promise
+$promise2 = Mojo::Promise->new->then(sub {@_});
+$promise3 = Mojo::Promise->new->then(sub {@_});
+@results  = ();
+Mojo::Promise->race($promise2, 'first', $promise3)
+  ->then(sub { @results = @_ });
+$promise2->resolve('second');
+$promise3->resolve('third');
+Mojo::IOLoop->one_tick;
+is_deeply \@results, ['first'], 'promises resolved';
+
+# Race with all non-Promises
+@results  = ();
+Mojo::Promise->race('first', 'second', 'third')->then(sub { @results = @_ });
+Mojo::IOLoop->one_tick;
+is_deeply \@results, ['first'], 'promises resolved';
+
 # Rejected race
 $promise  = Mojo::Promise->new->then(sub {@_});
 $promise2 = Mojo::Promise->new->then(sub {@_});

--- a/t/mojo/promise.t
+++ b/t/mojo/promise.t
@@ -171,6 +171,22 @@ $promise->resolve('first');
 Mojo::IOLoop->one_tick;
 is_deeply \@results, [['first'], ['second'], ['third']], 'promises resolved';
 
+# All with a non-Promise
+$promise  = Mojo::Promise->new->then(sub {@_});
+$promise3 = Mojo::Promise->new->then(sub {@_});
+@results  = ();
+Mojo::Promise->all($promise, 'second', $promise3)->then(sub { @results = @_ });
+$promise3->resolve('third');
+$promise->resolve('first');
+Mojo::IOLoop->one_tick;
+is_deeply \@results, [['first'], ['second'], ['third']], 'promises resolved';
+
+# All with all non-Promises
+@results  = ();
+Mojo::Promise->all('first', 'second', 'third')->then(sub { @results = @_ });
+Mojo::IOLoop->one_tick;
+is_deeply \@results, [['first'], ['second'], ['third']], 'promises resolved';
+
 # Rejected all
 $promise  = Mojo::Promise->new->then(sub {@_});
 $promise2 = Mojo::Promise->new->then(sub {@_});


### PR DESCRIPTION
### Summary
Currently `Mojo::Promise->all` cannot take non-Promise objects as an argument. This is surprising for those who've used JavaScript Promises, whose `all` method can do so.

### Motivation
This current behaviour does not match the expectations of those who've used JS Promises. There, the expectation is for accepting non-Promises, and for interoperation.

### References
As discussed on IRC: https://irclog.perlgeek.de/mojo/2017-12-30#i_15633913
  