### PR TITLE
The pre-forking server requires KillMode=control-group

### DIFF
--- a/lib/Mojolicious/Guides/Cookbook.pod
+++ b/lib/Mojolicious/Guides/Cookbook.pod
@@ -154,7 +154,7 @@ configuration file like this.
   [Service]
   Type=simple
   ExecStart=/home/sri/myapp/script/my_app prefork -m production -l http://*:8080
-  KillMode=process
+  KillMode=control-group
 
   [Install]
   WantedBy=multi-user.target


### PR DESCRIPTION
### Summary

Fix one of the `systemd` configs in `lib/Mojolicious/Guides/Cookbook.pod` so that the preforking server can be stopped via `systemd` after it has been started.

### Motivation
If `KillMode=process` then `systemd` believes that the app has been stopped, despite the fact that the processes happily continue on.

### References
https://stackoverflow.com/questions/48242004/why-cant-i-stop-my-mojo-app-using-systemd

It might be worth checking if the `systemd` config for `hypnotoad` also suffers from the same issue.

Tested on Ubuntu 16.04.3 LTS

```
$ systemd --version
systemd 229
+PAM +AUDIT +SELINUX +IMA +APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ -LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD -IDN
```
