### PR TITLE
Prohibit path traversal for static files with embedded directory separators 

### DIFF
--- a/t/mojolicious/app.t
+++ b/t/mojolicious/app.t
@@ -419,6 +419,11 @@ $t->get_ok('/../../mojolicious/secret.txt')->status_is(404)
 $t->get_ok('/.../mojolicious/secret.txt')->status_is(404)
   ->header_is(Server => 'Mojolicious (Perl)')->content_like(qr/Page not found/);
 
+# Try to access a file which is not under the web root via path
+# traversal (escaped backslashes)
+$t->get_ok('/..%5C..%5Cmojolicious%5Csecret.txt')->status_is(404)
+  ->header_is(Server => 'Mojolicious (Perl)')->content_like(qr/Page not found/);
+
 # Check If-Modified-Since
 $t->get_ok('/hello.txt' => {'If-Modified-Since' => $mtime})->status_is(304)
   ->header_is(Server => 'Mojolicious (Perl)')->content_is('');

--- a/t/mojolicious/production_app.t
+++ b/t/mojolicious/production_app.t
@@ -107,6 +107,11 @@ $t->get_ok('/../../mojolicious/secret.txt')->status_is(404)
 $t->get_ok('/.../mojolicious/secret.txt')->status_is(404)
   ->header_is(Server => 'Mojolicious (Perl)')->content_like(qr/Page not found/);
 
+# Try to access a file which is not under the web root via path
+# traversal in production mode (escaped backslashes)
+$t->get_ok('/..%5C..%5Cmojolicious%5Csecret.txt')->status_is(404)
+  ->header_is(Server => 'Mojolicious (Perl)')->content_like(qr/Page not found/);
+
 # Embedded production static file
 $t->get_ok('/some/static/file.txt')->status_is(200)
   ->header_is(Server => 'Mojolicious (Perl)')

--- a/t/mojolicious/testing_app.t
+++ b/t/mojolicious/testing_app.t
@@ -51,4 +51,10 @@ $t->get_ok('/.../mojolicious/secret.txt')->status_is(404)
   ->header_is(Server => 'Mojolicious (Perl)')
   ->content_like(qr/Testing not found/);
 
+# Try to access a file which is not under the web root via path
+# traversal in testing mode (escaped backslashes)
+$t->get_ok('/..%5C..%5Cmojolicious%5Csecret.txt')->status_is(404)
+  ->header_is(Server => 'Mojolicious (Perl)')
+  ->content_like(qr/Testing not found/);
+
 done_testing();


### PR DESCRIPTION
### Summary
GET requests with embedded url_escaped backslashes can be used to access local files outside of webroot 

### Motivation
I think Mojo::Path is correct in splitting the URL only on slashes. The problem only occurs when the filesystem is accessed. I don't know whether this is the only location where this happens, but the reported bug can be fixed by checking the path parts for directory separators of the current OS.

### References
 https://irclog.perlgeek.de/mojo/2018-04-23#i_16083074 and following.