### PR TITLE
Fix uninitialized concatenation on Headers

### DIFF
--- a/lib/Mojo/Headers.pm
+++ b/lib/Mojo/Headers.pm
@@ -144,7 +144,9 @@ sub to_string {
   # Make sure multi-line values are formatted correctly
   my @headers;
   for my $name (@{$self->names}) {
-    push @headers, "$name: $_" for @{$self->{headers}{lc $name}};
+    for my $head (@{$self->{headers}{lc $name}}) {
+      push @headers, "$name: $head" if $head;
+    }
   }
 
   return join "\x0d\x0a", @headers;


### PR DESCRIPTION
Before concatenation, need to check if all Headers fields were set.

Signed-off-by: Kaio Rafael <perl@kaiux.com>

### Summary
Just a check to avoid warning on terminal if all Headers are not set.

### Motivation
That behavior happens on Debian (using PerlBrew) and FreeBSD 11.
Debian

> Use of uninitialized value $_ in concatenation (.) or string at /builders/perl/perl5/perls/perl-5.24.0/lib/site_perl/5.24.0/Mojo/Headers.pm line 147.

FreeBSD 11

> Use of uninitialized value $_ in concatenation (.) or string at /usr/local/lib/perl5/site_perl/Mojo/Headers.pm line 147.


Using the following code I get this error.
```
use Mojo::UserAgent;
use Data::Dumper;
use feature 'say';

my $SERVER="http://127.0.0.1:3000";
my $API="/api";
my $ENCODE="Content-Type: application/json";
my $url = $SERVER.$API;
my $k = "mykey007";

sub send_query {
   my ($url, $hash_ref) = @_;
   my $out = Mojo::UserAgent->new->put(
      $url => { $ENCODE },
      json => $hash_ref
   );

   my @res;
   push @res, $out->result->code;
   push @res, $out->result->body;
   return @res;
}

#main code
my @res = send_query( $url, { key => $k, domain => 'example.com'} );
say $res[0];
```

### References
None