### PR TITLE
Add section on Reverse Proxy in Cookbook/CONCEPTS

### DIFF
--- a/lib/Mojolicious/Guides/Cookbook.pod
+++ b/lib/Mojolicious/Guides/Cookbook.pod
@@ -67,10 +67,13 @@ In L<Mojolicious> this event loop is L<Mojo::IOLoop>.
 
 =head2 Reverse Proxy
 
-A I<reverse proxy> is a server that is put in front of your application and acts
-as the frontend facing clients. It can provide a lot of benefits, like
-protecting your application in the backend, balancing load across multiple
-instances, or supporting several backend applications from the same IP/port.
+A reverse proxy architecture is a deployment technique used in many production
+environments, where a I<reverse proxy> server is put in front of your
+application to act as the endpoint accessible by external clients. It can
+provide a lot of benefits, like terminating SSL connections from the outside,
+limiting the number of concurrent open sockets towards the Mojolicious
+application (or even using Unix sockets), balancing load across multiple
+instances, or supporting several applications through the same IP/port.
 
    .               ..........................................
                    :                                        :                        
@@ -86,17 +89,16 @@ instances, or supporting several backend applications from the same IP/port.
                    :                                        :
                    .. system boundary (e.g. same host) ......
 
-In this setup, your application will receive requests from the reverse proxy
-instead of the original client; additionally, the address/hostname where your
-application lives internally will be usually different from the one accessed
-externally. Last, it might even be the case that the reverse proxy exposes
-services via HTTPS, while contacting the Mojolicious application via plaintext
-HTTP.
+This setup introduces some problems, though: the application will receive
+requests from the reverse proxy instead of the original client; the
+address/hostname where your application lives internally will be different from
+the one visible from the outside; if terminating SSL, the reverse proxy exposes
+services via HTTPS, while using HTTP towards the Mojolicious application.
 
-As an example, compare a sample request from the client against what arrives to
-the Mojolicious application:
+As an example, compare a sample request from the client and what the Mojolicious
+application receives:
 
-   client                 reverse proxy (frontend)           Mojolicious app
+   client                       reverse proxy                Mojolicious app
     __|__              _______________|______________             ____|____
    /     \            /                              \           /         \
    1.2.3.4 --HTTPS--> api.example.com      10.20.30.39 --HTTP--> 10.20.30.40
@@ -106,13 +108,13 @@ the Mojolicious application:
    User-Agent: Mojolicious (Perl)     |    User-Agent: ShinyProxy/1.2
    ...                                |    ...
 
-You're losing the client's address (e.g. useful for analytics, or Geo-IP) and if
-the application generates URLs via L<Mojolicious::Controller/"url_for">, the
-result will be like this:
+The client address is no longer available (it might be useful for analytics, or
+Geo-IP) and URLs generated via L<Mojolicious::Controller/"url_for"> will be like
+this:
 
    http://10.20.30.40/bar/2
 
-instead of something I<meaningful for the client>, like this:
+instead of something meaningful for the client, like this:
 
    https://api.example.com/bar/2
 
@@ -128,7 +130,7 @@ environment variable C<MOJO_REVERSE_PROXY=1>; OR
 
 =item *
 
-do-it-yourself like suggested in L</Rewriting>.
+do it yourself like suggested in L</Rewriting>.
 
 =back
 

--- a/lib/Mojolicious/Guides/Cookbook.pod
+++ b/lib/Mojolicious/Guides/Cookbook.pod
@@ -65,6 +65,74 @@ connections concurrently.
 
 In L<Mojolicious> this event loop is L<Mojo::IOLoop>.
 
+=head2 Reverse Proxy
+
+A I<reverse proxy> is a server that is put in front of your application and acts
+as the frontend facing clients. It can provide a lot of benefits, like
+protecting your application in the backend, balancing load across multiple
+instances, or supporting several backend applications from the same IP/port.
+
+   .               ..........................................
+                   :                                        :                        
+                   :                       +-------------+  :                        
+                   :  +------------+      +-------------+|  :
+   +--------+      :  |            |      |             ||  :
+   |        |-------->|  reverse   |----->| Mojolicious ||  :
+   | client |      :  |   proxy    |      | application ||  :
+   |        |<--------|            |<-----|             ||  :
+   +--------+      :  | (frontend) |      |  (backend)  ||  :
+                   :  |            |      |             |+  :
+                   :  +------------+      +-------------+   :                       
+                   :                                        :
+                   .. system boundary (e.g. same host) ......
+
+In this setup, your application will receive requests from the reverse proxy
+instead of the original client; additionally, the address/hostname where your
+application lives internally will be usually different from the one accessed
+externally. Last, it might even be the case that the reverse proxy exposes
+services via HTTPS, while contacting the Mojolicious application via plaintext
+HTTP.
+
+As an example, compare a sample request from the client against what arrives to
+the Mojolicious application:
+
+   client                 reverse proxy (frontend)           Mojolicious app
+    __|__              _______________|______________             ____|____
+   /     \            /                              \           /         \
+   1.2.3.4 --HTTPS--> api.example.com      10.20.30.39 --HTTP--> 10.20.30.40
+
+   GET /foo/1 HTTP/1.1                |    GET /foo/1 HTTP/1.1
+   Host: api.example.com              |    Host: 10.20.30.40
+   User-Agent: Mojolicious (Perl)     |    User-Agent: ShinyProxy/1.2
+   ...                                |    ...
+
+You're losing the client's address (e.g. useful for analytics, or Geo-IP) and if
+the application generates URLs via L<Mojolicious::Controller/"url_for">, the
+result will be like this:
+
+   http://10.20.30.40/bar/2
+
+instead of something I<meaningful for the client>, like this:
+
+   https://api.example.com/bar/2
+
+To solve these problems you can:
+
+=over
+
+=item *
+
+configure your reverse proxy to send the missing data (see L</Nginx> and
+L</"Apache/mod_proxy">) and tell your application about it, usually setting the
+environment variable C<MOJO_REVERSE_PROXY=1>; OR
+
+=item *
+
+do-it-yourself like suggested in L</Rewriting>.
+
+=back
+
+
 =head1 DEPLOYMENT
 
 Getting L<Mojolicious> and L<Mojolicious::Lite> applications running on

--- a/lib/Mojolicious/Guides/Cookbook.pod
+++ b/lib/Mojolicious/Guides/Cookbook.pod
@@ -75,19 +75,17 @@ limiting the number of concurrent open sockets towards the Mojolicious
 application (or even using Unix sockets), balancing load across multiple
 instances, or supporting several applications through the same IP/port.
 
-   .               ..........................................
-                   :                                        :                        
-                   :                       +-------------+  :                        
-                   :  +------------+      +-------------+|  :
-   +--------+      :  |            |      |             ||  :
-   |        |-------->|  reverse   |----->| Mojolicious ||  :
-   | client |      :  |   proxy    |      | application ||  :
-   |        |<--------|            |<-----|             ||  :
-   +--------+      :  | (frontend) |      |  (backend)  ||  :
-                   :  |            |      |             |+  :
-                   :  +------------+      +-------------+   :                       
-                   :                                        :
-                   .. system boundary (e.g. same host) ......
+   .               ...........................................
+                   :                                         :
+                   :                      +---------------+  :
+   +--------+      :  +-----------+      +---------------+|  :
+   |        |-------->|           |      |               ||  :
+   | client |      :  |  reverse  |----->|  Mojolicious  ||  :
+   |        |<--------|   proxy   |      |  application  ||  :
+   +--------+      :  |           |<-----|               ||  :
+                   :  +-----------+      +---------------+   :
+                   :                                         :
+                   .. system boundary (e.g. same host) .......
 
 This setup introduces some problems, though: the application will receive
 requests from the reverse proxy instead of the original client; the

--- a/lib/Mojolicious/Guides/Cookbook.pod
+++ b/lib/Mojolicious/Guides/Cookbook.pod
@@ -92,8 +92,8 @@ instances, or supporting several applications through the same IP/port.
 This setup introduces some problems, though: the application will receive
 requests from the reverse proxy instead of the original client; the
 address/hostname where your application lives internally will be different from
-the one visible from the outside; if terminating SSL, the reverse proxy exposes
-services via HTTPS, while using HTTP towards the Mojolicious application.
+the one visible from the outside; and if terminating SSL, the reverse proxy
+exposes services via HTTPS while using HTTP towards the Mojolicious application.
 
 As an example, compare a sample request from the client and what the Mojolicious
 application receives:
@@ -105,12 +105,12 @@ application receives:
 
    GET /foo/1 HTTP/1.1                |    GET /foo/1 HTTP/1.1
    Host: api.example.com              |    Host: 10.20.30.40
-   User-Agent: Mojolicious (Perl)     |    User-Agent: ShinyProxy/1.2
+   User-Agent: Firefox                |    User-Agent: ShinyProxy/1.2
    ...                                |    ...
 
-The client address is no longer available (it might be useful for analytics, or
-Geo-IP) and URLs generated via L<Mojolicious::Controller/"url_for"> will be like
-this:
+However, now the client address is no longer available (which might be useful
+for analytics, or Geo-IP) and URLs generated via
+L<Mojolicious::Controller/"url_for"> will look like this:
 
    http://10.20.30.40/bar/2
 
@@ -118,22 +118,11 @@ instead of something meaningful for the client, like this:
 
    https://api.example.com/bar/2
 
-To solve these problems you can:
-
-=over
-
-=item *
-
-configure your reverse proxy to send the missing data (see L</Nginx> and
-L</"Apache/mod_proxy">) and tell your application about it, usually setting the
-environment variable C<MOJO_REVERSE_PROXY=1>; OR
-
-=item *
-
-do it yourself like suggested in L</Rewriting>.
-
-=back
-
+To solve these problems, you can configure your reverse proxy to send the
+missing data (see L</Nginx> and L</"Apache/mod_proxy">) and tell your
+application about it setting the environment variable C<MOJO_REVERSE_PROXY>. For
+finer control, L</Rewriting> includes examples of how the changes could be
+implemented manually.
 
 =head1 DEPLOYMENT
 


### PR DESCRIPTION
### Summary

Add a section about Reverse Proxies, to explain what they are, why you should care about them and how to solve the problem they introduce.

### Motivation

- Information about reverse proxies and how to set them up is a bit scattered around and not always immediately evident in some deployment use cases.
- Looking for `mojolicious reverse proxy` in Google returns solutions that are unnecessary/overkill in the general case (which only involves some configuration).

### References

- [Start of discussion in IRC](https://irclog.perlgeek.de/mojo/2018-01-30#i_15758733)
- [Suggestion to start a PR](https://irclog.perlgeek.de/mojo/2018-02-01#i_15766494)
