### PR TITLE
Mojo::UserAgent::Server creates unnecessary extra listening point

### DIFF
--- a/t/mojo/user_agent.t
+++ b/t/mojo/user_agent.t
@@ -568,7 +568,7 @@ is $tx->res->body, '0123456789', 'right content';
 is $stream, 1, 'no leaking subscribers';
 
 # Mixed blocking and non-blocking requests, with custom URL
-$ua = Mojo::UserAgent->new(ioloop => Mojo::IOLoop->singleton);
+$ua = Mojo::UserAgent->new;
 $tx = $ua->get($ua->server->url);
 ok $tx->success, 'successful';
 ok !$tx->kept_alive, 'kept connection not alive';
@@ -624,7 +624,7 @@ is_deeply \@kept_alive, [1, 1], 'connections kept alive';
 
 # Unexpected 1xx responses
 $req = Mojo::Message::Request->new;
-$id  = Mojo::IOLoop->server(
+$id  = $ua->ioloop->server(
   {address => '127.0.0.1'} => sub {
     my ($loop, $stream) = @_;
     $stream->on(
@@ -640,7 +640,7 @@ $id  = Mojo::IOLoop->server(
     );
   }
 );
-$port = Mojo::IOLoop->acceptor($id)->port;
+$port = $ua->ioloop->acceptor($id)->port;
 $tx = $ua->build_tx(GET => "http://127.0.0.1:$port/");
 my @unexpected;
 $tx->on(unexpected => sub { push @unexpected, pop });

--- a/t/mojolicious/before_server_start.t
+++ b/t/mojolicious/before_server_start.t
@@ -1,0 +1,38 @@
+use Mojo::Base -strict;
+
+BEGIN { $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll' }
+
+use Test::More;
+
+use Mojolicious::Lite;
+use Test::Mojo;
+
+my $starts;
+sub reset_starts { $starts = 0; }
+
+hook before_server_start => sub { ++$starts; };
+
+# ho hum
+get '/' => {text => "works"};
+
+my $t = Test::Mojo->new;
+
+reset_starts();
+$t->get_ok('/')->status_is(200)->content_is('works');
+is($starts, 1, 'get_ok bss count');
+
+{
+  open my $stdout, '>', \my $out;
+  local *STDOUT = $stdout;
+
+  reset_starts();
+  app->commands->run(qw(get /));
+  is($out,    'works', 'correct output');
+  is($starts, 1,       'get command bss count');
+}
+
+reset_starts();
+is(app->commands->run(qw(eval 1)), 1, 'eval output');
+is($starts,                        0, 'eval command bss count');
+
+done_testing();


### PR DESCRIPTION
### Summary
`Mojo::UserAgent`(`::Server`) **only** needs to create separate listening points for blocking vs. non-blocking self-requests when its event loops are distinct (i.e., when `ua->ioloop` is **not** the singleton).

### Motivation

1. This should make tests run slightly faster.  I'm seeing what appears to be a roughly 8% speed improvement in calls to `get_ok` [...See Benchmarking below...]

2. What actually inspired this was noticing that `before_server_start` fires **twice** on a command-line get or a `get_ok()` test (see `t/mojolicious/before_server_start.t` to reproduce), which I found baffling.  This patch won't eliminate all instances of double-firing, but I'd like to think they're now limited to the cases where the user is doing something odd/not-recommended, e.g., using blocking UA self-requests in server-side event handlers

### References
haven't found any.  I'm guessing this is something that would have been fixed earlier if anyone'd noticed.

### Discussion
The reason behind having two separate listening points, as I understand it:

- only one event loop runs at any given time, so for the client to get a response, there has to be a listener/server on the same event loop
- listeners on distinct event loops need distinct base URLs so that self-redirections go to the server on the same loop

**However** when we're inside a command-line `get`, or a test suite using `Mojo::Test::get_ok`/etc, we're explicitly using a UA that uses the singleton loop for _everything_, which makes sense for a one-shot request where there's no other server activity to worry about (or there **is** other stuff but you're _intentionally_ including it on the same loop for the purposes of the test), which then means that, due to UserAgent, line 289, 

  `my $base = $loop == $self->ioloop ? $server->url : $server->nb_url;`

`nb_url` will **never** be used (*) and thus setting up that 2nd listening point is a complete waste of time.


### Test Suite Modifications

(*) "Never", that is, **unless** somebody goes out of their way to refer to `nb_url` explicitly

which, of course, happens in `t/user_agent.t` "Mixed blocking and non-blocking" test (surprise)

which I've patched but hopefully in a way that keeps to the original intent of the test:

It would be easy enough to just change `[undef,1,1]` to `[1,1,1]` at line 599 to reflect that the first non-blocking request is now reusing the blocking connection because they're now the same listening point, which works.  

But I found that the whole thing *also* works as originally set up if you just create a natural UA with a separate blocking loop -- which I would think is more what you'd want to be testing here anyway.
(I suppose one could also put in _both_ versions of the test, depending on how overkill you want to be.)

The second version of the test (the one that's in this patch) does however break the "Unexpected 1xx" test later on, which unfortunately assumes the blocking `ua->start` call will run all of the server prep stuff that precedes it -- no longer the case if server prep is on the (now separate) singleton loop, which then means blocking call only runs the client side stuff, which then just times out.  This is solved by moving the server prep to `ua->ioloop`.

### Benchmarking

Rename this to `busy.t`

[busy.txt](https://github.com/kraih/mojo/files/2215813/busy.txt)

Results for Debian and Windows
[debian.txt](https://github.com/kraih/mojo/files/2215817/debian.txt)
[windows.txt](https://github.com/kraih/mojo/files/2215818/windows.txt)

My 8% claim is from the Debian tests.  

The Windows numbers are more dramatic, at least in wallclock terms, but I'm not sure how much I want to trust them [my Windows box has too much crap running on it; also the full mojolicious test suit on windows has numerous random failures for the current master, even thought the CPAN test/install of 7.87 went through without a hitch...]
