### PR TITLE
Protocol specific IOLoop streams

### DIFF
--- a/lib/Mojo/IOLoop/Stream/HTTPClient.pm
+++ b/lib/Mojo/IOLoop/Stream/HTTPClient.pm
@@ -1,0 +1,206 @@
+package Mojo::IOLoop::Stream::HTTPClient;
+use Mojo::Base 'Mojo::IOLoop::Stream';
+
+use Mojo::Transaction::WebSocket;
+use Mojo::Util 'term_escape';
+use Mojo::WebSocket 'challenge';
+use Scalar::Util 'weaken';
+
+use constant DEBUG => $ENV{MOJO_CLIENT_DEBUG} || 0;
+
+has request_timeout => sub { $ENV{MOJO_REQUEST_TIMEOUT} // 0 };
+
+sub new {
+  my $self = shift->SUPER::new(@_);
+  $self->on(read => sub { shift->_read_content(shift) });
+  $self->on(close => sub { $_[0]->{closing}++ || $_[0]->_finish(1) });
+  return $self;
+}
+
+sub process {
+  my ($self, $tx) = @_;
+
+  return if $self->{tx};
+  $self->{tx} = $tx;
+
+  my $handle = $self->handle;
+  unless ($handle->isa('IO::Socket::UNIX')) {
+    $tx->local_address($handle->sockhost)->local_port($handle->sockport);
+    $tx->remote_address($handle->peerhost)->remote_port($handle->peerport);
+  }
+
+  weaken $self;
+  $tx->on(resume => sub { $self->_write_content });
+  if (my $timeout = $self->request_timeout) {
+    $self->{req_timeout} = $self->reactor->timer(
+      $timeout => sub { $self->_error('Request timeout') });
+  }
+  $self->_write_content;
+}
+
+sub _error {
+  my ($self, $err) = @_;
+  $self->{tx}->res->error({message => $err}) if $self->{tx};
+  $self->_finish(1);
+}
+
+sub _finish {
+  my ($self, $close) = @_;
+
+  # Remove request timeout and finish transaction
+  $self->reactor->remove($self->{req_timeout}) if $self->{req_timeout};
+  return ++$self->{closing} && $self->close unless my $tx = delete $self->{tx};
+
+  # Premature connection close
+  my $res = $tx->res->finish;
+  if ($close && !$res->code && !$res->error) {
+    $res->error({message => 'Premature connection close'});
+  }
+
+  # Upgrade connection to WebSocket
+  if (my $ws = $self->_upgrade($tx)) {
+    $self->emit(upgrade => $ws);
+    return $ws->client_read($ws->handshake->res->content->leftovers);
+  }
+
+  ++$self->{closing} && $self->close_gracefully
+    if $tx->error || !$tx->keep_alive;
+  $res->error({message => $res->message, code => $res->code}) if $res->is_error;
+  $tx->closed;
+}
+
+sub _read_content {
+  my ($self, $chunk) = @_;
+
+  # Corrupted connection
+  return $self->close unless my $tx = $self->{tx};
+
+  warn term_escape "-- Client <<< Server (@{[_url($tx)]})\n$chunk\n" if DEBUG;
+  $tx->client_read($chunk);
+  $self->_finish if $tx->is_finished;
+}
+
+sub _upgrade {
+  my ($self, $tx) = @_;
+  my $code = $tx->res->code // 0;
+  return undef unless $tx->req->is_handshake && $code == 101;
+  my $ws = Mojo::Transaction::WebSocket->new(handshake => $tx, masked => 1);
+  return challenge($ws) ? $ws->established(1) : undef;
+}
+
+sub _url { shift->req->url->to_abs }
+
+sub _write_content {
+  my $self = shift;
+
+  # Protect from resume event recursion
+  return if !(my $tx = $self->{tx}) || $self->{cont_writing};
+  local $self->{cont_writing} = 1;
+  my $chunk = $tx->client_write;
+  warn term_escape "-- Client >>> Server (@{[_url($tx)]})\n$chunk\n" if DEBUG;
+  return unless length $chunk;
+  $self->write($chunk => sub { $_[0]->_write_content });
+}
+
+1;
+
+=encoding utf8
+
+=head1 NAME
+
+Mojo::IOLoop::Stream::HTTPClient - Non-blocking I/O HTTP client stream
+
+=head1 SYNOPSIS
+
+  use Mojo::IOLoop::Client;
+  use Mojo::IOLoop::Stream::HTTPClient;
+  use Mojo::Transaction::HTTP;
+  
+  # Create transaction
+  my $tx = Mojo::Transaction::HTTP->new;
+  $tx->req->method('GET')->url->parse('https://mojolicious.org');
+  $tx->on(
+    finish => sub {
+      my $tx = shift;
+      say $tx->res->code;
+    }
+  );
+  
+  # Create socket connection
+  my $client = Mojo::IOLoop::Client->new;
+  $client->on(
+    connect => sub {
+      my $stream = Mojo::IOLoop::Stream::HTTPClient->new(pop);
+      $stream->start;
+      $stream->process($tx);
+    }
+  );
+  
+  # Start connection
+  $client->connect(address => 'mojolicious.org', port => 80);
+  $client->reactor->start;
+
+=head1 DESCRIPTION
+
+L<Mojo::IOLoop::Stream::HTTPClient> is a container for I/O streams used by
+L<Mojo::IOLoop> to support the HTTP protocol client-side.
+
+=head1 EVENTS
+
+L<Mojo::IOLoop::Stream::HTTPClient> inherits all events from
+L<Mojo::IOLoop::Stream> and can emit the following new ones.
+
+=head2 upgrade
+
+  $stream->on(upgrade => sub {
+    my ($stream, $ws) = @_;
+    ...
+  });
+
+Emitted when the connection should be upgraded to the WebSocket protocol.
+
+=head1 ATTRIBUTES
+
+L<Mojo::IOLoop::Stream::HTTPClient> inherits all attributes from
+L<Mojo::IOLoop::Stream> and implements the following ones.
+
+=head2 request_timeout
+
+  my $timeout = $stream->request_timeout;
+  $stream     = $stream->request_timeout(5);
+
+Maximum amount of time in seconds sending the request and receiving a whole
+response may take before getting canceled, defaults to the value of the
+C<MOJO_REQUEST_TIMEOUT> environment variable or C<0>. Setting the value to C<0>
+will allow to wait indefinitely.
+
+=head1 METHODS
+
+L<Mojo::IOLoop::Stream::HTTPClient> inherits all methods from
+L<Mojo::IOLoop::Stream> and implements the following new ones.
+
+=head2 process
+
+  $stream->process(Mojo::Transaction::HTTP->new);
+
+Process a L<Mojo::Transaction::HTTP> object with the current connection.
+
+=head2 new
+
+  my $stream = Mojo::IOLoop::Stream::HTTPClient->new($handle);
+
+Construct a new L<Mojo::IOLoop::Stream::HTTPClient> object.
+
+=head1 DEBUGGING
+
+You can set the C<MOJO_CLIENT_DEBUG> environment variable to get some
+advanced diagnostics information printed to C<STDERR>.
+
+  MOJO_CLIENT_DEBUG=1
+
+=head1 SEE ALSO
+
+L<Mojolicious>, L<Mojolicious::Guides>, L<http://mojolicious.org>.
+
+=cut
+

--- a/lib/Mojo/IOLoop/Stream/HTTPServer.pm
+++ b/lib/Mojo/IOLoop/Stream/HTTPServer.pm
@@ -1,0 +1,247 @@
+package Mojo::IOLoop::Stream::HTTPServer;
+use Mojo::Base 'Mojo::IOLoop::Stream';
+
+use Mojo::Server;
+use Mojo::Transaction::WebSocket;
+use Mojo::Util 'term_escape';
+use Mojo::WebSocket 'server_handshake';
+use Scalar::Util 'weaken';
+
+use constant DEBUG => $ENV{MOJO_SERVER_DEBUG} || 0;
+
+has app => sub { Mojo::Server->new->build_app('Mojo::HelloWorld') };
+has max_requests => 100;
+
+sub new {
+  my $self = shift->SUPER::new(@_);
+  $self->on(read  => sub { shift->_read_content(shift) });
+  $self->on(close => sub { shift->_close });
+  return $self;
+}
+
+sub _build_tx {
+  my $self = shift;
+
+  my $tx = $self->app->build_tx;
+  $tx->res->headers->server('Mojolicious (Perl)');
+  my $handle = $self->handle;
+  unless ($handle->isa('IO::Socket::UNIX')) {
+    $tx->local_address($handle->sockhost)->local_port($handle->sockport);
+    $tx->remote_address($handle->peerhost)->remote_port($handle->peerport);
+  }
+  $tx->req->url->base->scheme('https') if $handle->isa('IO::Socket::SSL');
+
+  weaken $self;
+  $tx->on(
+    request => sub {
+      my $tx = shift;
+
+      # WebSocket
+      my $req = $tx->req;
+      if ($req->is_handshake) {
+        my $ws = $self->{next}
+          = Mojo::Transaction::WebSocket->new(handshake => $tx);
+        $self->emit(request => server_handshake $ws);
+      }
+
+      # HTTP
+      else { $self->emit(request => $tx) }
+
+      # Last keep-alive request or corrupted connection
+      $tx->res->headers->connection('close')
+        if ($self->{keep_alive} || 1) >= $self->max_requests || $req->error;
+
+      $tx->on(resume => sub { $self->_write_content });
+      $self->_write_content;
+    }
+  );
+
+  $self->emit(start => $tx);
+
+  # Kept alive if we have more than one request on the connection
+  return ++$self->{keep_alive} > 1 ? $tx->kept_alive(1) : $tx;
+}
+
+sub _close {
+  delete($_[0]->{tx})->closed if $_[0]->{tx};
+}
+
+sub _finish {
+  my $self = shift;
+
+  # Always remove connection for WebSockets
+  return unless my $tx = $self->{tx};
+
+  # Finish transaction
+  delete($self->{tx})->closed;
+
+  # Upgrade connection to WebSocket
+  if (my $ws = delete $self->{next}) {
+
+    # Successful upgrade
+    if ($ws->handshake->res->code == 101) {
+      $self->emit(upgrade => $ws->established(1));
+    }
+
+    # Failed upgrade
+    else { $ws->closed }
+  }
+
+  # Close connection if necessary
+  return $self->close_gracefully if $tx->error || !$tx->keep_alive;
+
+  # Build new transaction for leftovers
+  return unless length(my $leftovers = $tx->req->content->leftovers);
+  $self->{tx} = $tx = $self->_build_tx;
+  $tx->server_read($leftovers);
+}
+
+sub _read_content {
+  my ($self, $chunk) = @_;
+  my $tx = $self->{tx} ||= $self->_build_tx;
+  warn term_escape "-- Server <<< Client (@{[_url($tx)]})\n$chunk\n" if DEBUG;
+  $tx->server_read($chunk);
+}
+
+sub _url { shift->req->url->to_abs }
+
+sub _write_content {
+  my $self = shift;
+
+  # Protect from resume event recursion
+  return if !(my $tx = $self->{tx}) || $self->{cont_writing};
+  local $self->{cont_writing} = 1;
+  my $chunk = $tx->server_write;
+  warn term_escape "-- Server >>> Client (@{[_url($tx)]})\n$chunk\n" if DEBUG;
+  my $next
+    = $tx->is_finished ? '_finish' : length $chunk ? '_write_content' : undef;
+  return $self->write($chunk) unless $next;
+  $self->write($chunk => sub { shift->$next() });
+}
+
+1;
+
+=encoding utf8
+
+=head1 NAME
+
+Mojo::IOLoop::Stream::HTTPServer - Non-blocking I/O HTTP server stream
+
+=head1 SYNOPSIS
+
+  use Mojo::IOLoop::Server;
+  use Mojo::IOLoop::Stream::HTTPServer;
+  
+  # Create listen socket
+  my $server = Mojo::IOLoop::Server->new;
+  $server->on(
+    accept => sub {
+      my $stream = Mojo::IOLoop::Stream::HTTPServer->new(pop);
+  
+      $stream->on(
+        request => sub {
+          my ($stream, $tx) = @_;
+          $tx->res->code(200);
+          $tx->res->headers->content_type('text/plain');
+          $tx->res->body('Hello World!');
+          $tx->resume;
+        }
+      );
+      $stream->start;
+    }
+  );
+  $server->listen(port => 3000);
+  
+  # Start accepting connections
+  $server->start;
+
+=head1 DESCRIPTION
+
+L<Mojo::IOLoop::Stream::HTTPServer> is a container for I/O streams used by
+L<Mojo::IOLoop> to support the HTTP protocol server-side.
+
+
+=head1 EVENTS
+
+L<Mojo::IOLoop::Stream::HTTPServer> inherits all events from
+L<Mojo::IOLoop::Stream> and can emit the following new ones.
+
+=head2 request
+
+  $stream->on(request => sub {
+    my ($sream, $tx) = @_;
+    ...
+  });
+
+Emitted when a request is ready and needs to be handled.
+
+  $stream->on(request => sub {
+    my ($stream, $tx) = @_;
+    $tx->res->code(200);
+    $tx->res->headers->content_type('text/plain');
+    $tx->res->body('Hello World!');
+    $tx->resume;
+  });
+
+=head2 start
+
+  $stream->on(start => sub {
+    my ($stream, $tx) = @_;
+    ...
+  });
+
+Emitted whenever a transaction for a new request is about to start.
+
+=head2 upgrade
+
+  $stream->on(upgrade => sub {
+    my ($stream, $ws) = @_;
+    ...
+  });
+
+Emitted when the connection should be upgraded to the WebSocket protocol.
+
+=head1 ATTRIBUTES
+
+L<Mojo::IOLoop::Stream::HTTPServer> inherits all attributes from
+L<Mojo::IOLoop::Stream> and implements the following ones.
+
+=head2 app
+
+  my $app = $stream->app;
+  $stream = $stream->app(Mojolicious->new);
+
+Application responsible for building transactions. Defaults to
+a L<Mojo::HelloWorld> object.
+
+=head2 max_requests
+
+  my $max = $stream->max_requests;
+  $stream = $stream->max_requests(250);
+
+Maximum number of keep-alive requests per connection, defaults to C<100>.
+
+=head1 METHODS
+
+L<Mojo::IOLoop::Stream::HTTPServer> inherits all methods from
+L<Mojo::IOLoop::Stream> and implements the following new ones.
+
+=head2 new
+
+  my $stream = Mojo::IOLoop::Stream::HTTPServer->new($handle);
+
+Construct a new L<Mojo::IOLoop::Stream::HTTPServer> object.
+
+=head1 DEBUGGING
+
+You can set the C<MOJO_SERVER_DEBUG> environment variable to get some advanced
+diagnostics information printed to C<STDERR>.
+
+  MOJO_SERVER_DEBUG=1
+
+=head1 SEE ALSO
+
+L<Mojolicious>, L<Mojolicious::Guides>, L<http://mojolicious.org>.
+
+=cut
+

--- a/lib/Mojo/IOLoop/Stream/WebSocketClient.pm
+++ b/lib/Mojo/IOLoop/Stream/WebSocketClient.pm
@@ -1,0 +1,79 @@
+package Mojo::IOLoop::Stream::WebSocketClient;
+use Mojo::Base 'Mojo::IOLoop::Stream::HTTPClient';
+
+use Scalar::Util 'weaken';
+
+sub process {
+  my ($self, $tx) = @_;
+
+  return if $self->{tx};
+  $self->{tx} = $tx;
+
+  weaken $self;
+  $tx->on(resume => sub { $self->_write_content });
+  $self->_write_content;
+}
+
+sub _finish {
+  my $self = shift;
+  return ++$self->{closing} && $self->close unless $self->{tx};
+  delete($self->{tx})->closed;
+  ++$self->{closing} && $self->close_gracefully;
+}
+
+1;
+
+=encoding utf8
+
+=head1 NAME
+
+Mojo::IOLoop::Stream::WebSocketClient - Non-blocking I/O WebSocket client stream
+
+=head1 SYNOPSIS
+
+  use Mojo::IOLoop::Stream::WebSocketClient;
+  use Mojo::Transaction::WebSocket;
+  
+  # Create transaction
+  my $ws = Mojo::Transaction::WebSocket->new;
+  $ws->on(message => sub {
+    my ($ws, $msg) = @_;
+    say "Message: $msg";
+  });
+  
+  # Create stream and process transaction with it
+  my $stream = Mojo::IOLoop::Stream::WebSocketClient->new($handle);
+  $stream->process($ws);
+
+=head1 DESCRIPTION
+
+L<Mojo::IOLoop::Stream::WebSocketClient> is a container for I/O streams used by
+L<Mojo::IOLoop> to support the WebSocket protocol client-side.
+
+=head1 EVENTS
+
+L<Mojo::IOLoop::Stream::WebSocketClient> inherits all events from
+L<Mojo::IOLoop::Stream::HTTPClient>.
+
+=head1 ATTRIBUTES
+
+L<Mojo::IOLoop::Stream::WebSocketClient> inherits all attributes from
+L<Mojo::IOLoop::Stream::HTTPClient>.
+
+=head1 METHODS
+
+L<Mojo::IOLoop::Stream::WebSocketClient> inherits all methods from
+L<Mojo::IOLoop::Stream::HTTPClient> and implements the following new ones.
+
+=head2 process
+
+  $stream->process(Mojo::Transaction::WebSocket->new);
+
+Process a L<Mojo::Transaction::WebSocket> object.
+
+=head1 SEE ALSO
+
+L<Mojolicious>, L<Mojolicious::Guides>, L<http://mojolicious.org>.
+
+=cut
+

--- a/lib/Mojo/IOLoop/Stream/WebSocketServer.pm
+++ b/lib/Mojo/IOLoop/Stream/WebSocketServer.pm
@@ -1,0 +1,79 @@
+package Mojo::IOLoop::Stream::WebSocketServer;
+use Mojo::Base 'Mojo::IOLoop::Stream::HTTPServer';
+
+use Scalar::Util 'weaken';
+
+sub process {
+  my ($self, $tx) = @_;
+
+  return if $self->{tx};
+  $self->{tx} = $tx;
+
+  weaken $self;
+  $tx->on(resume => sub { $self->_write_content });
+  $self->_write_content;
+}
+
+sub _close {
+  delete($_[0]->{tx})->closed if $_[0]->{tx};
+}
+
+sub _finish { shift->close_gracefully }
+
+1;
+
+=encoding utf8
+
+=head1 NAME
+
+Mojo::IOLoop::Stream::WebSocketServer - Non-blocking I/O WebSocket server stream
+
+=head1 SYNOPSIS
+
+  use Mojo::IOLoop::Stream::WebSocketServer;
+  use Mojo::Transaction::WebSocket;
+  
+  # Create transaction
+  my $ws = Mojo::Transaction::WebSocket->new;
+  $ws->on(message => sub {
+    my ($ws, $msg) = @_;
+    say "Message: $msg";
+  });
+
+  # Create stream and process transaction with it
+  my $stream = Mojo::IOLoop::Stream::WebSocketServer->new($handle);
+  $stream->process($ws);
+
+=head1 DESCRIPTION
+
+L<Mojo::IOLoop::Stream::WebSocketServer> is a container for I/O streams used by
+L<Mojo::IOLoop> to support the WebSocket protocol server-side.
+
+
+=head1 EVENTS
+
+L<Mojo::IOLoop::Stream::WEBSocketServer> inherits all events from
+L<Mojo::IOLoop::Stream::HTTPServer>.
+
+=head1 ATTRIBUTES
+
+L<Mojo::IOLoop::Stream::WebSocketServer> inherits all attributes from
+L<Mojo::IOLoop::Stream::HTTPServer>.
+
+=head1 METHODS
+
+L<Mojo::IOLoop::Stream::WebSocketServer> inherits all methods from
+L<Mojo::IOLoop::Stream::HTTPServer> and implements the following new ones.
+
+=head2 process
+
+  $stream->process(Mojo::Transaction::WebSocket->new);
+
+Process a L<Mojo::Transaction::WebSocket> object.
+
+=head1 SEE ALSO
+
+L<Mojolicious>, L<Mojolicious::Guides>, L<http://mojolicious.org>.
+
+=cut
+

--- a/lib/Mojo/Server/Daemon.pm
+++ b/lib/Mojo/Server/Daemon.pm
@@ -3,13 +3,12 @@ use Mojo::Base 'Mojo::Server';
 
 use Carp 'croak';
 use Mojo::IOLoop;
-use Mojo::Transaction::WebSocket;
+use Mojo::IOLoop::Stream::HTTPServer;
+use Mojo::IOLoop::Stream::WebSocketServer;
 use Mojo::URL;
-use Mojo::Util 'term_escape';
-use Mojo::WebSocket 'server_handshake';
 use Scalar::Util 'weaken';
 
-use constant DEBUG => $ENV{MOJO_DAEMON_DEBUG} || 0;
+use constant DEBUG => $ENV{MOJO_SERVER_DEBUG} || 0;
 
 has acceptors => sub { [] };
 has [qw(backlog max_clients silent)];
@@ -23,6 +22,12 @@ sub DESTROY {
   my $self = shift;
   my $loop = $self->ioloop;
   $loop->remove($_) for keys %{$self->{connections} || {}}, @{$self->acceptors};
+}
+
+sub close_connections {
+  my $self = shift;
+  my $loop = $self->ioloop;
+  $loop->stream($_)->max_requests(1) for keys %{$self->{connections} || {}};
 }
 
 sub ports {
@@ -75,92 +80,7 @@ sub stop {
   return $self;
 }
 
-sub _build_tx {
-  my ($self, $id, $c) = @_;
-
-  my $tx = $self->build_tx->connection($id);
-  $tx->res->headers->server('Mojolicious (Perl)');
-  my $handle = $self->ioloop->stream($id)->handle;
-  unless ($handle->isa('IO::Socket::UNIX')) {
-    $tx->local_address($handle->sockhost)->local_port($handle->sockport);
-    $tx->remote_address($handle->peerhost)->remote_port($handle->peerport);
-  }
-  $tx->req->url->base->scheme('https') if $c->{tls};
-
-  weaken $self;
-  $tx->on(
-    request => sub {
-      my $tx = shift;
-
-      my $req = $tx->req;
-      if (my $error = $req->error) { $self->_debug($id, $error->{message}) }
-
-      # WebSocket
-      if ($req->is_handshake) {
-        my $ws = $self->{connections}{$id}{next}
-          = Mojo::Transaction::WebSocket->new(handshake => $tx);
-        $self->emit(request => server_handshake $ws);
-      }
-
-      # HTTP
-      else { $self->emit(request => $tx) }
-
-      # Last keep-alive request or corrupted connection
-      my $c = $self->{connections}{$id};
-      $tx->res->headers->connection('close')
-        if ($c->{requests} || 1) >= $self->max_requests || $req->error;
-
-      $tx->on(resume => sub { $self->_write($id) });
-      $self->_write($id);
-    }
-  );
-
-  # Kept alive if we have more than one request on the connection
-  return ++$c->{requests} > 1 ? $tx->kept_alive(1) : $tx;
-}
-
-sub _close {
-  my ($self, $id) = @_;
-  if (my $tx = $self->{connections}{$id}{tx}) { $tx->closed }
-  delete $self->{connections}{$id};
-}
-
 sub _debug { $_[0]->app->log->debug($_[2]) if $_[0]{connections}{$_[1]}{tx} }
-
-sub _finish {
-  my ($self, $id) = @_;
-
-  # Always remove connection for WebSockets
-  my $c = $self->{connections}{$id};
-  return unless my $tx = $c->{tx};
-  return $self->_remove($id) if $tx->is_websocket;
-
-  # Finish transaction
-  delete($c->{tx})->closed;
-
-  # Upgrade connection to WebSocket
-  if (my $ws = delete $c->{next}) {
-
-    # Successful upgrade
-    if ($ws->handshake->res->code == 101) {
-      $c->{tx} = $ws->established(1);
-      weaken $self;
-      $ws->on(resume => sub { $self->_write($id) });
-      $self->_write($id);
-    }
-
-    # Failed upgrade
-    else { $ws->closed }
-  }
-
-  # Close connection if necessary
-  return $self->_remove($id) if $tx->error || !$tx->keep_alive;
-
-  # Build new transaction for leftovers
-  return unless length(my $leftovers = $tx->req->content->leftovers);
-  $tx = $c->{tx} = $self->_build_tx($id, $c);
-  $tx->server_read($leftovers);
-}
 
 sub _listen {
   my ($self, $listen) = @_;
@@ -170,8 +90,11 @@ sub _listen {
   croak qq{Invalid listen location "$listen"}
     unless $proto eq 'http' || $proto eq 'https' || $proto eq 'http+unix';
 
-  my $query = $url->query;
-  my $options = {backlog => $self->backlog};
+  my $query   = $url->query;
+  my $options = {
+    backlog      => $self->backlog,
+    stream_class => 'Mojo::IOLoop::Stream::HTTPServer'
+  };
   $options->{$_} = $query->param($_) for qw(fd single_accept reuse);
   if ($proto eq 'http+unix') { $options->{path} = $url->host }
   else {
@@ -185,22 +108,26 @@ sub _listen {
   if (my $key  = $query->param('key'))  { $options->{'tls_key'}{''}  = $key }
   my $verify = $query->param('verify');
   $options->{tls_verify} = hex $verify if defined $verify;
-  my $tls = $options->{tls} = $proto eq 'https';
+  $options->{tls} = $proto eq 'https';
 
   weaken $self;
   push @{$self->acceptors}, $self->ioloop->server(
     $options => sub {
       my ($loop, $stream, $id) = @_;
 
-      $self->{connections}{$id} = {tls => $tls};
+      my $c = $self->{connections}{$id} = {};
       warn "-- Accept $id (@{[$stream->handle->peerhost]})\n" if DEBUG;
       $stream->timeout($self->inactivity_timeout);
+      $stream->max_requests($self->max_requests);
+      weaken $stream->app($self)->{app};
 
-      $stream->on(close => sub { $self && $self->_close($id) });
+      $stream->on(close => sub { $self && $self->_remove($id) });
       $stream->on(error =>
-          sub { $self && $self->app->log->error(pop) && $self->_close($id) });
-      $stream->on(read => sub { $self->_read($id => pop) });
+          sub { $self && $self->app->log->error(pop) && $self->_remove($id) });
+      $stream->on(request => sub { $self->_request($id, pop) });
+      $stream->on(start => sub { $c->{tx} = pop->connection($id) });
       $stream->on(timeout => sub { $self->_debug($id, 'Inactivity timeout') });
+      $stream->on(upgrade => sub { $self->_upgrade($id, pop) });
     }
   );
 
@@ -211,37 +138,39 @@ sub _listen {
   say 'Server available at ', $options->{path} // $url;
 }
 
-sub _read {
-  my ($self, $id, $chunk) = @_;
-
-  # Make sure we have a transaction
-  my $c = $self->{connections}{$id};
-  my $tx = $c->{tx} ||= $self->_build_tx($id, $c);
-  warn term_escape "-- Server <<< Client (@{[_url($tx)]})\n$chunk\n" if DEBUG;
-  $tx->server_read($chunk);
-}
-
 sub _remove {
   my ($self, $id) = @_;
   $self->ioloop->remove($id);
-  $self->_close($id);
+  delete $self->{connections}{$id};
 }
 
-sub _url { shift->req->url->to_abs }
+sub _request {
+  my ($self, $id, $tx) = @_;
+  if (my $error = $tx->error) { $self->_debug($id, $error->{message}) }
 
-sub _write {
-  my ($self, $id) = @_;
-
-  # Protect from resume event recursion
-  my $c = $self->{connections}{$id};
-  return if !(my $tx = $c->{tx}) || $c->{writing};
-  local $c->{writing} = 1;
-  my $chunk = $tx->server_write;
-  warn term_escape "-- Server >>> Client (@{[_url($tx)]})\n$chunk\n" if DEBUG;
-  my $next = $tx->is_finished ? '_finish' : length $chunk ? '_write' : undef;
-  return $self->ioloop->stream($id)->write($chunk) unless $next;
   weaken $self;
-  $self->ioloop->stream($id)->write($chunk => sub { $self->$next($id) });
+  $tx->on(finish => sub { delete $self->{connections}{$id}{tx} });
+  $self->emit(request => $tx);
+}
+
+sub _upgrade {
+  my ($self, $id, $ws) = @_;
+  my $c    = delete $self->{connections}{$id};
+  my $loop = $self->ioloop;
+
+  my $timeout = $loop->stream($id)->timeout;
+  my $stream = $loop->transition($id, 'Mojo::IOLoop::Stream::WebSocketServer');
+  $stream->timeout($timeout);
+
+  weaken $self;
+  $stream->on(timeout => sub { $self->_debug($id, 'Inactivity timeout') });
+  $stream->on(close => sub { $self && $self->_remove($id) });
+  $stream->on(
+    error => sub { $self && $self->app->log->error(pop) && $self->_remove($id) }
+  );
+
+  $self->{connections}{$id} = {tx => $ws};
+  $stream->process($ws);
 }
 
 1;
@@ -478,6 +407,13 @@ Disable console messages.
 L<Mojo::Server::Daemon> inherits all methods from L<Mojo::Server> and
 implements the following new ones.
 
+=head2 close_connections
+
+  $daemon->close_connections;
+
+Make connections to stop accepting new requests and close after
+finishing processing current one.
+
 =head2 ports
 
   my $ports = $daemon->ports;
@@ -515,10 +451,10 @@ Stop accepting connections through L</"ioloop">.
 
 =head1 DEBUGGING
 
-You can set the C<MOJO_DAEMON_DEBUG> environment variable to get some advanced
+You can set the C<MOJO_SERVER_DEBUG> environment variable to get some advanced
 diagnostics information printed to C<STDERR>.
 
-  MOJO_DAEMON_DEBUG=1
+  MOJO_SERVER_DEBUG=1
 
 =head1 SEE ALSO
 

--- a/lib/Mojo/Server/Prefork.pm
+++ b/lib/Mojo/Server/Prefork.pm
@@ -155,7 +155,7 @@ sub _spawn {
   # Clean worker environment
   $SIG{$_} = 'DEFAULT' for qw(CHLD INT TERM TTIN TTOU);
   $SIG{QUIT} = sub { $loop->stop_gracefully };
-  $loop->on(finish => sub { $self->max_requests(1) });
+  $loop->on(finish => sub { $self->max_requests(1)->close_connections });
   delete $self->{reader};
   srand;
 

--- a/t/mojo/streams.t
+++ b/t/mojo/streams.t
@@ -1,0 +1,180 @@
+use Mojo::Base -strict;
+
+BEGIN { $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll' }
+
+use Test::More;
+use Mojo::IOLoop;
+use Mojo::IOLoop::Stream::HTTPClient;
+use Mojo::IOLoop::Stream::HTTPServer;
+use Mojo::IOLoop::Stream::WebSocketClient;
+use Mojo::IOLoop::Stream::WebSocketServer;
+use Mojo::Transaction::HTTP;
+use Mojolicious;
+
+# Default app
+my ($app, $client_stream, $server_stream);
+$server_stream = Mojo::IOLoop::Stream::HTTPServer->new;
+$app           = $server_stream->app;
+ok $app, 'has default app';
+isa_ok $app, 'Mojo::HelloWorld', 'right default app';
+
+# App
+$app = Mojolicious->new;
+$app->log->level('fatal');
+
+$app->routes->any('/' => sub { shift->render(text => 'Yay!') });
+
+$app->routes->any(
+  '/hello' => sub {
+    my $c = shift;
+    $c->render(text => $c->req->body . 'World!');
+  }
+);
+
+$app->routes->any(
+  '/keep-alive' => sub {
+    my $c = shift;
+    Mojo::IOLoop->stream($c->tx->connection)->max_requests(2);
+    $c->on(finish => sub { $_[0]->stash->{kept_alive} = $_[0]->tx->kept_alive }
+    );
+    $c->render(text => 'Ok');
+  }
+);
+$app->routes->any(
+  '/premature' => sub { Mojo::IOLoop->stream(shift->tx->connection)->close });
+
+$app->routes->any('/timeout' => sub { shift->render_later });
+
+# Server
+my $id = Mojo::IOLoop->server(
+  {address => '127.0.0.1',
+    stream_class => 'Mojo::IOLoop::Stream::HTTPServer'} => sub {
+    my ($loop, $stream, $id) = @_;
+    $server_stream = $stream->app($app);
+    $stream->on(request => sub { shift->app->handler(shift) });
+    $stream->on(start   => sub { pop->connection($id) });
+  }
+);
+my $port = Mojo::IOLoop->acceptor($id)->port;
+
+# Client connection options and callback
+my $opts = {port => $port, stream_class => 'Mojo::IOLoop::Stream::HTTPClient'};
+my $tx;
+my $cb = sub {
+  $client_stream = pop;
+  $client_stream->process($tx);
+  return $client_stream;
+};
+
+# Simple request
+$tx = _tx('http://127.0.0.1/hello');
+$tx->req->body('Hello');
+my ($code, $result);
+$tx->on(
+  finish => sub {
+    my $tx = shift;
+    $code   = $tx->res->code;
+    $result = $tx->res->body;
+    Mojo::IOLoop->stop;
+  }
+);
+_client($opts => $cb);
+Mojo::IOLoop->start;
+is $code,   200,           'right code';
+is $result, 'HelloWorld!', 'right result';
+
+# Premature connection close (server)
+$tx = _tx('http://127.0.0.1/premature');
+my $err;
+$tx->on(
+  finish => sub {
+    $err = shift->error;
+    Mojo::IOLoop->stop;
+  }
+);
+$client_stream->process($tx);
+Mojo::IOLoop->start;
+ok !defined $err->{code}, 'no code';
+is $err->{message}, 'Premature connection close', 'right message';
+
+# Premature connection close (client)
+$tx = _tx('http://127.0.0.1/');
+$tx->on(
+  finish => sub {
+    $err = shift->error;
+    Mojo::IOLoop->stop;
+  }
+);
+$err = undef;
+_client($opts => sub { $cb->(@_)->close });
+Mojo::IOLoop->start;
+ok !defined $err->{code}, 'no code';
+is $err->{message}, 'Premature connection close', 'right message';
+
+# HTTP Error
+$tx = _tx('http://127.0.0.1/not_found');
+$tx->on(
+  finish => sub {
+    $err = shift->error;
+    Mojo::IOLoop->stop;
+  }
+);
+$err = undef;
+_client($opts => $cb);
+Mojo::IOLoop->start;
+is $err->{code},    404,         'right code';
+is $err->{message}, 'Not Found', 'right message';
+
+# Keep-alive
+my ($closed, $stash);
+$app->plugins->once(before_dispatch => sub { $stash = shift->stash });
+$tx = _tx('http://127.0.0.1/keep-alive');
+$tx->on(finish => sub { Mojo::IOLoop->stop });
+_client(
+  $opts => sub {
+    $cb->(@_)->on(close => sub { $closed++ });
+  }
+);
+Mojo::IOLoop->start;
+ok !$stash->{kept_alive}, 'connection was not kept alive';
+ok !$closed, 'connection is not closed';
+$app->plugins->once(before_dispatch => sub { $stash = shift->stash });
+$tx = _tx('http://127.0.0.1/keep-alive');
+$tx->on(finish => sub { Mojo::IOLoop->stop });
+$client_stream->process($tx);
+Mojo::IOLoop->start;
+ok $stash->{kept_alive}, 'connection was kept alive';
+is $closed, 1, 'connection is closed';
+
+# Timeout
+$tx = _tx('http://127.0.0.1/timeout');
+$tx->on(
+  finish => sub {
+    $err = shift->error;
+    Mojo::IOLoop->stop;
+  }
+);
+$err = undef;
+_client(
+  $opts => sub {
+    $client_stream = pop->request_timeout(0.5);
+    $client_stream->process($tx);
+  }
+);
+Mojo::IOLoop->start;
+ok !defined $err->{code}, 'no code';
+is $err->{message}, 'Request timeout', 'right message';
+
+sub _client {
+  my $opts = {%{(shift)}};
+  Mojo::IOLoop->client($opts => shift);
+}
+
+sub _tx {
+  my $t = Mojo::Transaction::HTTP->new;
+  $t->req->method('GET')->url->parse(shift);
+  return $t;
+}
+
+done_testing();
+

--- a/t/mojo/user_agent_online.t
+++ b/t/mojo/user_agent_online.t
@@ -233,9 +233,4 @@ ok $tx->is_finished, 'transaction is finished';
 is $tx->error->{message}, 'Connect timeout', 'right error';
 $ua->connect_timeout(3);
 
-# Request timeout (non-routable address)
-$tx = $ua->request_timeout(0.5)->get('192.0.2.1');
-ok $tx->is_finished, 'transaction is finished';
-is $tx->error->{message}, 'Request timeout', 'right error';
-
 done_testing();


### PR DESCRIPTION
### Summary
Implementing Mojo::IOLoop::Stream subclasses for HTTP and WebSocket connections.

### Motivation
An attempt to implement feature required for an issue.

### References
https://github.com/kraih/mojo/issues/423#issuecomment-376509948
