### PR TITLE
Cached templates on EP and EPL

### DIFF
--- a/lib/Mojolicious/Plugin/EPLRenderer.pm
+++ b/lib/Mojolicious/Plugin/EPLRenderer.pm
@@ -23,7 +23,7 @@ sub _render {
   else {
     my $inline = $options->{inline};
     my $name = defined $inline ? md5_sum encode('UTF-8', $inline) : undef;
-    return unless defined($name //= $renderer->template_name($options));
+    return unless defined($name //= $renderer->template_path($options) || $renderer->template_name($options));
 
     # Inline
     if (defined $inline) {

--- a/lib/Mojolicious/Plugin/EPRenderer.pm
+++ b/lib/Mojolicious/Plugin/EPRenderer.pm
@@ -22,7 +22,7 @@ sub register {
     $conf->{name} || 'ep' => sub {
       my ($renderer, $c, $output, $options) = @_;
 
-      my $name = $options->{inline} // $renderer->template_name($options);
+      my $name = $options->{inline} // $renderer->template_path($options) || $renderer->template_name($options);
       return unless defined $name;
       my $key = md5_sum encode 'UTF-8', $name;
 


### PR DESCRIPTION

### Summary
Cached templates by full source path if possible.

### Motivation
App dispatch a lot of domains with separate templates folders like:

```
  ./lib
  ./log
  ./public
  ./script
  ./templates
  ./templates@domain1.com
  ./templates@domain2.com
  ...
```

Then app hooks like:

```
$app->hook(before_dispatch => sub {
  my $c = shift;
  my $home = $c->app->home;
  my $host = $c->req->url->to_abs->host;
  unshift @{$c->app->renderer->paths}, $home->rel_file('templates@'.$host);
});

$app->hook(after_dispatch => sub {
  my $c = shift;
  my $paths = $c->app->renderer->paths;
  $paths->[$_] =~ /\/templates@/
    and splice(@$paths, $_, 1)
    for (0..$#$paths);
});
```

Especially useful for a **not_found** and **exception** separate per domain templates.

### References
This PR files changed.
