### PR TITLE
Patch 1

### DIFF
--- a/lib/Mojolicious/Static.pm
+++ b/lib/Mojolicious/Static.pm
@@ -34,7 +34,7 @@ sub dispatch {
   return undef unless my @parts = @{$path->canonicalize->parts};
 
   # Serve static file and prevent path traversal
-  return undef if $parts[0] eq '..' || !$self->serve($c, join('/', @parts));
+  return undef if $parts[0] =~ /^\.\./ || !$self->serve($c, join('/', @parts));
   $stash->{'mojo.static'} = 1;
   return !!$c->rendered;
 }

--- a/t/mojolicious/app.t
+++ b/t/mojolicious/app.t
@@ -419,6 +419,11 @@ $t->get_ok('/../../mojolicious/secret.txt')->status_is(404)
 $t->get_ok('/.../mojolicious/secret.txt')->status_is(404)
   ->header_is(Server => 'Mojolicious (Perl)')->content_like(qr/Page not found/);
 
+# Try to access a file which is not under the web root via path
+# traversal (url_escaped backslashes)
+$t->get_ok('/..%5C..%5Cmojolicious%5Csecret.txt')->status_is(404)
+  ->header_is(Server => 'Mojolicious (Perl)')->content_like(qr/Page not found/);
+
 # Check If-Modified-Since
 $t->get_ok('/hello.txt' => {'If-Modified-Since' => $mtime})->status_is(304)
   ->header_is(Server => 'Mojolicious (Perl)')->content_is('');

--- a/t/mojolicious/production_app.t
+++ b/t/mojolicious/production_app.t
@@ -107,6 +107,11 @@ $t->get_ok('/../../mojolicious/secret.txt')->status_is(404)
 $t->get_ok('/.../mojolicious/secret.txt')->status_is(404)
   ->header_is(Server => 'Mojolicious (Perl)')->content_like(qr/Page not found/);
 
+# Try to access a file which is not under the web root via path
+# traversal (url_escaped backslashes)
+$t->get_ok('/..%5C..%5Cmojolicious%5Csecret.txt')->status_is(404)
+  ->header_is(Server => 'Mojolicious (Perl)')->content_like(qr/Page not found/);
+
 # Embedded production static file
 $t->get_ok('/some/static/file.txt')->status_is(200)
   ->header_is(Server => 'Mojolicious (Perl)')

--- a/t/mojolicious/testing_app.t
+++ b/t/mojolicious/testing_app.t
@@ -54,6 +54,6 @@ $t->get_ok('/.../mojolicious/secret.txt')->status_is(404)
 # Try to access a file which is not under the web root via path
 # traversal (url_escaped backslashes)
 $t->get_ok('/..%5C..%5Cmojolicious%5Csecret.txt')->status_is(404)
-  ->header_is(Server => 'Mojolicious (Perl)')->content_like(qr/Page not found/);
+  ->header_is(Server => 'Mojolicious (Perl)')->content_like(qr/Testing not found/);
 
 done_testing();

--- a/t/mojolicious/testing_app.t
+++ b/t/mojolicious/testing_app.t
@@ -51,4 +51,9 @@ $t->get_ok('/.../mojolicious/secret.txt')->status_is(404)
   ->header_is(Server => 'Mojolicious (Perl)')
   ->content_like(qr/Testing not found/);
 
+# Try to access a file which is not under the web root via path
+# traversal (url_escaped backslashes)
+$t->get_ok('/..%5C..%5Cmojolicious%5Csecret.txt')->status_is(404)
+  ->header_is(Server => 'Mojolicious (Perl)')->content_like(qr/Page not found/);
+
 done_testing();


### PR DESCRIPTION
### Summary
GET requests with backslashes (or url_escaped backslashes) can be used to access files outside of webroot on Windows hosts. 

### Motivation
There is already a proposed solution (PR #1214), but some performance issues were found.
Proposal approach is to consider any path starting with '..' as an intent of path traversal. Thats simple to check because current code is checking for exact match already.

### References
PR #1214, https://irclog.perlgeek.de/mojo/2018-04-23#i_16083074 and following.