### PR TITLE
Remove ambiguity in use of shift

### DIFF
--- a/lib/Mojo/DOM/CSS.pm
+++ b/lib/Mojo/DOM/CSS.pm
@@ -74,7 +74,7 @@ sub _combinator {
 }
 
 sub _compile {
-  my ($css, %ns) = (trim(shift . ''), @_);
+  my ($css, %ns) = (trim('' . shift), @_);
 
   my $group = [[]];
   while (my $selectors = $group->[-1]) {


### PR DESCRIPTION
### Summary
This causes warnings on 5.10.

### Motivation
Clean up warnings

### References
https://irclog.perlgeek.de/mojo/2018-05-02#i_16119092