### PR TITLE
Fix exception and not_found templates HTML validity

### DIFF
--- a/lib/Mojolicious/resources/templates/mojo/exception.html.ep
+++ b/lib/Mojolicious/resources/templates/mojo/exception.html.ep
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html>
-  <head><title>Server error</title></head>
-  <style>
+  <head>
+    <title>Server error</title>
+    <style>
       body { background-color: #caecf6 }
       #raptor {
         background: url(<%= url_for '/mojo/failraptor.png' %>);
@@ -14,6 +15,7 @@
         width: 743px;
       }
     </style>
+  </head>
   <body><div id="raptor"></div></body>
 </html>
 <!-- a padding to disable MSIE and Chrome friendly error page -->

--- a/lib/Mojolicious/resources/templates/mojo/not_found.html.ep
+++ b/lib/Mojolicious/resources/templates/mojo/not_found.html.ep
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html>
-  <head><title>Page not found</title></head>
-  <style>
+  <head>
+    <title>Page not found</title>
+    <style>
       a img { border: 0 }
       body { background-color: #caecf6 }
       #noraptor {
@@ -20,6 +21,7 @@
         width: 306px;
       }
     </style>
+  </head>
   <body>
     %= link_to url_for->base => begin
       %= image '/mojo/noraptor.png', alt => 'Bye!', id => 'noraptor'


### PR DESCRIPTION
### Summary
I fixed exception and not_found templates by putting `style` tag inside `head`.

### Motivation
They were not HTML valid (the `style` tag was outside `head` and `body`)
