### PR TITLE
Match optimization

### DIFF
--- a/lib/Mojolicious/Routes/Match.pm
+++ b/lib/Mojolicious/Routes/Match.pm
@@ -84,10 +84,10 @@ sub _match {
   }
 
   # Match children
-  my @snapshot = $r->parent ? ([@{$self->stack}], $captures) : ([], {});
+  my $snapshot = $r->parent ? [@{$self->stack}] : [];
   for my $child (@{$r->children}) {
     return 1 if $self->_match($child, $c, $options);
-    $self->stack([@{$snapshot[0]}])->{captures} = $snapshot[1];
+    $self->stack([@$snapshot]);
   }
 }
 


### PR DESCRIPTION
### Summary
Because `{ captures }` are localized they are will be unchanged
when `->_match` returns. So we are not required to restore them

### Motivation
Because [`$captures` is a hash reference to `$self->{ captures }`](https://github.com/kraih/mojo/blob/master/lib/Mojolicious/Routes/Match.pm#L49)

[The code](https://github.com/kraih/mojo/blob/master/lib/Mojolicious/Routes/Match.pm#L90) effectively do nothing, eg. `$hashref =  $hashref`.  
Maybe you mean copy by value `$hashref = { %$hashref }` as this is done for `$self->stack`:

     $self->stack([@{$snapshot[0]}])->{captures} = { %{ $snapshot[1] }};

But `{captures}` are localized so this copy by value is not required


### References
related to this [commit](https://github.com/kraih/mojo/commit/175cc94bb7)
