### PR TITLE
clone and wrap trees without a root node in _parse

### DIFF
--- a/lib/Mojo/DOM.pm
+++ b/lib/Mojo/DOM.pm
@@ -289,9 +289,11 @@ sub _parent { $_[0]->[$_[0][0] eq 'tag' ? 3 : 2] }
 
 sub _parse {
   my ($self, $input) = @_;
-  return dclone $input->tree
-    if blessed $input && $input->isa('Mojo::DOM') && $input->type eq 'root';
-  return Mojo::DOM::HTML->new(xml => $self->xml)->parse($input)->tree;
+  return Mojo::DOM::HTML->new(xml => $self->xml)->parse($input)->tree
+    unless blessed $input && $input->isa('Mojo::DOM');
+
+  my $tree = dclone $input->tree;
+  return $tree->[0] eq 'root' ? $tree : _wrap_root($tree);
 }
 
 sub _replace {
@@ -364,6 +366,8 @@ sub _wrap {
   push @$current, @{_link($current, [$tree])};
   return $self;
 }
+
+sub _wrap_root { _link(my $r = ['root', @_], [@_]); $r }
 
 1;
 


### PR DESCRIPTION
### Summary
Wrap cloned dom tree in a root node if it doesn't have one

### Motivation
Keep efficiency of cloning dom trees when not at the root node

### References
#1224 https://irclog.perlgeek.de/mojo/2018-05-18#i_16178465
