### PR TITLE
make max optional in num validation check

### DIFF
--- a/lib/Mojolicious/Validator.pm
+++ b/lib/Mojolicious/Validator.pm
@@ -38,7 +38,7 @@ sub _in {
 sub _num {
   my ($validation, $name, $value, $min, $max) = @_;
   return 1 if $value !~ /^[0-9]+$/;
-  return defined $min && $max ? $min > $value || $max < $value : undef;
+  return defined $min && $min > $value || defined $max && $max < $value;
 }
 
 sub _size {
@@ -96,6 +96,7 @@ String value needs to match the regular expression.
 =head2 num
 
   $validation = $validation->num;
+  $validation = $validation->num(2);
   $validation = $validation->num(2, 5);
 
 String value needs to be a non-fractional number and if provided in the given

--- a/t/mojolicious/validation_lite_app.t
+++ b/t/mojolicious/validation_lite_app.t
@@ -145,6 +145,14 @@ $validation = $t->app->validation->input({foo => 23});
 ok !$validation->required('foo')->num(24, 25)->is_valid, 'not valid';
 ok $validation->has_error, 'has error';
 is_deeply $validation->error('foo'), [qw(num 1 24 25)], 'right error';
+$validation = $t->app->validation->input({foo => 23});
+ok $validation->required('foo')->num(22)->is_valid, 'valid';
+$validation = $t->app->validation->input({foo => 23});
+ok $validation->required('foo')->num(23)->is_valid, 'valid';
+$validation = $t->app->validation->input({foo => 23});
+ok !$validation->required('foo')->num(24)->is_valid, 'not valid';
+ok $validation->has_error, 'has error';
+is_deeply $validation->error('foo'), ['num', 1, 24], 'right error';
 
 # Size
 $validation

--- a/t/mojolicious/validation_lite_app.t
+++ b/t/mojolicious/validation_lite_app.t
@@ -150,6 +150,14 @@ $v = $t->app->validation->input({foo => 23});
 ok !$v->required('foo')->num(24, undef)->is_valid, 'not valid';
 ok $v->has_error, 'has error';
 is_deeply $v->error('foo'), ['num', 1, 24, undef], 'right error';
+$v = $t->app->validation->input({foo => 23});
+ok $v->required('foo')->num(undef, 24)->is_valid, 'valid';
+$v = $t->app->validation->input({foo => 23});
+ok $v->required('foo')->num(undef, 23)->is_valid, 'valid';
+$v = $t->app->validation->input({foo => 23});
+ok !$v->required('foo')->num(undef, 22)->is_valid, 'not valid';
+ok $v->has_error, 'has error';
+is_deeply $v->error('foo'), ['num', 1, undef, 22], 'right error';
 
 # Size
 $v = $t->app->validation->input({foo => 'bar', baz => 'yada', yada => 'yada'});


### PR DESCRIPTION
### Summary
make max value optional in num validation check

### Motivation
`num(1)` looks better than `num(1, 999)` or `num(1, 'inf')`