### PR TITLE
fix exceptions triggered from non-UTF-8 files

### DIFF
--- a/lib/Mojo/Exception.pm
+++ b/lib/Mojo/Exception.pm
@@ -1,5 +1,6 @@
 package Mojo::Exception;
 use Mojo::Base -base;
+use Mojo::Util 'decode';
 use overload bool => sub {1}, '""' => sub { shift->to_string }, fallback => 1;
 
 has [qw(frames line lines_after lines_before)] => sub { [] };
@@ -19,8 +20,9 @@ sub inspect {
 
   # Search for context in files
   for my $file (@files) {
-    next unless -r $file->[0] && open my $handle, '<:utf8', $file->[0];
-    $self->_context($file->[1], [[<$handle>]]);
+    next unless -r $file->[0] && open my $handle, '<', $file->[0];
+    my @lines = map { decode('UTF-8', $_) // $_ } <$handle>;
+    $self->_context($file->[1], [\@lines]);
     return $self;
   }
 

--- a/t/mojo/exception/non_utf8.txt
+++ b/t/mojo/exception/non_utf8.txt
@@ -1,0 +1,5 @@
+use strict;
+use warnings;
+no utf8;
+
+my $s = 'Über•résumé';

--- a/t/mojo/exception/utf8.txt
+++ b/t/mojo/exception/utf8.txt
@@ -1,0 +1,5 @@
+use strict;
+use warnings;
+use utf8;
+
+my $s = 'Über•résumé';


### PR DESCRIPTION
### Summary
Assume source code is bytes if it does not cleanly decode from UTF-8.

### Motivation
A source file may have non-UTF8 data and this causes issues when Mojo::Exception attempts to retrieve context for the exception.

### References
Fixes #1200
