### PR TITLE
ensure timely cleanup of UserAgent temporary files

### DIFF
--- a/lib/Mojo/UserAgent.pm
+++ b/lib/Mojo/UserAgent.pm
@@ -247,7 +247,7 @@ sub _finish {
   # CONNECT requests always have a follow-up request
   $self->_reuse($id, $close) unless uc $old->req->method eq 'CONNECT';
   $res->error({message => $res->message, code => $res->code}) if $res->is_error;
-  $c->{cb}($self, $old) unless $self->_redirect($c, $old);
+  (delete $c->{cb})->($self, $old) unless $self->_redirect($c, $old);
 }
 
 sub _process {

--- a/t/mojo/user_agent.t
+++ b/t/mojo/user_agent.t
@@ -363,16 +363,18 @@ ok $tx->res->headers->content_length, 'has "Content-Length" value';
 ok !$tx->is_empty,                    'transaction is not empty';
 is $tx->res->body, 'x' x 262144, 'right content';
 
-# memory->file asset promotion, plus timely cleanup
-{
+subtest 'memory->file asset promotion, plus timely cleanup' => sub {
     local $ENV{MOJO_MAX_MEMORY_SIZE} = 262144/2;
     $tx = $ua->get('/huge');
-}
-is $tx->res->body, 'x' x 262144, 'right content';
-my $filename = $tx->res->content->asset->path;
-ok $filename, 'the huge body should be saved to a temporary file';
-undef $tx;
-ok !(-e $filename), 'the temporary file should be deleted as soon as the transaction is destroyed';
+
+    is $tx->res->body, 'x' x 262144, 'right content';
+
+    my $filename = $tx->res->content->asset->path;
+    ok $filename, 'the huge body should be saved to a temporary file';
+
+    undef $tx;
+    ok !(-e $filename), 'the temporary file should be deleted as soon as the transaction is destroyed';
+};
 
 # Non-blocking form
 ($success, $code, $body) = ();

--- a/t/mojo/user_agent.t
+++ b/t/mojo/user_agent.t
@@ -363,6 +363,17 @@ ok $tx->res->headers->content_length, 'has "Content-Length" value';
 ok !$tx->is_empty,                    'transaction is not empty';
 is $tx->res->body, 'x' x 262144, 'right content';
 
+# memory->file asset promotion, plus timely cleanup
+{
+    local $ENV{MOJO_MAX_MEMORY_SIZE} = 262144/2;
+    $tx = $ua->get('/huge');
+}
+is $tx->res->body, 'x' x 262144, 'right content';
+my $filename = $tx->res->content->asset->path;
+ok $filename, 'the huge body should be saved to a temporary file';
+undef $tx;
+ok !(-e $filename), 'the temporary file should be deleted as soon as the transaction is destroyed';
+
 # Non-blocking form
 ($success, $code, $body) = ();
 $ua->post(


### PR DESCRIPTION
### Summary

Ensure that temporary files created by `Mojo::UserAgent` are cleaned up as soon as the transaction is destroyed.

### Motivation

the `$cb` that `sub start` passes to `sub _start` is:

    sub { shift->ioloop->stop; $tx = shift }

which closes over `$tx`, which owns the response, its content, its asset, and its tempfile (when the asset is a `Mojo::Asset::File`)

if we leave the callback inside the `{connections}` hashref, the tempfile will not be cleaned up until the connection is next re-used, which may not happen any time soon, especially for long-lived applications that download data from many sources

deleting the callback just before calling it, ensures a timely cleanup

I've also added a test to prove the problem and the fix. All tests pass.
