### PR TITLE
added static files traversal tests and squashed

### DIFF
--- a/lib/Mojolicious/Static.pm
+++ b/lib/Mojolicious/Static.pm
@@ -34,7 +34,8 @@ sub dispatch {
   return undef unless my @parts = @{$path->canonicalize->parts};
 
   # Serve static file and prevent path traversal
-  return undef if $parts[0] eq '..' || !$self->serve($c, join('/', @parts));
+  my $canon_path = join '/', @parts;
+  return undef if $canon_path =~ /^\.\.\/|\\/ || !$self->serve($c, $canon_path);
   $stash->{'mojo.static'} = 1;
   return !!$c->rendered;
 }

--- a/t/mojolicious/app.t
+++ b/t/mojolicious/app.t
@@ -415,9 +415,28 @@ $t->get_ok('/../../mojolicious/secret.txt')->status_is(404)
   ->header_is(Server => 'Mojolicious (Perl)')->content_like(qr/Page not found/);
 
 # Try to access a file which is not under the web root via path
+# traversal (goes back and forth one directory)
+$t->get_ok('/another/../../../mojolicious/secret.txt')->status_is(404)
+  ->header_is(Server => 'Mojolicious (Perl)')->content_like(qr/Page not found/);
+
+# Try to access a file which is not under the web root via path
 # traversal (triple dot)
 $t->get_ok('/.../mojolicious/secret.txt')->status_is(404)
   ->header_is(Server => 'Mojolicious (Perl)')->content_like(qr/Page not found/);
+
+# Try to access a file which is not under the web root via path
+# traversal (backslashes)
+$t->get_ok('/..\\..\\mojolicious\\secret.txt')->status_is(404)
+  ->header_is(Server => 'Mojolicious (Perl)')->content_like(qr/Page not found/);
+
+# Try to access a file which is not under the web root via path
+# traversal (escaped backslashes)
+$t->get_ok('/..%5C..%5Cmojolicious%5Csecret.txt')->status_is(404)
+  ->header_is(Server => 'Mojolicious (Perl)')->content_like(qr/Page not found/);
+
+# Check that backslashes on query or fragment parts don't block access
+$t->get_ok('/another/file?one=\\1#two=\\2')->status_is(200)
+  ->content_like(qr/Hello Mojolicious!/);
 
 # Check If-Modified-Since
 $t->get_ok('/hello.txt' => {'If-Modified-Since' => $mtime})->status_is(304)

--- a/t/mojolicious/production_app.t
+++ b/t/mojolicious/production_app.t
@@ -107,6 +107,21 @@ $t->get_ok('/../../mojolicious/secret.txt')->status_is(404)
 $t->get_ok('/.../mojolicious/secret.txt')->status_is(404)
   ->header_is(Server => 'Mojolicious (Perl)')->content_like(qr/Page not found/);
 
+# Try to access a file which is not under the web root via path
+# traversal in production mode (backslashes)
+$t->get_ok('/..\\..\\mojolicious\\secret.txt')->status_is(404)
+  ->header_is(Server => 'Mojolicious (Perl)')->content_like(qr/Page not found/);
+
+# Try to access a file which is not under the web root via path
+# traversal in production mode (escaped backslashes)
+$t->get_ok('/..%5C..%5Cmojolicious%5Csecret.txt')->status_is(404)
+  ->header_is(Server => 'Mojolicious (Perl)')->content_like(qr/Page not found/);
+
+# Check that backslashes on query or fragment parts don't block access
+# in production mode
+$t->get_ok('/hello.txt?one=\\1#two=\\2')->status_is(200)
+  ->content_like(qr/Hello Mojo from a static file!/);
+
 # Embedded production static file
 $t->get_ok('/some/static/file.txt')->status_is(200)
   ->header_is(Server => 'Mojolicious (Perl)')

--- a/t/mojolicious/testing_app.t
+++ b/t/mojolicious/testing_app.t
@@ -46,9 +46,32 @@ $t->get_ok('/../../mojolicious/secret.txt')->status_is(404)
   ->content_like(qr/Testing not found/);
 
 # Try to access a file which is not under the web root via path
+# traversal in testing mode (goes back and forth one directory)
+$t->get_ok('/another/../../../mojolicious/secret.txt')->status_is(404)
+  ->header_is(Server => 'Mojolicious (Perl)')
+  ->content_like(qr/Testing not found/);
+
+# Try to access a file which is not under the web root via path
 # traversal in testing mode (triple dot)
 $t->get_ok('/.../mojolicious/secret.txt')->status_is(404)
   ->header_is(Server => 'Mojolicious (Perl)')
   ->content_like(qr/Testing not found/);
+
+# Try to access a file which is not under the web root via path
+# traversal in testing mode (backslashes)
+$t->get_ok('/..\\..\\mojolicious\\secret.txt')->status_is(404)
+  ->header_is(Server => 'Mojolicious (Perl)')
+  ->content_like(qr/Testing not found/);
+
+# Try to access a file which is not under the web root via path
+# traversal in testing mode (escaped backslashes)
+$t->get_ok('/..%5C..%5Cmojolicious%5Csecret.txt')->status_is(404)
+  ->header_is(Server => 'Mojolicious (Perl)')
+  ->content_like(qr/Testing not found/);
+
+# Check that backslashes on query or fragment parts don't block access
+# in testing mode
+$t->get_ok('/hello.txt?one=\\1#two=\\2')->status_is(200)
+  ->content_like(qr/Hello Mojo from a static file!/);
 
 done_testing();


### PR DESCRIPTION
### Summary
GET requests with embedded backslashes can be used to access local files on Windows hosts

### Motivation
Path separator used in Windows systems is the backslash.

Using backslashes in the path part of a URL can be used on those systems to bypass Mojolicious protection against directory traversal.

To avoid that, this PR blocks any url with backlashes inside the path part of it. 

### References
https://irclog.perlgeek.de/mojo/2018-04-23#i_16083074 and following.
