### PR TITLE
Update license URL in Makefile.PL

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -22,7 +22,7 @@ WriteMakefile(
     resources => {
       bugtracker => {web => 'https://github.com/mojolicious/mojo/issues'},
       homepage   => 'https://mojolicious.org',
-      license    => ['http://www.opensource.org/licenses/artistic-license-2.0'],
+      license    => ['https://opensource.org/license/artistic-2-0'],
       repository => {
         type => 'git',
         url  => 'https://github.com/mojolicious/mojo.git',


### PR DESCRIPTION
Previous URL resulted in a 404

### Summary
Update License URL

### Motivation
The current Licence URL results in 404

### References
None
