### PR TITLE
Fix documentation error

### DIFF
--- a/lib/Mojo/Template.pm
+++ b/lib/Mojo/Template.pm
@@ -334,8 +334,8 @@ For all templates L<strict>, L<warnings>, L<utf8> and Perl 5.10
 L<features|feature> are automatically enabled.
 
   <% Perl code %>
-  <%= Perl expression, replaced with result %>
-  <%== Perl expression, replaced with XML escaped result %>
+  <%= Perl expression, replaced with XML escaped result %>
+  <%== Perl expression, replaced with result %>
   <%# Comment, useful for debugging %>
   <%% Replaced with "<%", useful for generating templates %>
   % Perl code line, treated as "<% line =%>" (explained later)


### PR DESCRIPTION
McA noted in IRC that the syntax examples in Mojo::Template have swapped explanations for <%= and <%==.