### PR TITLE
Implement SameSite attribute for sessions cookie.

### DIFF
--- a/lib/Mojo/Cookie/Response.pm
+++ b/lib/Mojo/Cookie/Response.pm
@@ -4,9 +4,9 @@ use Mojo::Base 'Mojo::Cookie';
 use Mojo::Date;
 use Mojo::Util qw(quote split_cookie_header);
 
-has [qw(domain expires host_only httponly max_age path secure)];
+has [qw(domain expires host_only httponly max_age path secure samesite)];
 
-my %ATTRS = map { $_ => 1 } qw(domain expires httponly max-age path secure);
+my %ATTRS = map { $_ => 1 } qw(domain expires httponly max-age path secure samesite);
 
 sub parse {
   my ($self, $str) = @_;
@@ -31,7 +31,6 @@ sub parse {
 
 sub to_string {
   my $self = shift;
-
   # Name and value
   return '' unless length(my $name = $self->name // '');
   my $value = $self->value // '';
@@ -55,6 +54,9 @@ sub to_string {
 
   # "Max-Age"
   if (defined(my $max = $self->max_age)) { $cookie .= "; Max-Age=$max" }
+
+  # "SameSite"
+  if (defined(my $samesite = $self->samesite)) { $cookie .= '; SameSite'.ucfirst($samesite) }
 
   return $cookie;
 }
@@ -115,6 +117,17 @@ the cookie's L</"domain">.
 
 HttpOnly flag, which can prevent client-side scripts from accessing this
 cookie.
+
+=head2 samesite
+
+  my $same_site_policy = $cookie->samesite;
+  $cookie  = $cookie->samesite('strict');
+
+SameSite attribute, currently supported by firefox and chrome.
+If its value is 'strict', browsers send cookie only  to same-site requests.
+If its value is 'lax', browsers send them with cross-site requests too.
+All other values are ignored.
+
 
 =head2 max_age
 

--- a/lib/Mojolicious/Sessions.pm
+++ b/lib/Mojolicious/Sessions.pm
@@ -6,6 +6,7 @@ use Mojo::Util qw(b64_decode b64_encode);
 
 has [qw(cookie_domain secure)];
 has cookie_name        => 'mojolicious';
+has same_site          => 'lax';
 has cookie_path        => '/';
 has default_expiration => 3600;
 has deserialize        => sub { \&Mojo::JSON::j };
@@ -55,6 +56,7 @@ sub store {
     expires  => $session->{expires},
     httponly => 1,
     path     => $self->cookie_path,
+    samesite => $self->same_site,
     secure   => $self->secure
   };
   $c->signed_cookie($self->cookie_name, $value, $options);
@@ -139,6 +141,14 @@ A callback used to deserialize sessions, defaults to L<Mojo::JSON/"j">.
     my $bytes = shift;
     return {};
   });
+
+=head2 same_site
+
+  my $same_site_policy  = $sessions->same_site;
+  $sessions = $sessions->same_site('strict');
+
+Set the SameSite attribute on all session cookies. If attribute value is 'strict', browsers send them only
+to same-site requests. If attribute value is 'lax' (which is default), browsers send them with cross-site requests too.
 
 =head2 secure
 

--- a/t/mojo/cookie.t
+++ b/t/mojo/cookie.t
@@ -164,9 +164,10 @@ $cookie->max_age(60);
 $cookie->expires(1218092879);
 $cookie->secure(1);
 $cookie->httponly(1);
+$cookie->samesite('lax');
 is $cookie->to_string,
   '0="ba r"; expires=Thu, 07 Aug 2008 07:07:59 GMT; domain=example.com;'
-  . ' path=/test; secure; HttpOnly; Max-Age=60', 'right format';
+  . ' path=/test; secure; HttpOnly; Max-Age=60; SameSite=lax', 'right format';
 
 # Empty response cookie
 is_deeply(Mojo::Cookie::Response->parse, [], 'no cookies');

--- a/t/mojolicious/app.t
+++ b/t/mojolicious/app.t
@@ -61,6 +61,7 @@ is ref $t->app->routes->find('something')->root, 'Mojolicious::Routes',
   'right class';
 is $t->app->sessions->cookie_domain, '.example.com', 'right domain';
 is $t->app->sessions->cookie_path,   '/bar',         'right path';
+is $t->app->sessions->same_site,     'lax',          'right samesite';
 is_deeply $t->app->commands->namespaces,
   [qw(Mojolicious::Command MojoliciousTest::Command)], 'right namespaces';
 is $t->app, $t->app->commands->app, 'applications are equal';


### PR DESCRIPTION

### Summary
There is a draft for RFC 6525 
It introduce new cookie attribute - SameSite. It helps to fight against csrf attack.
From the draft
>4.1.2.7.  The SameSite Attribute

>The "SameSite" attribute limits the scope of the cookie such that it will only be attached to requests if those requests are same-site, as defined by the algorithm in Section 5.2.  For example, requests for "https://example.com/sekrit-image" will attach same-site cookies if and only if initiated from a context whose "site for cookies" is "example.com".
>
>If the "SameSite" attribute's value is "Strict", the cookie will only be sent along with "same-site" requests.  If the value is "Lax", the
 cookie will be sent with same-site requests, and with "cross-site" top-level navigations, as described in Section 5.3.7.1.  If the "SameSite" attribute's value is neither of these, the cookie will be ignored.

Modern versions of Chrome and Firefox supports it. 

Maybe Mojolicious can support it too?


### Motivation
It's very simple thing and it adds a bit of security to mojolicious. 

### References
https://www.ietf.org/id/draft-ietf-httpbis-rfc6265bis-02.txt RFC draft
https://caniuse.com/#search=samesite 
