### PR TITLE
refs #1172: Add short introduction to promises

### DIFF
--- a/lib/Mojo/Promise.pm
+++ b/lib/Mojo/Promise.pm
@@ -217,10 +217,10 @@ The most common way of dealing with promises is using the method
 L<Mojo::Promise/"then">. The will allow to call the provided callback 
 upon fulfillment of the promise.
 
-  my $promise = get("http://mojo.licio.us"); # returns a promise
+  my $promise = get("http://mojolicious.org"); # returns a promise
   $promise->then(sub {
     my ($self, $tx) = @_;
-    print "Mojolicous website is " . $tx->code;
+    say "Mojolicous website returns " . $tx->res->code;
   });
 
 Through the composable nature of promises you are now allowed to chain 
@@ -232,9 +232,9 @@ GET operations have completed using the method L<Mojo::Promise/"all">.
   my $promise1 = get("http://mojolicious.org");
   my $promise2 = get("https://perlbrew.pl/");
   my $both = Mojo::Promise->all($promise1, $promise2)->then(sub {
-    my ($value1, $value2) = @_;
-    println "Mojolicous website returns " . $value1;
-    println "Perlbrew website returns " . $valuu2;
+    my ($tx1, $tx2) = @_;
+    say "Mojolicous website returns " . $tx1->res->code;
+    say "Perlbrew website returns " . $tx2->res->code;
   });
 
 To handle errors the catch method can be used. The provided callback

--- a/lib/Mojolicious/Guides/Cookbook.pod
+++ b/lib/Mojolicious/Guides/Cookbook.pod
@@ -619,7 +619,7 @@ that create them for you.
 
   app->start;
 
-To create promises maually you just wrap your continuation-passing style APIs in
+To create promises manually you just wrap your continuation-passing style APIs in
 functions that return promises. Here's an example for how
 L<Mojo::UserAgent/"get_p"> works internally.
 
@@ -645,9 +645,7 @@ L<Mojo::UserAgent/"get_p"> works internally.
     say $tx->result->dom->at('title')->text;
   })->wait;
 
-Promises have three states, they start out as C<pending> and you call
-L<Mojo::Promise/"resolve"> to transition them to C<fulfilled>, or
-L<Mojo::Promise/"reject"> to transition them to C<rejected>.
+See L<Mojo::Promise> for more examples on working with promises.
 
 =head2 Timers
 


### PR DESCRIPTION
### Summary

This PR aims to improve the documentation of Mojo::Promise with a short introduction into the subject. Only documentation is added, no code changes.

The `println` in the examples should be replaced with something more useful, but should be ok for discussion for now.

### Motivation

Improve docs for beginners and newcomers that may find promises and their composability useful.

### References

Should close #1172 